### PR TITLE
refactor: make dev-container setup portable via .env config

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,48 @@
+# =============================================================================
+# AI Dev Base - Environment Configuration
+# =============================================================================
+# Copy this file to .env and adjust the values for your system.
+#
+# Usage:
+#   cp .env.example .env
+#   # Edit .env with your paths
+#   ./scripts/dev.sh start
+# =============================================================================
+
+# -----------------------------------------------------------------------------
+# Required: Project Directory
+# -----------------------------------------------------------------------------
+# Path to your code/projects directory on the host.
+# This will be mounted as ~/projects/ in the container.
+CODE_DIR=/path/to/your/code
+
+# -----------------------------------------------------------------------------
+# Optional: Shell Customization
+# -----------------------------------------------------------------------------
+# Set to "true" to skip mounting host shell configs (zshrc, oh-my-zsh, etc.)
+# Useful if you don't have oh-my-zsh or oh-my-posh installed on the host.
+SKIP_SHELL_MOUNTS=false
+
+# Path to your oh-my-posh theme (only used if SKIP_SHELL_MOUNTS=false)
+# Default expects: ~/.oh-my-zsh/custom/themes/.zsh-theme-remote.omp.json
+# OMP_THEME_PATH=~/.oh-my-zsh/custom/themes/.zsh-theme-remote.omp.json
+
+# -----------------------------------------------------------------------------
+# Optional: Resource Limits
+# -----------------------------------------------------------------------------
+# Adjust based on your system's capabilities
+CPU_LIMIT=6
+MEMORY_LIMIT=12G
+CPU_RESERVATION=2
+MEMORY_RESERVATION=4G
+
+# -----------------------------------------------------------------------------
+# Optional: Timezone
+# -----------------------------------------------------------------------------
+TZ=Europe/Berlin
+
+# -----------------------------------------------------------------------------
+# Security Options (set via cli flags, not here)
+# -----------------------------------------------------------------------------
+# ENABLE_FIREWALL - Use: ./dev.sh start --firewall
+# DOCKER_ENABLED  - Use: ./dev.sh start --docker

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,12 @@
+# Environment configuration (contains local paths)
+.env
+
+# IDE
+.idea/
+.vscode/
+*.swp
+*.swo
+
+# OS
+.DS_Store
+Thumbs.db

--- a/README.md
+++ b/README.md
@@ -16,14 +16,26 @@ Minimales, wiederverwendbares Base-Image für AI-gestützte Entwicklung mit **Cl
 
 ## Schnellstart
 
-### 1. Base-Image bauen
+### 1. Konfiguration erstellen
 
 ```bash
 cd ai-dev-base
-./dev.sh build
+
+# Template kopieren und anpassen
+cp .env.example .env
+
+# Mindestens CODE_DIR setzen:
+# CODE_DIR=/pfad/zu/deinen/projekten
+nano .env
 ```
 
-### 2. MCP Gateway starten (optional, aber empfohlen)
+### 2. Base-Image bauen
+
+```bash
+./scripts/dev.sh build
+```
+
+### 3. MCP Gateway starten (optional, aber empfohlen)
 
 ```bash
 cd mcp
@@ -33,11 +45,11 @@ cd mcp
 cd ..
 ```
 
-### 3. Tools authentifizieren (einmalig)
+### 4. Tools authentifizieren (einmalig)
 
 ```bash
 # Startet Container mit Host-Netzwerk für OAuth
-./dev.sh auth
+./scripts/dev.sh auth
 
 # Im Container:
 claude   # Folge dem OAuth-Flow im Browser
@@ -46,10 +58,10 @@ gemini auth  # Authentifizierung für Google Generative AI
 exit
 ```
 
-### 4. Normal arbeiten (täglich)
+### 5. Normal arbeiten (täglich)
 
 ```bash
-./dev.sh start
+./scripts/dev.sh start
 
 # Im Container:
 claude   # Mit MCP Tools verfügbar
@@ -504,10 +516,27 @@ ENTRYPOINT ["/bin/bash"]
 
 ### Festes Projekt-Verzeichnis ändern
 
-In `docker-compose.yml` anpassen:
+In `.env` anpassen:
 
-```yaml
-volumes:
-  # Projects directory - ADJUST THIS PATH
-  - /dein/pfad:/home/dev/projects
+```bash
+CODE_DIR=/dein/pfad/zu/projekten
+```
+
+### Shell-Mounts deaktivieren
+
+Falls du keine oh-my-zsh oder oh-my-posh Installation auf dem Host hast:
+
+```bash
+# In .env setzen:
+SKIP_SHELL_MOUNTS=true
+```
+
+### Resource-Limits anpassen
+
+```bash
+# In .env setzen:
+CPU_LIMIT=4
+MEMORY_LIMIT=8G
+CPU_RESERVATION=1
+MEMORY_RESERVATION=2G
 ```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,9 @@
 #   ./dev.sh start --docker     # Mit Docker Socket + Proxy
 #   ./dev.sh start --firewall   # Mit Netzwerk-Firewall
 #   ./dev.sh start --docker --firewall  # Beides kombiniert
+#
+# Configuration:
+#   Copy .env.example to .env and adjust paths for your system.
 # =============================================================================
 
 services:
@@ -20,10 +23,10 @@ services:
     container_name: ai-dev
     stdin_open: true
     tty: true
-    
+
     networks:
       - ai-dev-network
-    
+
     volumes:
       # Claude Code config & credentials
       - claude-config:/home/dev/.claude
@@ -35,41 +38,37 @@ services:
       - uv-cache:/home/dev/.cache/uv
       # fnm Node versions
       - fnm-versions:/home/dev/.local/share/fnm/node-versions
-      # SSH Keys from host
+      # SSH Keys from host (read-only)
       - ~/.ssh:/home/dev/.ssh:ro
-      # Git config from host
+      # Git config from host (read-only)
       - ~/.gitconfig:/home/dev/.gitconfig:ro
-      # ZSH configuration from host
-      - ~/.zshrc:/home/dev/.zshrc.local:ro
-      - ~/.oh-my-zsh/custom/themes/.zsh-theme-remote.omp.json:/home/dev/.zsh-theme.omp.json:ro
-      - ~/.oh-my-zsh/custom:/home/dev/.oh-my-zsh/custom:ro
       # Mount der Host-Konfiguration als Read-Only Quelle
       - ./config/claude:/home/dev/.claude_seed:ro
       - ./config/gemini:/home/dev/.gemini_seed:ro
-      # Projects directory - ADJUST THIS PATH
-      - /mnt/spaceIn/Laboratorium/Code:/home/dev/projects
+      # Projects directory - configured via .env or CODE_DIR environment variable
+      - ${CODE_DIR:?Please set CODE_DIR in .env or environment}:/home/dev/projects
 
     environment:
-      - TZ=Europe/Berlin
+      - TZ=${TZ:-Europe/Berlin}
       - MCP_GATEWAY_URL=http://mcp-gateway:8811/
       - ENABLE_FIREWALL=${ENABLE_FIREWALL:-false}
       - UV_LINK_MODE=copy
-      
+
     cap_add:
       - NET_ADMIN
-    
+
     # -------------------------------------------------------------------------
     # Resource Limits (Schutz vor Ressourcen-Erschöpfung)
     # -------------------------------------------------------------------------
     deploy:
       resources:
         limits:
-          cpus: '6'
-          memory: 12G
+          cpus: '${CPU_LIMIT:-6}'
+          memory: ${MEMORY_LIMIT:-12G}
         reservations:
-          cpus: '2'
-          memory: 4G
-    
+          cpus: '${CPU_RESERVATION:-2}'
+          memory: ${MEMORY_RESERVATION:-4G}
+
     working_dir: /home/dev/projects
 
   # ---------------------------------------------------------------------------
@@ -89,20 +88,21 @@ services:
       - codex-config:/home/dev/.codex
       - uv-cache:/home/dev/.cache/uv
       - fnm-versions:/home/dev/.local/share/fnm/node-versions
+      - ~/.ssh:/home/dev/.ssh:ro
       - ~/.gitconfig:/home/dev/.gitconfig:ro
-      - ~/.zshrc:/home/dev/.zshrc.local:ro
-      - ~/.oh-my-zsh/custom/themes/.zsh-theme-remote.omp.json:/home/dev/.zsh-theme.omp.json:ro
-      - ~/.oh-my-zsh/custom:/home/dev/.oh-my-zsh/custom:ro
-      - /media/willi/spaceIn/Laboratorium/Code:/home/dev/projects
+      - ./config/claude:/home/dev/.claude_seed:ro
+      - ./config/gemini:/home/dev/.gemini_seed:ro
+      # Same project directory as main container
+      - ${CODE_DIR:?Please set CODE_DIR in .env or environment}:/home/dev/projects
     environment:
-      - TZ=Europe/Berlin
+      - TZ=${TZ:-Europe/Berlin}
       - MCP_GATEWAY_URL=http://localhost:8811/
       - UV_LINK_MODE=copy
     deploy:
       resources:
         limits:
-          cpus: '6'
-          memory: 12G
+          cpus: '${CPU_LIMIT:-6}'
+          memory: ${MEMORY_LIMIT:-12G}
     working_dir: /home/dev/projects
 
 networks:

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -19,11 +19,85 @@ BLUE='\033[0;34m'
 NC='\033[0m' # No Color
 
 # -----------------------------------------------------------------------------
+# Load .env file if it exists
+# -----------------------------------------------------------------------------
+load_env() {
+    if [[ -f ".env" ]]; then
+        # Export variables from .env (ignore comments and empty lines)
+        set -a
+        # shellcheck source=/dev/null
+        source .env
+        set +a
+    fi
+}
+
+# -----------------------------------------------------------------------------
+# Check required configuration
+# -----------------------------------------------------------------------------
+check_config() {
+    if [[ -z "${CODE_DIR:-}" ]]; then
+        echo -e "${RED}Error: CODE_DIR is not set.${NC}"
+        echo ""
+        echo "Please configure your environment:"
+        echo "  1. Copy .env.example to .env:"
+        echo "     cp .env.example .env"
+        echo ""
+        echo "  2. Edit .env and set CODE_DIR to your projects directory:"
+        echo "     CODE_DIR=/path/to/your/code"
+        echo ""
+        echo "  Or set it directly:"
+        echo "     export CODE_DIR=/path/to/your/code"
+        exit 1
+    fi
+
+    # Expand tilde
+    CODE_DIR="${CODE_DIR/#\~/$HOME}"
+    export CODE_DIR
+
+    if [[ ! -d "$CODE_DIR" ]]; then
+        echo -e "${RED}Error: CODE_DIR does not exist: $CODE_DIR${NC}"
+        exit 1
+    fi
+}
+
+# -----------------------------------------------------------------------------
+# Build optional shell mount arguments
+# -----------------------------------------------------------------------------
+get_shell_mount_args() {
+    local args=""
+
+    # Skip all shell mounts if SKIP_SHELL_MOUNTS is true
+    if [[ "${SKIP_SHELL_MOUNTS:-false}" == "true" ]]; then
+        echo ""
+        return
+    fi
+
+    # ZSH config (mounted as .zshrc.local)
+    if [[ -f "$HOME/.zshrc" ]]; then
+        args="$args -v $HOME/.zshrc:/home/dev/.zshrc.local:ro"
+    fi
+
+    # Oh My Posh theme
+    local omp_theme="${OMP_THEME_PATH:-$HOME/.oh-my-zsh/custom/themes/.zsh-theme-remote.omp.json}"
+    omp_theme="${omp_theme/#\~/$HOME}"
+    if [[ -f "$omp_theme" ]]; then
+        args="$args -v $omp_theme:/home/dev/.zsh-theme.omp.json:ro"
+    fi
+
+    # Oh My ZSH custom directory (plugins, themes, etc.)
+    if [[ -d "$HOME/.oh-my-zsh/custom" ]]; then
+        args="$args -v $HOME/.oh-my-zsh/custom:/home/dev/.oh-my-zsh/custom:ro"
+    fi
+
+    echo "$args"
+}
+
+# -----------------------------------------------------------------------------
 # Compose File Selection
 # -----------------------------------------------------------------------------
 get_compose_files() {
     local docker_enabled="${1:-false}"
-    
+
     if [[ "$docker_enabled" == "true" ]]; then
         echo "-f docker-compose.yml -f docker-compose.docker.yml"
     else
@@ -51,6 +125,16 @@ ${YELLOW}Options:${NC}
   --here      Mount current directory additionally under ~/workspace/
   --mount <path>  Mount specified path additionally under ~/workspace/
 
+${YELLOW}Configuration:${NC}
+  Copy .env.example to .env and set at minimum:
+    CODE_DIR=/path/to/your/projects
+
+  Optional settings in .env:
+    SKIP_SHELL_MOUNTS=true   # Skip zshrc/oh-my-zsh mounts
+    CPU_LIMIT=4              # Adjust resource limits
+    MEMORY_LIMIT=8G
+    TZ=America/New_York      # Timezone
+
 ${YELLOW}Security Modes:${NC}
   ${GREEN}Default${NC}        Kein Docker-Zugriff, kein Firewall
   ${GREEN}--docker${NC}       Docker via Proxy (gefährliche Ops blockiert)
@@ -60,7 +144,7 @@ ${YELLOW}Security Modes:${NC}
 ${YELLOW}Workspace Mount:${NC}
   ${GREEN}--here${NC}         Mountet \$(pwd) zusätzlich unter ~/workspace/
   ${GREEN}--mount /path${NC}  Mountet beliebigen Pfad unter ~/workspace/
-  
+
   Im Container:
     ~/projects/   → Dein festes Code-Verzeichnis (immer)
     ~/workspace/  → Temporärer Mount (nur mit --here/--mount)
@@ -83,15 +167,16 @@ ${YELLOW}Docker-Proxy Sicherheit:${NC}
   - Container starten/stoppen erlaubt
   - Image pulls erlaubt
   - ${RED}BLOCKIERT:${NC} exec, build, commit, swarm, secrets, auth
-  
+
   Details: DOCKER-SOCKET-SECURITY.md
 
 ${YELLOW}Workflow:${NC}
-  1. ./dev.sh build                    # Image bauen
-  2. cd mcp && ./mcp.sh start          # MCP Gateway starten
-  3. ./mcp.sh enable duckduckgo        # MCP Server aktivieren
-  4. cd .. && ./dev.sh auth            # Einmalig: OAuth
-  5. ./dev.sh start --docker           # Täglich: Mit Docker-Zugriff
+  1. cp .env.example .env && edit .env # Konfigurieren
+  2. ./dev.sh build                    # Image bauen
+  3. cd mcp && ./mcp.sh start          # MCP Gateway starten
+  4. ./mcp.sh enable duckduckgo        # MCP Server aktivieren
+  5. cd .. && ./dev.sh auth            # Einmalig: OAuth
+  6. ./dev.sh start --docker           # Täglich: Mit Docker-Zugriff
 
 ${YELLOW}Workspace Workflow:${NC}
   # An lokaler Config schrauben:
@@ -102,26 +187,28 @@ EOF
 
 ensure_network() {
     if ! docker network inspect ai-dev-network &>/dev/null; then
-        echo -e "${BLUE}📡${NC} Creating ai-dev-network..."
+        echo -e "${BLUE}Creating ai-dev-network...${NC}"
         docker network create ai-dev-network
     fi
 }
 
 cmd_build() {
-    echo -e "${BLUE}🔨${NC} Building ai-dev-base image..."
+    echo -e "${BLUE}Building ai-dev-base image...${NC}"
     docker compose build
-    echo -e "${GREEN}✅${NC} Done! Run './dev.sh start' to begin."
+    echo -e "${GREEN}Done! Run './dev.sh start' to begin.${NC}"
 }
 
 cmd_start() {
+    load_env
+    check_config
     ensure_network
-    
+
     # Parse arguments
     local docker_enabled="false"
     local firewall_enabled="false"
     local mount_path=""
     local skip_next="false"
-    
+
     local args=("$@")
     for i in "${!args[@]}"; do
         if [[ "$skip_next" == "true" ]]; then
@@ -137,13 +224,13 @@ cmd_start() {
                 mount_path="${args[$((i+1))]:-}"
                 skip_next="true"
                 if [[ -z "$mount_path" ]]; then
-                    echo -e "${RED}❌${NC} --mount requires a path argument"
+                    echo -e "${RED}--mount requires a path argument${NC}"
                     exit 1
                 fi
                 ;;
         esac
     done
-    
+
     # Validiere Mount-Pfad falls angegeben
     local extra_volume_args=""
     if [[ -n "$mount_path" ]]; then
@@ -153,77 +240,94 @@ cmd_start() {
         if [[ -d "$mount_path" ]]; then
             mount_path="$(cd "$mount_path" && pwd)"
         else
-            echo -e "${RED}❌${NC} Mount path does not exist or is not a directory: $mount_path"
+            echo -e "${RED}Mount path does not exist or is not a directory: $mount_path${NC}"
             exit 1
         fi
         extra_volume_args="-v ${mount_path}:/home/dev/workspace"
     fi
-    
+
+    # Get optional shell mounts
+    local shell_mount_args
+    shell_mount_args=$(get_shell_mount_args)
+
     # Compose files basierend auf Flags
     local compose_files
     compose_files=$(get_compose_files "$docker_enabled")
-    
+
     echo ""
-    echo -e "${BLUE}🚀${NC} Starting AI Dev environment..."
+    echo -e "${BLUE}Starting AI Dev environment...${NC}"
     echo ""
-    
+    echo -e "   ${GREEN}Projects:${NC}  $CODE_DIR"
+
     # Status anzeigen
     if [[ "$docker_enabled" == "true" ]]; then
-        echo -e "   ${GREEN}🐳 Docker:${NC}   Enabled (via secure proxy)"
-        echo -e "      └─ Erlaubt: containers, images, networks, volumes"
-        echo -e "      └─ Blockiert: exec, build, commit, swarm, secrets"
+        echo -e "   ${GREEN}Docker:${NC}    Enabled (via secure proxy)"
     else
-        echo -e "   ${YELLOW}🐳 Docker:${NC}   Disabled (use --docker to enable)"
+        echo -e "   ${YELLOW}Docker:${NC}    Disabled (use --docker to enable)"
     fi
-    
+
     if [[ "$firewall_enabled" == "true" ]]; then
-        echo -e "   ${GREEN}🔒 Firewall:${NC} Enabled (outbound restricted)"
+        echo -e "   ${GREEN}Firewall:${NC}  Enabled (outbound restricted)"
     else
-        echo -e "   ${YELLOW}🔒 Firewall:${NC} Disabled (use --firewall to enable)"
+        echo -e "   ${YELLOW}Firewall:${NC}  Disabled (use --firewall to enable)"
     fi
-    
+
     if [[ -n "$mount_path" ]]; then
-        echo -e "   ${GREEN}📂 Workspace:${NC} $mount_path"
-        echo -e "      └─ Available at: ~/workspace/"
+        echo -e "   ${GREEN}Workspace:${NC} $mount_path"
+    fi
+
+    if [[ "${SKIP_SHELL_MOUNTS:-false}" == "true" ]]; then
+        echo -e "   ${YELLOW}Shell:${NC}     Using container defaults (SKIP_SHELL_MOUNTS=true)"
+    elif [[ -n "$shell_mount_args" ]]; then
+        echo -e "   ${GREEN}Shell:${NC}     Host config mounted"
+    else
+        echo -e "   ${YELLOW}Shell:${NC}     No host config found"
     fi
     echo ""
-    
+
     # Container starten
     # shellcheck disable=SC2086
     ENABLE_FIREWALL="$firewall_enabled" \
-        docker compose $compose_files run --rm $extra_volume_args dev
+        docker compose $compose_files run --rm $extra_volume_args $shell_mount_args dev
 }
 
 cmd_auth() {
+    load_env
+    check_config
+
     # Parse arguments
     local docker_enabled="false"
-    
+
     for arg in "$@"; do
         case "$arg" in
             --docker) docker_enabled="true" ;;
         esac
     done
-    
+
     local compose_files
     compose_files=$(get_compose_files "$docker_enabled")
-    
-    echo -e "${BLUE}🔐${NC} Starting AI Dev with host network for OAuth authentication..."
+
+    # Get optional shell mounts
+    local shell_mount_args
+    shell_mount_args=$(get_shell_mount_args)
+
+    echo -e "${BLUE}Starting AI Dev with host network for OAuth authentication...${NC}"
     echo ""
     echo "This mode uses network_mode: host so OAuth callbacks work."
     echo "After authenticating Claude Code, Gemini CLI and Codex, exit and use './dev.sh start'"
     echo ""
-    
+
     if [[ "$docker_enabled" == "true" ]]; then
-        echo -e "${YELLOW}⚠️  Docker-Proxy wird im Host-Network-Modus separat gestartet...${NC}"
+        echo -e "${YELLOW}Docker-Proxy wird im Host-Network-Modus separat gestartet...${NC}"
         # Proxy manuell starten wenn im auth-modus mit docker
         # shellcheck disable=SC2086
         docker compose $compose_files up -d docker-proxy 2>/dev/null || true
         sleep 2
     fi
-    
+
     # shellcheck disable=SC2086
-    docker compose $compose_files --profile auth run --rm dev-auth
-    
+    docker compose $compose_files --profile auth run --rm $shell_mount_args dev-auth
+
     # Proxy wieder stoppen
     if [[ "$docker_enabled" == "true" ]]; then
         # shellcheck disable=SC2086
@@ -232,59 +336,69 @@ cmd_auth() {
 }
 
 cmd_status() {
-    echo -e "${BLUE}📦 Containers:${NC}"
+    load_env
+
+    echo -e "${BLUE}Configuration:${NC}"
+    if [[ -n "${CODE_DIR:-}" ]]; then
+        echo "  CODE_DIR: $CODE_DIR"
+    else
+        echo "  CODE_DIR: (not set)"
+    fi
+    echo ""
+
+    echo -e "${BLUE}Containers:${NC}"
     docker ps -a --filter "name=ai-dev" --filter "name=mcp-" --format "table {{.Names}}\t{{.Status}}\t{{.Image}}"
     echo ""
-    
-    echo -e "${BLUE}💾 Volumes:${NC}"
+
+    echo -e "${BLUE}Volumes:${NC}"
     docker volume ls --filter "name=ai-dev" --filter "name=mcp-" --format "table {{.Name}}\t{{.Driver}}"
     echo ""
-    
-    echo -e "${BLUE}🌐 Networks:${NC}"
+
+    echo -e "${BLUE}Networks:${NC}"
     docker network ls --filter "name=ai-dev" --format "table {{.Name}}\t{{.Driver}}"
     echo ""
-    
+
     # Docker Proxy Status
     if docker ps --format '{{.Names}}' | grep -q '^ai-dev-docker-proxy$'; then
-        echo -e "${GREEN}🐳 Docker Proxy: Running${NC}"
+        echo -e "${GREEN}Docker Proxy: Running${NC}"
         # Proxy-Statistiken
         local blocked
         blocked=$(docker logs ai-dev-docker-proxy 2>&1 | grep -c "blocked" || echo "0")
-        echo "   └─ Blocked requests: $blocked"
+        echo "   Blocked requests: $blocked"
     else
-        echo -e "${YELLOW}🐳 Docker Proxy: Not running${NC}"
-        echo "   └─ Start with: ./dev.sh start --docker"
+        echo -e "${YELLOW}Docker Proxy: Not running${NC}"
+        echo "   Start with: ./dev.sh start --docker"
     fi
     echo ""
-    
+
     # MCP Status
     if docker ps --format '{{.Names}}' | grep -q '^mcp-gateway$'; then
-        echo -e "${GREEN}🤖 MCP Gateway: Running${NC}"
+        echo -e "${GREEN}MCP Gateway: Running${NC}"
         if command -v docker &>/dev/null && docker mcp server ls &>/dev/null 2>&1; then
             echo "   Enabled servers:"
             docker mcp server ls 2>/dev/null | sed 's/^/   /'
         fi
     else
-        echo -e "${YELLOW}🤖 MCP Gateway: Not running${NC}"
+        echo -e "${YELLOW}MCP Gateway: Not running${NC}"
         echo "   Start with: cd mcp && ./mcp.sh start"
     fi
 }
 
 cmd_clean() {
-    echo -e "${BLUE}🧹${NC} Cleaning up..."
-    
+    echo -e "${BLUE}Cleaning up...${NC}"
+
     # Alle compose configs verwenden für vollständiges cleanup
     docker compose -f docker-compose.yml -f docker-compose.docker.yml down 2>/dev/null || true
-    
+
     if [[ "${1:-}" == "--all" ]]; then
-        echo -e "${RED}⚠️  Removing ALL volumes (including credentials)...${NC}"
+        echo -e "${RED}Removing ALL volumes (including credentials)...${NC}"
         docker volume rm $(docker volume ls -q | grep ai-dev) 2>/dev/null || true
-        echo -e "${RED}⚠️  Removing network...${NC}"
+        echo -e "${RED}Removing network...${NC}"
         docker network rm ai-dev-network 2>/dev/null || true
-        echo -e "${GREEN}✅${NC} All volumes and network removed."
+        echo -e "${GREEN}All volumes and network removed.${NC}"
     fi
-    
-    echo -e "${GREEN}✅${NC} Cleanup complete."
+
+    echo -e "${GREEN}Cleanup complete.${NC}"
 }
 
 # -----------------------------------------------------------------------------
@@ -292,12 +406,12 @@ cmd_clean() {
 # -----------------------------------------------------------------------------
 cmd_audit() {
     if ! docker ps --format '{{.Names}}' | grep -q '^ai-dev-docker-proxy$'; then
-        echo -e "${RED}❌${NC} Docker Proxy is not running."
+        echo -e "${RED}Docker Proxy is not running.${NC}"
         echo "   Start with: ./dev.sh start --docker"
         exit 1
     fi
-    
-    echo -e "${BLUE}📋${NC} Docker Proxy Audit Log (last 50 lines):"
+
+    echo -e "${BLUE}Docker Proxy Audit Log (last 50 lines):${NC}"
     echo ""
     docker logs --tail 50 ai-dev-docker-proxy 2>&1
 }


### PR DESCRIPTION
- Add .env.example template with all configurable variables
- Replace hardcoded paths with CODE_DIR environment variable
- Add optional shell mounts (zshrc, oh-my-zsh, oh-my-posh)
- Add SKIP_SHELL_MOUNTS option for systems without oh-my-zsh
- Make resource limits configurable (CPU_LIMIT, MEMORY_LIMIT)
- Update README with new configuration workflow
- Add .gitignore to exclude .env from version control