### PR TITLE
CLI output redesign: palette, banner, rules-based two-world startup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -149,6 +149,7 @@ RUN chmod +x ~/.tools/install.sh ~/.tools/installers/*.sh 2>/dev/null || true \
     && date +%s > ~/.build-timestamp
 
 COPY --chown=dev:dev scripts/entrypoint.sh /home/dev/entrypoint.sh
+COPY --chown=dev:dev scripts/output-lib.sh /home/dev/output-lib.sh
 COPY --chown=dev:dev scripts/seed-lib.sh /home/dev/seed-lib.sh
 COPY --chown=dev:dev scripts/mcp-register.sh /home/dev/mcp-register.sh
 RUN chmod +x ~/entrypoint.sh ~/mcp-register.sh

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -55,6 +55,8 @@ x-common-volumes: &common-volumes
 
 x-common-environment: &common-environment
   TZ: ${TZ:-UTC}
+  NO_COLOR: ${NO_COLOR:-}
+  DJINN_TERM_WIDTH: ${DJINN_TERM_WIDTH:-}
   UV_LINK_MODE: copy
   # Host-local LLM endpoint (e.g. Ollama on the host)
   LOCAL_ENDPOINT: ${LOCAL_ENDPOINT:-http://host.docker.internal:11434/v1}

--- a/docs/design/CLI_DESIGN_SYSTEM.md
+++ b/docs/design/CLI_DESIGN_SYSTEM.md
@@ -1,334 +1,194 @@
-# Djinn in a Box CLI Design System
+# Djinn CLI Design System
 
-> **Version:** 1.0.0
-> **Framework:** Rich (Python)
-> **Aesthetic:** Neo-Terminal Elegance
+This document describes the shipped CLI output system for `djinn` and
+`mcpgateway`. The source of truth for Python styling is
+`src/djinn_in_a_box/core/theme.py`; the source of truth for container-startup
+shell styling is `scripts/output-lib.sh`.
 
----
+## Palette
 
-## 1. Design Philosophy
+All Python color values are defined once as constants in `theme.py`. Command
+modules use Rich role names, never literal colors.
 
-### Core Principles
+| Role | Value | Usage |
+|------|-----|-------|
+| `primary` | `#69B9A1` | Brand color, rule titles, table titles and headers, command highlights, emphasized values. |
+| `secondary` | `#226666` | Depth color for table categories and the lower banner logo gradient; avoid small unbolded body text. |
+| `success` | `#C1FF62` | Success icon and enabled/running/connected states. |
+| `error` | `#F53263` | Error icon, failures, aborts, and failed states. |
+| `warning` | `#FAF870` | Warning icon, disabled states, gaps, and non-fatal missing optional tools. |
+| `info` | ANSI blue color 4 | Info icon and informational messages; terminal-adaptive and plain weight. |
+| `path` | `#8608B8` | Filesystem paths in status output and config displays. |
+| `muted` | `#333676` | Secondary labels, hints, timestamps, and table values. |
+| `border` | `#29526D` | Rule lines, table borders, and separators. |
 
-**"Simple elegance with deliberate accents"**
+Terminal default text is intentionally not a palette color. It remains unset so
+the CLI respects the user's terminal theme.
 
-The CLI follows the principle of **clarity over decoration**:
+## Derived Roles
 
-- At first glance: clean, professional, focused
-- Colors communicate **meaning**, not decoration
-- Consistent appearance across the Djinn CLI surface
+`DJINN_THEME` exposes semantic roles used by commands:
 
-### Design DNA
+| Derived role | Mapping |
+|--------------|---------|
+| `header` | `primary`, bold |
+| `table.title` | `primary`, bold |
+| `table.header` | `primary`, bold |
+| `table.category` | `secondary` |
+| `table.value` | `muted` |
+| `path` | `#8608B8` |
+| `status.enabled` | `success` |
+| `status.disabled` | `warning` |
+| `status.error` | `error` |
+| `primary.bold`, `secondary.bold`, `info.bold` | Bold variants of their base roles |
 
-| Principle | Implementation |
-|-----------|----------------|
-| **Semantic Colors** | Colors show status, not style. |
-| **Hierarchy First** | Highlight what matters and keep the rest quiet. |
-| **Restraint Is Power** | Accent colors are reserved for important elements. |
-| **Icons as Signals** | Unicode icons support fast recognition. |
+The status icons live in `ICONS`: success `✓`, error `✗`, warning `⚠`, and
+info `ℹ`. Command code should use `success()`, `error()`, `warning()`, `info()`,
+`status_line()`, `rule()`, or table roles instead of embedding color names.
 
----
+## Python Components
 
-## 2. Color System
+### Rules
 
-### 2.1 Core Palette
+Section structure uses `rule(title)` to render `─ Title ─...`. The title uses
+`primary.bold`; the line uses `border`. `rule()` owns section spacing by writing
+exactly one blank line before the rule, and the rendered rule line spans the
+current Rich console width.
 
-```text
-┌─────────────────────────────────────────────────────────────────┐
-│                    DJINN CLI COLOR SYSTEM                       │
-├─────────────────────────────────────────────────────────────────┤
-│                                                                 │
-│  ┌─────────┐  ┌─────────┐                                      │
-│  │ PRIMARY │  │  MUTED  │                                      │
-│  │ #69B9A1 │  │ #b2bec3 │                                      │
-│  │  Teal   │  │  Gray   │                                      │
-│  └─────────┘  └─────────┘                                      │
-│                                                                 │
-│  Status Colors:                                                 │
-│  ┌─────────┐  ┌─────────┐  ┌─────────┐  ┌─────────┐            │
-│  │ SUCCESS │  │  INFO   │  │ WARNING │  │  ERROR  │            │
-│  │ #03b971 │  │ #0e8ac8 │  │ #f5b332 │  │ #9c0136 │            │
-│  │  Green  │  │  Blue   │  │ Orange  │  │   Red   │            │
-│  └─────────┘  └─────────┘  └─────────┘  └─────────┘            │
-│                                                                 │
-└─────────────────────────────────────────────────────────────────┘
-```
+Examples of shipped rule sections include `djinn start` (`Environment`,
+`Container`), `djinn status`, `djinn doctor`, `djinn clean volumes`, `djinn
+agents`, and `mcpgateway status`.
 
-### 2.2 Color Tokens
+### Status Lines
 
-| Token | Hex | Rich Style | Usage |
-|-------|-----|------------|-------|
-| `PRIMARY` | `#69B9A1` | `[primary]` | Labels and important elements |
-| `TEXT_MUTED` | `#b2bec3` | `[muted]` | Hints and secondary text |
+`status_line(label, value, style="status.enabled", value_style=None)` writes
+aligned operational state to stderr. Use `value_style="path"` only for
+filesystem path values such as Projects, Workspace, CODE_DIR, and sync roots.
+Use the `status.*` roles for state labels and message roles for message helpers.
 
-### 2.3 Status Colors
+### Tables
 
-| Token | Hex | Rich Style | Usage |
-|-------|-----|------------|-------|
-| `SUCCESS` | `#03b971` | `[success]` | Success and enabled states |
-| `INFO` | `#0e8ac8` | `[info]` / `[header]` | Information and section headers |
-| `WARNING` | `#f5b332` | `[warning]` | Warnings and disabled states |
-| `ERROR` | `#9c0136` | `[error]` | Errors and critical states |
-
-### 2.4 Color Application Rules
-
-```text
-70% ─── Default Text (#ffffff)
-        → Regular content
-
-20% ─── Primary/Info (#69B9A1, #0e8ac8)
-        → Labels, headers, emphasis
-
-8%  ─── Muted (#b2bec3)
-        → Hints and secondary information
-
-2%  ─── Status Colors (Success, Error, Warning)
-        → Status changes only
-```
-
----
-
-## 3. Typography & Text Styles
-
-### 3.1 Text Hierarchy
-
-| Element | Rich Style | Usage |
-|---------|------------|-------|
-| **Headers** | `[header]` / `[info.bold]` | Section titles |
-| **Labels** | `[primary]` | Labels |
-| **Body** | Normal | Regular content |
-| **Emphasis** | `[primary.bold]` | Important elements |
-| **Muted** | `[muted]` | Secondary information and hints |
-
-### 3.2 Message Styles
-
-| Message Type | Format | Example |
-|--------------|--------|---------|
-| Error | `[error]✗ Error: {msg}[/error]` | ✗ Error: File not found |
-| Success | `[success]✓ {msg}[/success]` | ✓ Build complete |
-| Warning | `[warning]⚠ Warning: {msg}[/warning]` | ⚠ Warning: Config missing |
-| Info | `[info]ℹ {msg}[/info]` | ℹ Starting build... |
-
----
-
-## 4. Icons (Unicode)
-
-### 4.1 Status Icons
-
-| Icon | Unicode | Style | Usage |
-|------|---------|-------|-------|
-| ✓ | U+2713 | `[success]` | Success and completed work |
-| ✗ | U+2717 | `[error]` | Errors and failed work |
-| ⚠ | U+26A0 | `[warning]` | Warning |
-| ℹ | U+2139 | `[info]` | Information |
-
-### 4.2 Icon Usage
+Rich tables use the central table roles:
 
 ```python
-# Defined in theme.py
-ICONS = {
-    "success": "✓",
-    "error": "✗",
-    "warning": "⚠",
-    "info": "ℹ",
-}
-```
-
----
-
-## 5. Component Patterns
-
-### 5.1 Status Line
-
-Format: `   {label}:  {value}`
-
-```text
-   Projects:   /home/user/projects
-   Docker:     Running
-   Agent:      claude
-```
-
-Code:
-
-```python
-status_line("Projects", "/home/user/projects", "status.enabled")
-status_line("Docker", "Disabled", "status.disabled")
-```
-
-### 5.2 Header
-
-```python
-header("Configuration")
-# Output: Configuration:  (in [header] style)
-```
-
-### 5.3 Tables
-
-```python
-table = Table(title="Djinn Volumes", title_style="table.title")
+table = Table(
+    title="Djinn Volumes",
+    title_style="table.title",
+    header_style="table.header",
+    border_style="border",
+)
 table.add_column("Category", style="table.category")
 table.add_column("Volume", style="table.value")
 ```
 
-### 5.4 Progress Output
+Shipped table users include `config show`, `status`, `doctor`, `agents`, and
+resource lists used by `clean volumes`.
 
-```text
-ℹ Building djinn-in-a-box image...
-✓ Build complete
-⚠ Warning: Cache not available
-✗ Error: Docker daemon not running
-```
+## Banner
 
----
+`src/djinn_in_a_box/core/banner.py` renders the startup banner for `djinn start`.
+It never raises to the caller; if rendering fails it falls back to the plain
+title.
 
-## 6. Rich Theme Definition
+The banner has three modes:
 
-### 6.1 Theme Structure
+| Mode | Predicate | Output |
+|------|-----------|--------|
+| Full | UTF-8 output, color enabled, terminal width at least 70 columns | Braille djinn logo with a `primary` to `secondary` vertical gradient plus the block `DJINN` wordmark and muted `in a box` tagline. |
+| Wordmark | UTF-8 output, but narrow or colorless | Block `DJINN` wordmark and muted tagline. |
+| Plain | Non-empty `NO_COLOR`, dumb terminal, non-UTF-8 output, or fallback path | `Djinn in a Box`. |
 
-```python
-from rich.style import Style
-from rich.theme import Theme
+Font support for Braille glyphs is best-effort and is not auto-detected.
 
-DJINN_THEME = Theme({
-    # Semantic Message Styles
-    "success": Style(color="#03b971"),
-    "error": Style(color="#9c0136", bold=True),
-    "warning": Style(color="#f5b332"),
-    "info": Style(color="#0e8ac8"),
-    "info.bold": Style(color="#0e8ac8", bold=True),
+## Startup Structure
 
-    # Primary Styles
-    "primary": Style(color="#69B9A1"),
-    "primary.bold": Style(color="#69B9A1", bold=True),
+`djinn start` uses a two-world output model:
 
-    # Text Styles
-    "muted": Style(color="#b2bec3"),
+| Producer | Sections |
+|----------|----------|
+| Python/Rich | Banner, `Environment`, `Container`. |
+| Container shell | `Seed & Config`, `MCP`, `Tools`, `Security`. |
 
-    # Header Styles
-    "header": Style(color="#0e8ac8", bold=True),
+Python writes startup UI through `err_console`, so UI goes to stderr. The
+interactive Docker run inherits host stdio; shell-side startup messages also
+write to stderr.
 
-    # Status Indicators
-    "status.enabled": Style(color="#03b971"),
-    "status.disabled": Style(color="#f5b332"),
-    "status.error": Style(color="#9c0136"),
+## Shell Output Library
 
-    # Table Styles
-    "table.title": Style(color="#0e8ac8", bold=True),
-    "table.header": Style(bold=True),
-    "table.category": Style(color="#f5b332"),
-    "table.value": Style(color="#b2bec3"),
-})
-```
+`scripts/output-lib.sh` is sourced by the container entrypoint and MCP
+registration script. It provides:
 
-### 6.2 Console Initialization
+| Function | Purpose |
+|----------|---------|
+| `ui_section "Title"` | Rule-like section line. |
+| `ui_ok "Message"` | Success marker. |
+| `ui_warn "Message"` | Warning marker. |
+| `ui_err "Message"` | Error marker. |
+| `ui_info "Message"` | Info marker. |
+| `ui_boxed "Title"` | Reads body lines from stdin and renders indented external output in an open-right muted frame. |
+| `ui_item "Marker" "Message"` | Generic info-colored item marker unless a caller explicitly passes another role. |
 
-```python
-from rich.console import Console
-from djinn_in_a_box.core.theme import DJINN_THEME
+Shell sections print exactly one blank line before the rule. `ui_section`
+resolves rule width from `COLUMNS`, then `tput cols`, then the second field of
+`stty size`, and finally falls back to 80 columns. The visible rule line spans
+that resolved width exactly.
 
-console = Console(theme=DJINN_THEME)
-err_console = Console(stderr=True, theme=DJINN_THEME)
-```
+The library uses exact Python palette RGB values when `COLORTERM` is
+`truecolor` or `24bit`. Otherwise it uses ANSI-256 approximations:
 
----
+| Role | Truecolor | ANSI-256 fallback |
+|------|-----------|-------------------|
+| `primary` | `38;2;105;185;161` | `73` |
+| `secondary` | `38;2;34;102;102` | `23` |
+| `success` | `38;2;193;255;98` | `155` |
+| `error` | `38;2;245;50;99` | `203` |
+| `warning` | `38;2;250;248;112` | `227` |
+| `info` | ANSI blue `0;34` | ANSI blue `0;34` |
+| `path` | `38;2;134;8;184` | `91` |
+| `muted` | `38;2;51;54;118` | `60` |
+| `border` | `38;2;41;82;109` | `24` |
 
-## 7. Usage Examples
+Color is enabled only when stderr is a TTY, unless the test hook
+`DJINN_FORCE_UI_COLOR=1` is set. `NO_COLOR` wins only when it is present with a
+non-empty value.
 
-### 7.1 Basic Output
+`ui_boxed "Title"` is for captured output from external tools inside startup
+sections. It writes nothing for empty stdin. When body text is present, it
+renders a short frame indented two spaces, colors the frame and body with
+`muted`, and leaves the right side open so long tool output such as URLs cannot
+overrun a right border. Plain mode uses ASCII-only `+-`, `|`, and `+---` frame
+lines.
 
-```python
-from djinn_in_a_box.core.console import error, success, info, warning
+## NO_COLOR And Plain Output
 
-# Messages
-success("Build complete")           # ✓ Build complete
-error("File not found")             # ✗ Error: File not found
-warning("Config missing")           # ⚠ Warning: Config missing
-info("Starting build...")           # ℹ Starting build...
-```
+Python Rich output follows Rich's `no_color` behavior. The banner uses plain mode
+when color is disabled or the terminal is dumb.
 
-### 7.2 Rich Markup
+Shell output uses plain ASCII-compatible markers when `NO_COLOR` is non-empty
+or when stderr is not a TTY:
 
-```python
-from djinn_in_a_box.core.console import console
+| Color marker | Plain marker |
+|--------------|--------------|
+| `✓` | `[ok]` |
+| `⚠` | `[warn]` |
+| `✗` | `[err]` |
+| `ℹ` | `[info]` |
 
-console.print("[primary]djinn[/primary] [muted]v1.0.0[/muted]")
-console.print("[header]Configuration:[/header]")
-console.print("  [muted]1.[/muted] First step")
-console.print("  [success]✓[/success] Completed task")
-```
+Plain shell sections render as `- Title ...` and contain no ANSI escape
+sequences.
 
-### 7.3 Status Lines
+## Stream Discipline
 
-```python
-from djinn_in_a_box.core.console import status_line, header
+Operational UI belongs on stderr. This keeps stdout available for command data
+and agent output. Existing examples:
 
-header("Environment")
-status_line("Projects", "/home/user/projects")
-status_line("Docker", "Running", "status.enabled")
-status_line("GPU", "Disabled", "status.disabled")
-```
+| Surface | stdout | stderr |
+|---------|--------|--------|
+| `djinn run` | Agent stdout | Run status and agent stderr |
+| `djinn session --prompt` | Agent stdout | Agent stderr and errors |
+| `djinn config path` | Raw config path | Errors only |
+| `djinn start` | Interactive container stdout | Startup UI |
+| Shell startup | None for UI | Section lines, markers, and startup diagnostics |
 
----
-
-## 8. Migration Guide
-
-### From Inline Colors to Theme Styles
-
-| Old (Inline) | New (Theme) |
-|--------------|-------------|
-| `[red]` | `[error]` |
-| `[green]` | `[success]` or `[status.enabled]` |
-| `[yellow]` | `[warning]` or `[status.disabled]` |
-| `[blue]` | `[info]` or `[header]` |
-| `[bold]` | `[primary.bold]` or `[info.bold]` |
-| `[dim]` | `[muted]` |
-
----
-
-## 9. Accessibility
-
-### Contrast Ratios (WCAG AA)
-
-| Foreground | Background | Ratio | Status |
-|------------|------------|-------|--------|
-| #ffffff | #212121 | 13.5:1 | ✓ AAA |
-| #69B9A1 | #212121 | 6.8:1 | ✓ AA |
-| #b2bec3 | #212121 | 8.2:1 | ✓ AAA |
-| #03b971 | #212121 | 6.2:1 | ✓ AA |
-| #9c0136 | #212121 | 4.8:1 | ✓ AA |
-
----
-
-## 10. Quick Reference
-
-### Color Tokens
-
-```text
-PRIMARY:      #69B9A1  (Teal)
-SUCCESS:      #03b971  (Green)
-INFO:         #0e8ac8  (Blue)
-WARNING:      #f5b332  (Orange)
-ERROR:        #9c0136  (Red)
-MUTED:        #b2bec3  (Gray)
-```
-
-### Style Names
-
-```text
-[success]     [error]       [warning]     [info]
-[primary]     [primary.bold] [muted]       [header]
-[info.bold]
-[status.enabled]  [status.disabled]  [status.error]
-[table.title]     [table.header]     [table.category] [table.value]
-```
-
-### Icons
-
-```text
-✓ success    ✗ error    ⚠ warning    ℹ info
-```
-
----
-
-*Djinn CLI design system v1.0.0*
-*Adapted for CLI usage with the Rich library*
+When a command intentionally returns data, keep that data on stdout and put
+status/progress on stderr.

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -5,11 +5,47 @@ set -euo pipefail
 # Djinn in a Box - Entrypoint Script
 # =============================================================================
 
+OUTPUT_LIB="${OUTPUT_LIB:-/home/dev/output-lib.sh}"
+_djinn_define_plain_ui_fallbacks() {
+    ui_section() { echo "[info] $1" >&2; }
+    ui_ok() { echo "[ok] $1" >&2; }
+    ui_warn() { echo "[warn] $1" >&2; }
+    ui_err() { echo "[err] $1" >&2; }
+    ui_info() { echo "[info] $1" >&2; }
+    ui_item() {
+        local marker=$1
+        local message=$2
+        local plain_marker=${3:-}
+        local plain_message=${5:-$message}
+
+        if [[ -z "$plain_marker" ]]; then
+            case "$marker" in
+                "↻") plain_marker="[sync]" ;;
+                "⊕") plain_marker="[merge]" ;;
+                "✕") plain_marker="[stale]" ;;
+                "+") plain_marker="[init]" ;;
+                "-") plain_marker="[off]" ;;
+                "!") plain_marker="[warn]" ;;
+                *) plain_marker="[info]" ;;
+            esac
+        fi
+
+        echo "$plain_marker $plain_message" >&2
+    }
+}
+
+if [[ -r "$OUTPUT_LIB" ]] && source "$OUTPUT_LIB"; then
+    :
+else
+    _djinn_define_plain_ui_fallbacks
+    ui_warn "output library not found at $OUTPUT_LIB; using plain startup output."
+fi
+
 # -----------------------------------------------------------------------------
 # Firewall & Permissions
 # -----------------------------------------------------------------------------
 if [[ "${ENABLE_FIREWALL:-false}" == "true" ]]; then
-    echo "🔒 Initializing firewall..."
+    ui_info "Initializing firewall..."
     sudo /usr/local/bin/init-firewall.sh
 fi
 
@@ -38,11 +74,12 @@ fi
 # =============================================================================
 # Tool Configuration & Seed Sync
 # =============================================================================
+ui_section "Seed & Config"
 mkdir -p ~/.claude/{agents,skills,commands} ~/.gemini ~/.codex ~/.config/opencode/commands
 SEED_LIB="${SEED_LIB:-/home/dev/seed-lib.sh}"
 if [[ ! -r "$SEED_LIB" ]]; then
-    echo "✗ seed library not found at $SEED_LIB — the image is stale or broken." >&2
-    echo "  Rebuild it with: djinn build" >&2
+    ui_err "seed library not found at $SEED_LIB — the image is stale or broken."
+    ui_info "Rebuild it with: djinn build"
     exit 1
 fi
 source "$SEED_LIB"
@@ -54,27 +91,38 @@ if [[ -f "$HOME/.claude/claude.json" ]]; then
     cp "$HOME/.claude/claude.json" "$HOME/.claude.json"
 fi
 
-claude_settings_merge "$HOME/.claude_seed" "$HOME/.claude/settings.json"
+ui_info "[seed-sync] claude:"
+claude_settings_merge "$HOME/.claude_seed" "$HOME/.claude/settings.json" >&2
 
-sync_seed "gemini"   "$HOME/.gemini_seed"   "$HOME/.gemini"          "$HOME/.gemini/settings.json"
-sync_seed "opencode" "$HOME/.opencode/seed" "$HOME/.config/opencode" "$HOME/.config/opencode/.opencode.json"
+sync_seed "gemini"   "$HOME/.gemini_seed"   "$HOME/.gemini"          "$HOME/.gemini/settings.json" >&2
+sync_seed "opencode" "$HOME/.opencode/seed" "$HOME/.config/opencode" "$HOME/.config/opencode/.opencode.json" >&2
 
 # =============================================================================
 # MCP Server Registration (all CLI tools, from canonical config)
 # =============================================================================
-source /home/dev/mcp-register.sh
-register_mcp_servers
+ui_section "MCP"
+MCP_REGISTER="${MCP_REGISTER:-/home/dev/mcp-register.sh}"
+source "$MCP_REGISTER"
+register_mcp_servers >&2
 
 # =============================================================================
 # Optional Tools Installation (with caching)
 # =============================================================================
+ui_section "Tools"
 if [[ -f ~/.tools/install.sh ]]; then
-    ~/.tools/install.sh
+    ~/.tools/install.sh >&2
 fi
 
 # =============================================================================
-# Docker Status & Verification
+# Security Summary
 # =============================================================================
+ui_section "Security"
+if [[ "${ENABLE_FIREWALL:-false}" == "true" ]]; then
+    ui_ok "Firewall:     Enabled"
+else
+    ui_warn "Firewall:     Disabled"
+fi
+
 if [[ "${DOCKER_DIRECT:-false}" == "true" ]]; then
     # Direct socket mode: fix permissions so dev user can access immediately
     if [[ -S /var/run/docker.sock ]]; then
@@ -85,70 +133,50 @@ if [[ "${DOCKER_DIRECT:-false}" == "true" ]]; then
         fi
     fi
 
-    echo ""
-    echo "🐳 Docker Access: Direct socket (NO PROXY)"
-    echo "   Socket: /var/run/docker.sock"
-    echo ""
-    echo "   ⚠  WARNING: Full Docker access — no API filtering!"
-    echo "   All operations allowed: build, exec, push, etc."
-    echo ""
+    ui_ok "Docker Access: Direct socket (NO PROXY)"
+    ui_info "Socket: /var/run/docker.sock"
+    ui_warn "WARNING: Full Docker access — no API filtering!"
+    ui_info "All operations allowed: build, exec, push, etc."
 
     if docker version &>/dev/null; then
-        echo "   Status: ✓ Connected"
+        ui_ok "Status: Connected"
     else
-        echo "   Status: ✗ Connection failed"
-        echo "   Hint: Check socket permissions (host docker GID: ${SOCK_GID:-unknown})"
+        ui_err "Status: Connection failed"
+        ui_info "Hint: Check socket permissions (host docker GID: ${SOCK_GID:-unknown})"
     fi
-    echo ""
 elif [[ -n "${DOCKER_HOST:-}" ]]; then
-    echo ""
-    echo "🐳 Docker Access: Enabled via proxy"
-    echo "   Host: $DOCKER_HOST"
+    ui_ok "Docker Access: Enabled via proxy"
+    ui_info "Host: $DOCKER_HOST"
 
     # Test connection
     if docker version &>/dev/null; then
-        echo "   Status: ✓ Connected"
+        ui_ok "Status: Connected"
 
         # Document proxy restrictions
-        echo ""
-        echo "   Allowed operations:"
-        echo "     ✓ docker ps, images, networks, volumes"
-        echo "     ✓ docker run, start, stop, rm"
-        echo "     ✓ docker pull"
-        echo ""
-        echo "   Blocked operations (security):"
-        echo "     ✗ docker exec (use 'docker run' instead)"
-        echo "     ✗ docker build (use pre-built images)"
-        echo "     ✗ docker commit, push"
-        echo "     ✗ swarm, secrets, configs"
+        ui_info "Allowed operations:"
+        ui_ok "docker ps, images, networks, volumes"
+        ui_ok "docker run, start, stop, rm"
+        ui_ok "docker pull"
+        ui_info "Blocked operations (security):"
+        ui_err "docker exec (use 'docker run' instead)"
+        ui_err "docker build (use pre-built images)"
+        ui_err "docker commit, push"
+        ui_err "swarm, secrets, configs"
     else
-        echo "   Status: ✗ Connection failed"
-        echo "   Hint: Is docker-proxy running? Check: docker ps | grep proxy"
+        ui_err "Status: Connection failed"
+        ui_info "Hint: Is docker-proxy running? Check: docker ps | grep proxy"
     fi
-    echo ""
 else
-    echo ""
-    echo "🐳 Docker Access: Disabled"
-    echo "   Enable with: djinn start --docker"
-    echo ""
+    ui_warn "Docker Access: Disabled"
+    ui_info "Enable with: djinn start --docker"
 fi
 
-# =============================================================================
-# Security Summary
-# =============================================================================
-echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
-echo "Security Status:"
-printf "  Firewall:     %s\n" "${ENABLE_FIREWALL:-false}" | sed 's/true/✓ Enabled/;s/false/✗ Disabled/'
-if [[ "${DOCKER_DIRECT:-false}" == "true" ]]; then
-    printf "  Docker:       ✓ Enabled (DIRECT — no proxy)\n"
-elif [[ "${DOCKER_ENABLED:-false}" == "true" ]]; then
-    printf "  Docker:       ✓ Enabled (proxied)\n"
+if [[ "${MCP_REACHABLE:-false}" == "true" ]]; then
+    ui_ok "MCP Gateway:  Connected"
 else
-    printf "  Docker:       ✗ Disabled\n"
+    ui_warn "MCP Gateway:  Not connected"
 fi
-printf "  MCP Gateway:  %s\n" "$([[ "$MCP_REACHABLE" == "true" ]] && echo '✓ Connected' || echo '✗ Not connected')"
-echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
-echo ""
+echo "" >&2
 
 # =============================================================================
 # Interactive Shell (reverse-sync settings on exit)

--- a/scripts/init-firewall.sh
+++ b/scripts/init-firewall.sh
@@ -14,6 +14,42 @@
 
 set -euo pipefail
 
+OUTPUT_LIB="${OUTPUT_LIB:-/home/dev/output-lib.sh}"
+_djinn_define_plain_ui_fallbacks() {
+    ui_section() { echo "[info] $1" >&2; }
+    ui_ok() { echo "[ok] $1" >&2; }
+    ui_warn() { echo "[warn] $1" >&2; }
+    ui_err() { echo "[err] $1" >&2; }
+    ui_info() { echo "[info] $1" >&2; }
+    ui_item() {
+        local marker=$1
+        local message=$2
+        local plain_marker=${3:-}
+        local plain_message=${5:-$message}
+
+        if [[ -z "$plain_marker" ]]; then
+            case "$marker" in
+                "↻") plain_marker="[sync]" ;;
+                "⊕") plain_marker="[merge]" ;;
+                "✕") plain_marker="[stale]" ;;
+                "+") plain_marker="[init]" ;;
+                "-") plain_marker="[off]" ;;
+                "!") plain_marker="[warn]" ;;
+                *) plain_marker="[info]" ;;
+            esac
+        fi
+
+        echo "$plain_marker $plain_message" >&2
+    }
+}
+
+if [[ -r "$OUTPUT_LIB" ]] && source "$OUTPUT_LIB"; then
+    :
+else
+    _djinn_define_plain_ui_fallbacks
+    ui_warn "output library not found at $OUTPUT_LIB; using plain startup output."
+fi
+
 # -----------------------------------------------------------------------------
 # Whitelisted domains
 # -----------------------------------------------------------------------------
@@ -66,8 +102,8 @@ resolve_domain() {
 # -----------------------------------------------------------------------------
 # Apply firewall rules
 # -----------------------------------------------------------------------------
-echo ""
-echo "🔒 Initializing firewall..."
+echo "" >&2
+ui_info "Initializing firewall..."
 
 # Flush existing rules
 iptables -F OUTPUT 2>/dev/null || true
@@ -85,37 +121,37 @@ iptables -A OUTPUT -p tcp --dport 53 -j ACCEPT
 # -----------------------------------------------------------------------------
 # Allow Docker internal networks (for MCP Gateway + Docker Proxy)
 # -----------------------------------------------------------------------------
-echo ""
-echo "📡 Allowing Docker internal networks..."
+echo "" >&2
+ui_info "Allowing Docker internal networks..."
 for network in "${DOCKER_NETWORKS[@]}"; do
     iptables -A OUTPUT -d "$network" -j ACCEPT
-    echo "  ✓ Allowed network: $network"
+    ui_ok "Allowed network: $network"
 done
 
 # -----------------------------------------------------------------------------
 # Allow whitelisted domains
 # -----------------------------------------------------------------------------
-echo ""
-echo "🌐 Allowing whitelisted domains..."
+echo "" >&2
+ui_info "Allowing whitelisted domains..."
 for domain in "${ALLOWED_DOMAINS[@]}"; do
     ip=$(resolve_domain "$domain")
     if [ -n "$ip" ]; then
         iptables -A OUTPUT -d "$ip" -j ACCEPT
-        echo "  ✓ Allowed: $domain ($ip)"
+        ui_ok "Allowed: $domain ($ip)"
     else
-        echo "  ⚠ Could not resolve: $domain"
+        ui_warn "Could not resolve: $domain"
     fi
 done
 
 # Default deny
 iptables -A OUTPUT -j DROP
 
-echo ""
-echo "🔒 Firewall initialized. Outbound traffic restricted to whitelist."
-echo ""
-echo "Allowed:"
-echo "  - Docker internal networks (MCP Gateway, Docker Proxy, etc.)"
-echo "  - Whitelisted domains (package registries, AI APIs, etc.)"
-echo ""
-echo "To add domains at runtime:"
-echo "  iptables -I OUTPUT -d \$(getent hosts example.com | awk '{print \$1}') -j ACCEPT"
+echo "" >&2
+ui_ok "Firewall initialized. Outbound traffic restricted to whitelist."
+echo "" >&2
+ui_info "Allowed:"
+ui_info "Docker internal networks (MCP Gateway, Docker Proxy, etc.)"
+ui_info "Whitelisted domains (package registries, AI APIs, etc.)"
+echo "" >&2
+ui_info "To add domains at runtime:"
+ui_info "iptables -I OUTPUT -d \$(getent hosts example.com | awk '{print \$1}') -j ACCEPT"

--- a/scripts/mcp-register.sh
+++ b/scripts/mcp-register.sh
@@ -4,6 +4,86 @@
 # mcp-servers.json registry. This file is sourceable so the entrypoint logic can
 # be tested without running the whole container startup sequence.
 
+if ! whence -w ui_section >/dev/null 2>&1; then
+    _djinn_define_plain_ui_fallbacks() {
+        ui_section() { echo "[info] $1" >&2; }
+        ui_ok() { echo "[ok] $1" >&2; }
+        ui_warn() { echo "[warn] $1" >&2; }
+        ui_err() { echo "[err] $1" >&2; }
+        ui_info() { echo "[info] $1" >&2; }
+        ui_boxed() {
+            local title=$1
+            local line
+            local opened=0
+
+            while IFS= read -r line || [[ -n "$line" ]]; do
+                if (( opened == 0 )); then
+                    echo "  +- $title --------------------------" >&2
+                    opened=1
+                fi
+                echo "  | $line" >&2
+            done
+
+            if (( opened != 0 )); then
+                echo "  +-----------------------------------" >&2
+            fi
+        }
+        ui_item() {
+            local marker=$1
+            local message=$2
+            local plain_marker=${3:-}
+            local plain_message=${5:-$message}
+
+            if [[ -z "$plain_marker" ]]; then
+                case "$marker" in
+                    "↻") plain_marker="[sync]" ;;
+                    "⊕") plain_marker="[merge]" ;;
+                    "✕") plain_marker="[stale]" ;;
+                    "+") plain_marker="[init]" ;;
+                    "-") plain_marker="[off]" ;;
+                    "!") plain_marker="[warn]" ;;
+                    *) plain_marker="[info]" ;;
+                esac
+            fi
+
+            echo "$plain_marker $plain_message" >&2
+        }
+    }
+
+    _OUTPUT_LIB_DEFAULT="${${(%):-%x}:A:h}/output-lib.sh"
+    OUTPUT_LIB="${OUTPUT_LIB:-$_OUTPUT_LIB_DEFAULT}"
+    if [[ -r "$OUTPUT_LIB" ]] && source "$OUTPUT_LIB"; then
+        :
+    else
+        _djinn_define_plain_ui_fallbacks
+        ui_warn "output library not found at $OUTPUT_LIB; using plain startup output."
+    fi
+fi
+
+_mcp_run_boxed() {
+    local title=$1
+    shift
+
+    local had_errexit=0
+    case "$-" in
+        *e*) had_errexit=1; set +e ;;
+    esac
+
+    local output
+    output="$("$@" 2>&1)"
+    local cmd_status=$?
+
+    if (( had_errexit != 0 )); then
+        set -e
+    fi
+
+    if [[ -n "$output" ]]; then
+        printf '%s\n' "$output" | ui_boxed "$title"
+    fi
+
+    return "$cmd_status"
+}
+
 _codex_config_file() {
     echo "${CODEX_CONFIG:-$HOME/.codex/config.toml}"
 }
@@ -86,7 +166,7 @@ _codex_register_server() {
 
     if [[ "$transport" != "streamable-http" ]]; then
         _codex_remove_server_from_toml "$server"
-        echo "    ! ${server}: Codex does not support ${transport}, skipped"
+        ui_warn "${server}: Codex does not support ${transport}, skipped"
         return 0
     fi
 
@@ -97,7 +177,7 @@ _codex_disable_server() {
     local server=$1
 
     if command -v codex &>/dev/null; then
-        codex mcp remove "$server" 2>/dev/null || true
+        _mcp_run_boxed "codex mcp" codex mcp remove "$server" || true
     fi
     _codex_remove_server_from_toml "$server"
 }
@@ -107,24 +187,24 @@ register_mcp_servers() {
     MCP_REACHABLE=false
 
     if [[ ! -f "$mcp_config" ]] || ! command -v jq &>/dev/null; then
-        echo "  [mcp] No mcp-servers.json found, skipping global MCP registration"
+        ui_info "[mcp] No mcp-servers.json found, skipping global MCP registration"
         return 0
     fi
 
     local mcp_config_name=$(basename "$mcp_config")
     if ! jq -e 'type == "object"' "$mcp_config" >/dev/null 2>&1; then
-        echo "  [mcp] Error: $mcp_config_name must contain a top-level JSON object"
+        ui_err "[mcp] Error: $mcp_config_name must contain a top-level JSON object"
         return 0
     fi
 
     local server_count
     server_count=$(jq 'length' "$mcp_config")
     if [[ "$server_count" == "0" ]]; then
-        echo "  [mcp] No servers configured in $mcp_config_name"
+        ui_info "[mcp] No servers configured in $mcp_config_name"
         return 0
     fi
 
-    echo "  [mcp] Registering servers from $mcp_config_name..."
+    ui_info "[mcp] Registering servers from $mcp_config_name..."
 
     local gemini_config=~/.gemini/settings.json
     local opencode_config=~/.config/opencode/.opencode.json
@@ -143,7 +223,7 @@ register_mcp_servers() {
         server=$(jq -r '.key' <<< "$entry")
 
         if [[ ! "$server" =~ ^[a-zA-Z0-9_-]+$ ]]; then
-            echo "    ! mcp: Skipping invalid server name: $server"
+            ui_warn "mcp: Skipping invalid server name: $server"
             (( ++skipped ))
             continue
         fi
@@ -160,46 +240,46 @@ register_mcp_servers() {
         startup_timeout_sec=$(jq -r '.value.startup_timeout_sec // ""' <<< "$entry")
 
         if [[ "$(jq -r '(.value | has("type")) and (.value | has("transport") | not)' <<< "$entry")" == "true" ]]; then
-            echo "    ⚠ ${server}: legacy 'type' key detected; migrate local mcp-servers.json to 'transport' + 'enabled'"
+            ui_warn "${server}: legacy 'type' key detected; migrate local mcp-servers.json to 'transport' + 'enabled'"
             (( ++legacy ))
         fi
 
         if [[ "$enabled" != "true" && "$enabled" != "false" ]]; then
-            echo "    ! mcp: Skipping invalid enabled value for $server: $enabled"
+            ui_warn "mcp: Skipping invalid enabled value for $server: $enabled"
             (( ++skipped ))
             continue
         fi
         if [[ ! "$transport" =~ ^(streamable-http|sse)$ ]]; then
-            echo "    ! mcp: Skipping invalid transport for $server: $transport"
+            ui_warn "mcp: Skipping invalid transport for $server: $transport"
             (( ++skipped ))
             continue
         fi
         if [[ ! "$url" =~ ^https?://[a-zA-Z0-9./_:@-]+$ ]]; then
-            echo "    ! mcp: Skipping invalid URL for $server: $url"
+            ui_warn "mcp: Skipping invalid URL for $server: $url"
             (( ++skipped ))
             continue
         fi
         if [[ -n "$tool_timeout_sec" && ! "$tool_timeout_sec" =~ ^[0-9]+$ ]]; then
-            echo "    ! mcp: Skipping invalid tool_timeout_sec for $server: $tool_timeout_sec"
+            ui_warn "mcp: Skipping invalid tool_timeout_sec for $server: $tool_timeout_sec"
             (( ++skipped ))
             continue
         fi
         if [[ -n "$startup_timeout_sec" && ! "$startup_timeout_sec" =~ ^[0-9]+$ ]]; then
-            echo "    ! mcp: Skipping invalid startup_timeout_sec for $server: $startup_timeout_sec"
+            ui_warn "mcp: Skipping invalid startup_timeout_sec for $server: $startup_timeout_sec"
             (( ++skipped ))
             continue
         fi
 
         if [[ "$enabled" == "false" ]]; then
             if command -v claude &>/dev/null; then
-                claude mcp remove --scope user "$server" 2>/dev/null || true
+                _mcp_run_boxed "claude mcp" claude mcp remove --scope user "$server" || true
             fi
             _codex_disable_server "$server"
             jq --arg name "$server" 'del(.mcpServers[$name])' \
                 "$gemini_config" > "$gemini_config.tmp" && mv "$gemini_config.tmp" "$gemini_config"
             jq --arg name "$server" 'del(.mcpServers[$name])' \
                 "$opencode_config" > "$opencode_config.tmp" && mv "$opencode_config.tmp" "$opencode_config"
-            echo "    - ${server} (disabled)"
+            ui_item "-" "${server} (disabled)"
             (( ++disabled ))
             continue
         fi
@@ -210,14 +290,14 @@ register_mcp_servers() {
         if curl -s --connect-timeout 2 "$url" >/dev/null 2>&1; then
             [[ "$server" == "docker-gateway" ]] && MCP_REACHABLE=true
         else
-            echo "    ⚠ ${server}: not reachable (${host})"
+            ui_warn "${server}: not reachable (${host})"
         fi
 
         if command -v claude &>/dev/null; then
             claude_transport="$transport"
             [[ "$transport" == "streamable-http" ]] && claude_transport="http"
-            claude mcp remove --scope user "$server" 2>/dev/null || true
-            claude mcp add --transport "$claude_transport" --scope user "$server" "$url" 2>/dev/null || true
+            _mcp_run_boxed "claude mcp" claude mcp remove --scope user "$server" || true
+            _mcp_run_boxed "claude mcp" claude mcp add --transport "$claude_transport" --scope user "$server" "$url" || true
         fi
 
         jq --arg name "$server" --arg url "$url" \
@@ -232,9 +312,9 @@ register_mcp_servers() {
 
         _codex_register_server "$server" "$url" "$transport" "$tool_timeout_sec" "$startup_timeout_sec"
 
-        echo "    ✓ ${server} (${transport})"
+        ui_ok "${server} (${transport})"
         (( ++registered ))
     done < <(jq -c 'to_entries[]' "$mcp_config")
 
-    echo "  [mcp] Summary: ${registered} registered, ${disabled} disabled, ${skipped} skipped, ${legacy} legacy"
+    ui_info "[mcp] Summary: ${registered} registered, ${disabled} disabled, ${skipped} skipped, ${legacy} legacy"
 }

--- a/scripts/output-lib.sh
+++ b/scripts/output-lib.sh
@@ -1,0 +1,243 @@
+#!/bin/zsh
+
+# Sourceable shell UI helpers for container startup output.
+#
+# Color tiers:
+# - COLORTERM=truecolor/24bit emits exact RGB escapes for the Python palette.
+# - Other color terminals use ANSI-256 approximations chosen as nearest distinct
+#   xterm indices.
+# - info deliberately stays terminal-adaptive ANSI blue in both tiers.
+#
+# role      truecolor RGB     ANSI-256 fallback
+# primary   #69B9A1          73  (#5fafaf)
+# secondary #226666          23  (#005f5f)
+# success   #C1FF62          155 (#afff5f)
+# error     #F53263          203 (#ff5f5f)
+# warning   #FAF870          227 (#ffff5f)
+# info      ANSI blue        4   (terminal-adaptive basic color)
+# path      #8608B8          91  (#8700af)
+# muted     #333676          60  (#5f5f87, nearest dark indigo)
+# border    #29526D          24  (#005f87; next distinct after secondary collision)
+#
+# DJINN_FORCE_UI_COLOR=1 is a test hook for non-tty subprocess tests. Per
+# no-color.org, NO_COLOR disables color only when present with a non-empty value.
+#
+# Sourced by BOTH zsh (container entrypoint) and bash (host-side scripts like
+# update-agents.sh) — keep every construct valid in both shells.
+
+# Idempotent-source guard: the readonly constants below would error on re-source.
+if [[ -n "${_DJINN_OUTPUT_LIB_LOADED:-}" ]]; then
+    return 0
+fi
+_DJINN_OUTPUT_LIB_LOADED=1
+
+readonly UI_COLOR_PRIMARY=73
+readonly UI_COLOR_SECONDARY=23
+readonly UI_COLOR_SUCCESS=155
+readonly UI_COLOR_ERROR=203
+readonly UI_COLOR_WARNING=227
+readonly UI_COLOR_INFO=4
+readonly UI_COLOR_PATH=91
+readonly UI_COLOR_MUTED=60
+readonly UI_COLOR_BORDER=24
+
+_djinn_ui_color_enabled() {
+    [[ -z "${NO_COLOR:-}" ]] && { [[ -t 2 ]] || [[ "${DJINN_FORCE_UI_COLOR:-}" == "1" ]]; }
+}
+
+_djinn_ui_truecolor_enabled() {
+    [[ "${COLORTERM:-}" == "truecolor" || "${COLORTERM:-}" == "24bit" ]]
+}
+
+_djinn_ui_color() {
+    local color=$1
+    if _djinn_ui_truecolor_enabled; then
+        case "$color" in
+            "$UI_COLOR_PRIMARY") printf '\033[38;2;105;185;161m'; return ;;
+            "$UI_COLOR_SECONDARY") printf '\033[38;2;34;102;102m'; return ;;
+            "$UI_COLOR_SUCCESS") printf '\033[38;2;193;255;98m'; return ;;
+            "$UI_COLOR_ERROR") printf '\033[38;2;245;50;99m'; return ;;
+            "$UI_COLOR_WARNING") printf '\033[38;2;250;248;112m'; return ;;
+            "$UI_COLOR_PATH") printf '\033[38;2;134;8;184m'; return ;;
+            "$UI_COLOR_MUTED") printf '\033[38;2;51;54;118m'; return ;;
+            "$UI_COLOR_BORDER") printf '\033[38;2;41;82;109m'; return ;;
+        esac
+    fi
+
+    if (( color >= 0 && color <= 7 )); then
+        printf '\033[0;3%sm' "$color"
+    else
+        printf '\033[38;5;%sm' "$color"
+    fi
+}
+
+_djinn_ui_terminal_width() {
+    local width="${DJINN_TERM_WIDTH:-}"
+
+    if [[ -z "$width" ]] || ! [[ "$width" =~ ^[0-9]+$ ]] || (( width <= 0 )); then
+        width="${COLUMNS:-}"
+    fi
+
+    if [[ -z "$width" ]] || ! [[ "$width" =~ ^[0-9]+$ ]] || (( width <= 0 )); then
+        width="$(tput cols 2>/dev/null || true)"
+    fi
+
+    if [[ -z "$width" ]] || ! [[ "$width" =~ ^[0-9]+$ ]] || (( width <= 0 )); then
+        width="$(stty size 2>/dev/null | awk '{print $2}' || true)"
+    fi
+
+    if [[ -z "$width" ]] || ! [[ "$width" =~ ^[0-9]+$ ]] || (( width <= 0 )); then
+        width=80
+    fi
+
+    echo "$width"
+}
+
+_djinn_ui_emit() {
+    local marker=$1
+    local plain_marker=$2
+    local color=$3
+    local message=$4
+    local plain_message=${5:-$message}
+
+    if _djinn_ui_color_enabled; then
+        printf '  %s%s\033[0m %s\n' "$(_djinn_ui_color "$color")" "$marker" "$message" >&2
+    else
+        printf '  %s %s\n' "$plain_marker" "$plain_message" >&2
+    fi
+}
+
+_djinn_ui_plain_item_marker() {
+    local marker=$1
+
+    case "$marker" in
+        "↻") echo "[sync]" ;;
+        "⊕") echo "[merge]" ;;
+        "✕") echo "[stale]" ;;
+        "+") echo "[init]" ;;
+        "-") echo "[off]" ;;
+        "!") echo "[warn]" ;;
+        *) echo "[info]" ;;
+    esac
+}
+
+ui_section() {
+    local title=$1
+    local width
+    width="$(_djinn_ui_terminal_width)"
+    local prefix="─ "
+    local suffix_len=$(( width - ${#title} - 3 ))
+    (( suffix_len < 0 )) && suffix_len=0
+    local suffix=""
+    local plain_suffix=""
+    local i
+    for (( i = 0; i < suffix_len; i++ )); do
+        suffix="${suffix}─"
+        plain_suffix="${plain_suffix}-"
+    done
+
+    printf '\n' >&2
+    if _djinn_ui_color_enabled; then
+        printf '%s%s%s%s\033[0m %s\033[0m\n' \
+            "$(_djinn_ui_color "$UI_COLOR_BORDER")" \
+            "$prefix" \
+            "$(_djinn_ui_color "$UI_COLOR_PRIMARY")" \
+            "$title" \
+            "$(_djinn_ui_color "$UI_COLOR_BORDER")$suffix" >&2
+    else
+        printf -- '- %s %s\n' "$title" "$plain_suffix" >&2
+    fi
+}
+
+ui_ok() {
+    local message=$1
+    _djinn_ui_emit "✓" "[ok]" "$UI_COLOR_SUCCESS" "$message"
+}
+
+ui_warn() {
+    local message=$1
+    _djinn_ui_emit "⚠" "[warn]" "$UI_COLOR_WARNING" "$message"
+}
+
+ui_err() {
+    local message=$1
+    _djinn_ui_emit "✗" "[err]" "$UI_COLOR_ERROR" "$message"
+}
+
+ui_info() {
+    local message=$1
+    _djinn_ui_emit "ℹ" "[info]" "$UI_COLOR_INFO" "$message"
+}
+
+ui_boxed() {
+    local title=$1
+    local width
+    width="$(_djinn_ui_terminal_width)"
+    local frame_width=$(( width - 2 ))
+    (( frame_width > 40 )) && frame_width=40
+    (( frame_width < 1 )) && frame_width=1
+
+    local color=""
+    local reset=""
+    local head_open
+    local foot_prefix
+    local rule_char
+    local body_prefix
+
+    if _djinn_ui_color_enabled; then
+        color="$(_djinn_ui_color "$UI_COLOR_MUTED")"
+        reset=$'\033[0m'
+        head_open="╭─"
+        foot_prefix="╰"
+        rule_char="─"
+        body_prefix="│"
+    else
+        head_open="+-"
+        foot_prefix="+"
+        rule_char="-"
+        body_prefix="|"
+    fi
+
+    # Head is deliberately one rule char LONGER than the foot (user-approved
+    # look). Visible head = open(2) + " title " + fill; frame chars are muted,
+    # the title and body text keep the terminal default color.
+    local head_fill_len=$(( frame_width - ${#title} - 4 + 2 ))
+    (( head_fill_len < 0 )) && head_fill_len=0
+    local foot_fill_len=$(( frame_width - ${#foot_prefix} ))
+    (( foot_fill_len < 0 )) && foot_fill_len=0
+    local head_fill=""
+    local foot_fill=""
+    local i
+    for (( i = 0; i < head_fill_len; i++ )); do
+        head_fill="${head_fill}${rule_char}"
+    done
+    for (( i = 0; i < foot_fill_len; i++ )); do
+        foot_fill="${foot_fill}${rule_char}"
+    done
+
+    local line
+    local opened=0
+    while IFS= read -r line || [[ -n "$line" ]]; do
+        if (( opened == 0 )); then
+            printf '  %s%s%s %s %s%s%s\n' \
+                "$color" "$head_open" "$reset" "$title" "$color" "$head_fill" "$reset" >&2
+            opened=1
+        fi
+        printf '  %s%s%s %s\n' "$color" "$body_prefix" "$reset" "$line" >&2
+    done
+
+    if (( opened != 0 )); then
+        printf '  %s%s%s%s\n' "$color" "$foot_prefix" "$foot_fill" "$reset" >&2
+    fi
+}
+
+ui_item() {
+    local marker=$1
+    local message=$2
+    local plain_marker=${3:-}
+    local color=${4:-$UI_COLOR_INFO}
+    local plain_message=${5:-$message}
+
+    [[ -n "$plain_marker" ]] || plain_marker=$(_djinn_ui_plain_item_marker "$marker")
+    _djinn_ui_emit "$marker" "$plain_marker" "$color" "$message" "$plain_message"
+}

--- a/scripts/seed-lib.sh
+++ b/scripts/seed-lib.sh
@@ -1,5 +1,33 @@
 #!/bin/zsh
 
+if ! whence -w ui_info >/dev/null 2>&1; then
+    ui_section() { echo "[info] $1" >&2; }
+    ui_ok() { echo "[ok] $1" >&2; }
+    ui_warn() { echo "[warn] $1" >&2; }
+    ui_err() { echo "[err] $1" >&2; }
+    ui_info() { echo "[info] $1" >&2; }
+    ui_item() {
+        local marker=$1
+        local message=$2
+        local plain_marker=${3:-}
+        local plain_message=${5:-$message}
+
+        if [[ -z "$plain_marker" ]]; then
+            case "$marker" in
+                "↻") plain_marker="[sync]" ;;
+                "⊕") plain_marker="[merge]" ;;
+                "✕") plain_marker="[stale]" ;;
+                "+") plain_marker="[init]" ;;
+                "-") plain_marker="[off]" ;;
+                "!") plain_marker="[warn]" ;;
+                *) plain_marker="[info]" ;;
+            esac
+        fi
+
+        echo "$plain_marker $plain_message" >&2
+    }
+fi
+
 # -----------------------------------------------------------------------------
 # merge_settings: Deep-merge two JSON settings files with selective replacement.
 # Most keys are recursively merged (overlay wins on conflicts). Plugin-related
@@ -42,13 +70,13 @@ sync_seed() {
         return
     fi
 
-    echo "  [seed-sync] ${label}:"
+    ui_info "[seed-sync] ${label}:"
     : > "$tmp_manifest"
 
     # Phase 1: Clean-replace subdirectories (seed = source of truth)
     for dir in "$seed_dir"/*(N/); do
         local dirname=${dir:t}
-        echo "    ↻ ${dirname}/"
+        ui_item "↻" "${dirname}/"
         rm -rf "${target_dir}/${dirname}"
         cp -r "$dir" "${target_dir}/${dirname}"
         # No `|| true`: a swallowed manifest-append failure would poison Phase 3
@@ -60,7 +88,7 @@ sync_seed() {
     for file in "$seed_dir"/*(N.); do
         local filename=${file:t}
         [[ "$filename" == "settings.json" ]] && continue
-        echo "    ↻ ${filename}"
+        ui_item "↻" "${filename}"
         cp "$file" "${target_dir}/${filename}"
         echo "$filename" >> "$tmp_manifest"
     done
@@ -71,7 +99,7 @@ sync_seed() {
             [[ -z "$entry" ]] && continue
             if ! grep -qxF "$entry" "$tmp_manifest"; then
                 if [[ -e "${target_dir}/${entry}" ]]; then
-                    echo "    ✕ ${entry} (stale)"
+                    ui_item "✕" "${entry} (stale)"
                     rm -f "${target_dir}/${entry}"
                 fi
             fi
@@ -86,7 +114,7 @@ sync_seed() {
     # Phase 5: Deep-merge settings.json (seed wins; plugin keys fully replaced)
     if [[ -n "$config_file" ]] && [[ -f "$seed_dir/settings.json" ]]; then
         if [[ -f "$config_file" ]]; then
-            echo "    ⊕ settings.json (merged)"
+            ui_item "⊕" "settings.json (merged)"
             if merge_settings "$config_file" "$seed_dir/settings.json" "${config_file}.tmp"; then
                 mv "${config_file}.tmp" "$config_file"
             else
@@ -95,10 +123,10 @@ sync_seed() {
                 jq -e . "$config_file" >/dev/null 2>&1 || bad="$config_file"
                 jq -e . "$seed_dir/settings.json" >/dev/null 2>&1 \
                     || bad="${bad:+${bad}, }${seed_dir}/settings.json"
-                echo "    ✗ settings merge failed — ${bad:-unknown input} is not valid JSON; keeping existing settings." >&2
+                ui_err "settings merge failed — ${bad:-unknown input} is not valid JSON; keeping existing settings."
             fi
         else
-            echo "    + settings.json (init)"
+            ui_item "+" "settings.json (init)"
             cp "$seed_dir/settings.json" "$config_file"
         fi
     fi
@@ -120,13 +148,13 @@ claude_settings_merge() {
         local missing=""
         [[ -f "$seed_dir/CLAUDE.md" ]] || missing="CLAUDE.md"
         [[ -f "$seed_dir/settings.json" ]] || missing="${missing:+${missing}, }settings.json"
-        echo "  [workflow] ✗ config/claude seed incomplete (missing: ${missing}) — skipping settings merge." >&2
-        echo "             Run \`djinn init\` on the host (or restart via \`djinn start\`, which reseeds automatically)." >&2
+        ui_err "[workflow] config/claude seed incomplete (missing: ${missing}) — skipping settings merge."
+        ui_info "Run \`djinn init\` on the host (or restart via \`djinn start\`, which reseeds automatically)."
     else
         local base="$seed_dir/settings.json" out="$target_settings_file"
         if [[ -f "$seed_dir/settings.local.json" ]]; then
             if merge_settings "$base" "$seed_dir/settings.local.json" "$out.tmp"; then
-                mv "$out.tmp" "$out" && echo "    ⊕ settings.json (baseline ⊕ local)"
+                mv "$out.tmp" "$out" && ui_item "⊕" "settings.json (baseline ⊕ local)" "" "" "settings.json (baseline + local)"
             else
                 rm -f "$out.tmp"
                 # jq parses BOTH inputs — pinpoint the actual offender instead of
@@ -136,20 +164,20 @@ claude_settings_merge() {
                 jq -e . "$base" >/dev/null 2>&1 || bad="$base"
                 jq -e . "$seed_dir/settings.local.json" >/dev/null 2>&1 \
                     || bad="${bad:+${bad}, }${seed_dir}/settings.local.json"
-                echo "  [workflow] ✗ settings merge failed — ${bad:-unknown input} is not valid JSON." >&2
-                echo "             Fix it on the host under config/claude/. Keeping existing settings." >&2
+                ui_err "[workflow] settings merge failed — ${bad:-unknown input} is not valid JSON."
+                ui_info "Fix it on the host under config/claude/. Keeping existing settings."
                 # A fresh volume must still get a permissions baseline — but never
                 # a malformed one.
                 if [[ ! -f "$out" ]]; then
                     if jq -e . "$base" >/dev/null 2>&1; then
                         cp "$base" "$out"
                     else
-                        echo "  [workflow] ⚠ baseline itself is invalid — no settings.json initialised." >&2
+                        ui_warn "[workflow] baseline itself is invalid — no settings.json initialised."
                     fi
                 fi
             fi
         else
-            echo "  [workflow] ⚠ no settings.local.json — keeping existing settings; baseline only if none yet" >&2
+            ui_warn "[workflow] no settings.local.json — keeping existing settings; baseline only if none yet"
             # NEVER clobber an existing volume settings.json with the bare baseline: a missing personal
             # overlay (e.g. a fresh git pull — settings.local.json is git-ignored) must not wipe the
             # user's prefs/marketplace. Only initialise from the baseline when no settings.json exists yet.
@@ -168,12 +196,12 @@ reverse_sync_file() {
     [[ -f "$volume_file" && -d "$seed_dir_path" ]] && {
         if [[ ! -w "$seed_dir_path" ]]; then
             # Same user outcome as a failed cp — same signal (not a silent skip).
-            echo "  ⚠ could not persist ${volume_file} → ${seed_file} (target directory not writable)" >&2
+            ui_warn "could not persist ${volume_file} → ${seed_file} (target directory not writable)"
         elif ! diff -q "$volume_file" "$seed_file" &>/dev/null; then
             # Best-effort with warning: a single failed persist must not abort the
             # session-end sync chain or clobber the shell's exit code (set -e).
             cp "$volume_file" "$seed_file" \
-                || echo "  ⚠ could not persist ${volume_file} → ${seed_file}" >&2
+                || ui_warn "could not persist ${volume_file} → ${seed_file}"
         fi
     }
     return 0

--- a/scripts/update-agents.sh
+++ b/scripts/update-agents.sh
@@ -10,13 +10,44 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 DOCKERFILE="$SCRIPT_DIR/../Dockerfile"
+OUTPUT_LIB="${OUTPUT_LIB:-$SCRIPT_DIR/output-lib.sh}"
 
-# Colors
-RED='\033[0;31m'
-GREEN='\033[0;32m'
-YELLOW='\033[1;33m'
-BLUE='\033[0;34m'
-NC='\033[0m' # No Color
+if [[ -r "$OUTPUT_LIB" ]] && source "$OUTPUT_LIB"; then
+    :
+else
+    UI_COLOR_SUCCESS=155
+    UI_COLOR_ERROR=203
+    UI_COLOR_WARNING=227
+    UI_COLOR_INFO=4
+    _djinn_ui_color_enabled() { return 1; }
+    _djinn_ui_color() {
+        local color=$1
+        if (( color >= 0 && color <= 7 )); then
+            printf '\033[0;3%sm' "$color"
+        else
+            printf '\033[38;5;%sm' "$color"
+        fi
+    }
+fi
+
+color_start() {
+    local color=$1
+    if _djinn_ui_color_enabled; then
+        _djinn_ui_color "$color"
+    fi
+}
+
+color_reset() {
+    if _djinn_ui_color_enabled; then
+        printf '\033[0m'
+    fi
+}
+
+color_text() {
+    local color=$1
+    local text=$2
+    printf '%b%s%b' "$(color_start "$color")" "$text" "$(color_reset)"
+}
 
 # Packages to update (ARG name -> npm package for version lookup)
 # Note: Claude Code uses the native installer (not npm), but npm registry
@@ -28,7 +59,9 @@ declare -A PACKAGES=(
     ["OPENCODE_VERSION"]="opencode-ai"
 )
 
-echo -e "${BLUE}Fetching latest CLI agent versions...${NC}"
+printf '%bFetching latest CLI agent versions...%b\n' \
+    "$(color_start "$UI_COLOR_INFO")" \
+    "$(color_reset)"
 echo ""
 
 # Track if any updates were made
@@ -44,20 +77,26 @@ for arg_name in "${!PACKAGES[@]}"; do
     latest=$(npm view "$package" version 2>/dev/null || echo "error")
 
     if [[ "$latest" == "error" ]]; then
-        echo -e "  ${RED}$package: Failed to fetch version${NC}"
+        printf '  %b\n' "$(color_text "$UI_COLOR_ERROR" "$package: Failed to fetch version")"
         continue
     fi
 
     # Validate semver format to prevent sed injection
     if ! [[ "$latest" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-        echo -e "  ${RED}$package: Invalid version format '${latest}', skipping${NC}"
+        printf '  %b\n' \
+            "$(color_text "$UI_COLOR_ERROR" "$package: Invalid version format '${latest}', skipping")"
         continue
     fi
 
     if [[ "$current" == "$latest" ]]; then
-        echo -e "  ${GREEN}$package${NC}: $current (up to date)"
+        printf '  %b: %s (up to date)\n' \
+            "$(color_text "$UI_COLOR_SUCCESS" "$package")" \
+            "$current"
     else
-        echo -e "  ${YELLOW}$package${NC}: $current -> ${GREEN}$latest${NC}"
+        printf '  %b: %s -> %b\n' \
+            "$(color_text "$UI_COLOR_WARNING" "$package")" \
+            "$current" \
+            "$(color_text "$UI_COLOR_SUCCESS" "$latest")"
 
         # Update Dockerfile
         sed -i "s/ARG ${arg_name}=.*/ARG ${arg_name}=${latest}/" "$DOCKERFILE"
@@ -68,14 +107,22 @@ done
 echo ""
 
 if [[ "$updates_made" == "true" ]]; then
-    echo -e "${GREEN}Dockerfile updated!${NC}"
+    printf '%bDockerfile updated!%b\n' \
+        "$(color_start "$UI_COLOR_SUCCESS")" \
+        "$(color_reset)"
     echo ""
     echo "Changes:"
     git diff --no-color "$DOCKERFILE" | head -30
     echo ""
-    echo -e "Next steps:"
-    echo -e "  1. ${BLUE}djinn build${NC}   # Rebuild image with new versions"
-    echo -e "  2. ${BLUE}djinn start${NC}   # Start container"
+    echo "Next steps:"
+    printf '  1. %bdjinn build%b   # Rebuild image with new versions\n' \
+        "$(color_start "$UI_COLOR_INFO")" \
+        "$(color_reset)"
+    printf '  2. %bdjinn start%b   # Start container\n' \
+        "$(color_start "$UI_COLOR_INFO")" \
+        "$(color_reset)"
 else
-    echo -e "${GREEN}All CLI agents are already up to date.${NC}"
+    printf '%bAll CLI agents are already up to date.%b\n' \
+        "$(color_start "$UI_COLOR_SUCCESS")" \
+        "$(color_reset)"
 fi

--- a/src/djinn_in_a_box/cli/__init__.py
+++ b/src/djinn_in_a_box/cli/__init__.py
@@ -5,6 +5,7 @@ from collections.abc import Callable
 import typer
 
 from djinn_in_a_box import __version__
+from djinn_in_a_box.core.console import console
 
 
 def version_callback(name: str) -> Callable[[bool], None]:
@@ -12,7 +13,10 @@ def version_callback(name: str) -> Callable[[bool], None]:
 
     def callback(value: bool) -> None:
         if value:
-            typer.echo(f"{name} {__version__}")
+            console.print(
+                f"[primary.bold]{name}[/primary.bold] "
+                f"[secondary]{__version__}[/secondary]"
+            )
             raise typer.Exit()
 
     return callback

--- a/src/djinn_in_a_box/cli/mcpgateway.py
+++ b/src/djinn_in_a_box/cli/mcpgateway.py
@@ -35,7 +35,7 @@ def main(
     The MCP Gateway provides Model Context Protocol servers to AI coding
     agents running in the development container.
 
-    [bold]Quick start:[/bold]
+    [header]Quick start:[/header]
 
         mcpgateway start          # Start the gateway
 

--- a/src/djinn_in_a_box/commands/agent.py
+++ b/src/djinn_in_a_box/commands/agent.py
@@ -8,9 +8,10 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Annotated
 
 import typer
+from rich.table import Table
 
 from djinn_in_a_box.config.loader import load_agents, load_config
-from djinn_in_a_box.core.console import console, err_console, error, info, status_line
+from djinn_in_a_box.core.console import console, err_console, error, info, rule, status_line
 from djinn_in_a_box.core.decorators import handle_config_errors
 from djinn_in_a_box.core.docker import (
     DJINN_NETWORK,
@@ -23,6 +24,15 @@ from djinn_in_a_box.core.docker import (
 
 if TYPE_CHECKING:
     from djinn_in_a_box.config.models import AgentConfig
+
+
+def _agent_table(title: str) -> Table:
+    return Table(
+        title=title,
+        title_style="table.title",
+        header_style="table.header",
+        border_style="border",
+    )
 
 
 def build_agent_command(
@@ -166,9 +176,9 @@ def run(
         status_line("Model", model)
 
     if write:
-        status_line("Mode", "Read/Write (--write)", "warning")
+        status_line("Mode", "Read/Write (--write)", "status.disabled")
     else:
-        status_line("Mode", "Read-only (plan/analysis)", "success")
+        status_line("Mode", "Read-only (plan/analysis)", "status.enabled")
 
     if docker:
         status_line("Docker", "Enabled (proxy)")
@@ -256,21 +266,29 @@ def agents(
 
     if verbose:
         for name, cfg in sorted(agent_configs.items()):
-            console.print(f"[primary.bold]{name}[/primary.bold]: {cfg.description or cfg.binary}")
-            console.print(f"  [muted]Binary:[/muted]      {cfg.binary}")
-            console.print(f"  [muted]Model flag:[/muted]  {cfg.model_flag}")
+            table = _agent_table(name)
+            table.add_column("Setting", style="table.category")
+            table.add_column("Value", style="table.value")
+            table.add_row("Description", cfg.description or cfg.binary)
+            table.add_row("Binary", cfg.binary)
+            table.add_row("Model flag", cfg.model_flag)
             if cfg.headless_flags:
-                console.print(f"  [muted]Headless:[/muted]    {' '.join(cfg.headless_flags)}")
+                table.add_row("Headless", " ".join(cfg.headless_flags))
             if cfg.write_flags:
-                console.print(f"  [muted]Write mode:[/muted]  {' '.join(cfg.write_flags)}")
+                table.add_row("Write mode", " ".join(cfg.write_flags))
             if cfg.read_only_flags:
-                console.print(f"  [muted]Read-only:[/muted]   {' '.join(cfg.read_only_flags)}")
+                table.add_row("Read-only", " ".join(cfg.read_only_flags))
             if cfg.json_flags:
-                console.print(f"  [muted]JSON flags:[/muted]  {' '.join(cfg.json_flags)}")
+                table.add_row("JSON flags", " ".join(cfg.json_flags))
+            console.print(table)
             console.print()
     else:
-        console.print("[header]Available Agents:[/header]")
+        rule("Available Agents")
         console.print()
+        table = _agent_table("Available Agents")
+        table.add_column("Agent", style="table.category")
+        table.add_column("Description", style="table.value")
         for name, cfg in sorted(agent_configs.items()):
             desc = cfg.description or cfg.binary
-            console.print(f"  [primary]{name}[/primary]: {desc}")
+            table.add_row(name, desc)
+        console.print(table)

--- a/src/djinn_in_a_box/commands/config.py
+++ b/src/djinn_in_a_box/commands/config.py
@@ -11,10 +11,12 @@ from typing import Annotated
 
 import typer
 from pydantic import ValidationError
+from rich.table import Table
+from rich.text import Text
 
 from djinn_in_a_box.config.loader import load_config, save_config
 from djinn_in_a_box.config.models import AppConfig, ResourceLimits, ShellConfig
-from djinn_in_a_box.core.console import console, error, info, success, warning
+from djinn_in_a_box.core.console import console, error, info, rule, success, warning
 from djinn_in_a_box.core.decorators import handle_config_errors
 from djinn_in_a_box.core.docker import ensure_host_env
 from djinn_in_a_box.core.exceptions import ConfigNotFoundError, ConfigValidationError
@@ -33,6 +35,23 @@ ALLOWED_CONFIG_KEYS: tuple[str, ...] = (
     "shell.skip_mounts",
     "shell.omp_theme_path",
 )
+
+
+def _print_config_table(
+    title: str,
+    rows: list[tuple[str, object]],
+    *,
+    path_labels: set[str] | None = None,
+) -> None:
+    rule(title)
+    path_labels = path_labels or set()
+    table = Table.grid(padding=(0, 2))
+    table.add_column("Setting", style="table.category", no_wrap=True)
+    table.add_column("Value", style="table.value", overflow="fold")
+    for label, value in rows:
+        rendered_value = Text(str(value), style="path") if label in path_labels else str(value)
+        table.add_row(label, rendered_value)
+    console.print(table)
 
 
 def init_config(
@@ -194,8 +213,7 @@ def init_config(
     if created:
         success(f"Seeded {len(created)} default config file(s)")
 
-    console.print()
-    console.print("[primary.bold]Next steps:[/primary.bold]")
+    rule("Next steps")
     console.print("  [muted]1.[/muted] djinn build    [muted]# Build the Docker image[/muted]")
     console.print("  [muted]2.[/muted] djinn auth     [muted]# Authenticate with AI[/muted]")
     console.print("  [muted]3.[/muted] djinn start    [muted]# Start development shell[/muted]")
@@ -420,26 +438,37 @@ def config_show(
         console.print(output, highlight=False)
     else:
         # Human-readable output
-        info("Current Configuration")
-        console.print(f"  [muted]Config file:[/muted] {CONFIG_FILE}")
+        rule("Current Configuration")
+        console.print(
+            Text.assemble("  ", ("Config file:", "muted"), " ", (str(CONFIG_FILE), "path"))
+        )
         console.print()
 
-        console.print("[primary.bold]General[/primary.bold]")
-        console.print(f"  code_dir:  {config.code_dir}")
-        console.print(f"  timezone:  {config.timezone}")
+        _print_config_table(
+            "General",
+            [
+                ("code_dir", config.code_dir),
+                ("timezone", config.timezone),
+            ],
+            path_labels={"code_dir"},
+        )
         console.print()
 
-        console.print("[primary.bold]Resources[/primary.bold]")
-        console.print(f"  cpu_limit:          {config.resources.cpu_limit}")
-        console.print(f"  memory_limit:       {config.resources.memory_limit}")
-        console.print(f"  cpu_reservation:    {config.resources.cpu_reservation}")
-        console.print(f"  memory_reservation: {config.resources.memory_reservation}")
+        _print_config_table(
+            "Resources",
+            [
+                ("cpu_limit", config.resources.cpu_limit),
+                ("memory_limit", config.resources.memory_limit),
+                ("cpu_reservation", config.resources.cpu_reservation),
+                ("memory_reservation", config.resources.memory_reservation),
+            ],
+        )
         console.print()
 
-        console.print("[primary.bold]Shell[/primary.bold]")
-        console.print(f"  skip_mounts: {config.shell.skip_mounts}")
+        shell_rows: list[tuple[str, object]] = [("skip_mounts", config.shell.skip_mounts)]
         if config.shell.omp_theme_path:
-            console.print(f"  omp_theme_path: {config.shell.omp_theme_path}")
+            shell_rows.append(("omp_theme_path", config.shell.omp_theme_path))
+        _print_config_table("Shell", shell_rows, path_labels={"omp_theme_path"})
 
 
 def config_path() -> None:

--- a/src/djinn_in_a_box/commands/container.py
+++ b/src/djinn_in_a_box/commands/container.py
@@ -15,13 +15,14 @@ from djinn_in_a_box.commands.doctor import preflight
 from djinn_in_a_box.config.defaults import SYNC_PATHS, VOLUME_CATEGORIES
 from djinn_in_a_box.config.loader import load_config
 from djinn_in_a_box.config.models import AppConfig
+from djinn_in_a_box.core.banner import banner
 from djinn_in_a_box.core.console import (
     blank,
     console,
     err_console,
     error,
-    header,
     info,
+    rule,
     status_line,
     success,
     warning,
@@ -98,6 +99,7 @@ def build(
     result = compose_build(config, no_cache=no_cache)
 
     if result.success:
+        blank()
         success("Done! Run 'djinn start' to begin.")
     else:
         error(f"Build failed with exit code {result.returncode}")
@@ -167,11 +169,10 @@ def start(
             raise typer.Exit(1) from None
 
     # Print status output (to stderr, matching Bash format)
-    blank()
-    info("Starting Djinn environment...")
-    blank()
+    banner()
+    rule("Environment")
 
-    status_line("Projects", str(config.code_dir))
+    status_line("Projects", str(config.code_dir), value_style="path")
 
     if docker:
         status_line("Docker", "Enabled (via secure proxy)", "status.enabled")
@@ -186,7 +187,7 @@ def start(
         status_line("Firewall", "Disabled (use --firewall to enable)", "status.disabled")
 
     if mount_path:
-        status_line("Workspace", str(mount_path), "status.enabled")
+        status_line("Workspace", str(mount_path), "status.enabled", value_style="path")
 
     # Shell mount status
     shell_args = get_shell_mount_args(config)
@@ -213,7 +214,7 @@ def start(
             "Use --docker (proxy) for safer operation."
         )
 
-    blank()
+    rule("Container")
 
     # Run container
     options = ContainerOptions(
@@ -307,6 +308,7 @@ def _print_resource_table(title: str, value_header: str, entries: dict[str, list
         title_style="table.title",
         show_header=True,
         header_style="table.header",
+        border_style="border",
     )
 
     table.add_column("Category", style="table.category", width=15)
@@ -321,6 +323,27 @@ def _print_resource_table(title: str, value_header: str, entries: dict[str, list
             table.add_row("", "")
 
     console.print(table)
+
+
+def _print_docker_table(title: str, columns: list[str], output: str) -> bool:
+    rows = [line.split("\t") for line in output.strip().splitlines() if line.strip()]
+    if not rows:
+        return False
+
+    table = Table(
+        title=title,
+        title_style="table.title",
+        show_header=True,
+        header_style="table.header",
+        border_style="border",
+    )
+    for index, column in enumerate(columns):
+        style = "table.category" if index == 0 else "table.value"
+        table.add_column(column, style=style)
+    for row in rows:
+        table.add_row(*row)
+    console.print(table)
+    return True
 
 
 def _list_existing_volumes() -> dict[str, list[str]]:
@@ -368,17 +391,17 @@ def status() -> None:
         raise typer.Exit(1)
 
     # Configuration
-    header("Configuration")
+    rule("Configuration")
     try:
         config = load_config()
-        err_console.print(f"  CODE_DIR: {config.code_dir}")
+        status_line("CODE_DIR", str(config.code_dir), value_style="path")
     except ConfigNotFoundError:
         warning("Configuration not found. Run 'djinn init' to create one.")
 
     blank()
 
     # Containers
-    header("Containers")
+    rule("Containers")
     result = subprocess.run(
         [
             "docker",
@@ -389,21 +412,19 @@ def status() -> None:
             "--filter",
             "name=mcp-",
             "--format",
-            "table {{.Names}}\t{{.Status}}\t{{.Image}}",
+            "{{.Names}}\t{{.Status}}\t{{.Image}}",
         ],
         capture_output=True,
         text=True,
         check=False,
     )
-    if result.stdout.strip():
-        console.print(result.stdout.strip())
-    else:
+    if not _print_docker_table("Djinn Containers", ["Names", "Status", "Image"], result.stdout):
         err_console.print("  No containers found")
 
     blank()
 
     # Volumes
-    header("Volumes")
+    rule("Volumes")
     volume_entries = _list_existing_volumes()
     if volume_entries:
         _print_resource_table("Djinn Volumes", "Volume", volume_entries)
@@ -413,8 +434,8 @@ def status() -> None:
     blank()
 
     # Synced Paths
-    header("Synced Paths")
-    err_console.print(f"  Root: {get_config_root(config)}")
+    rule("Synced Paths")
+    status_line("Root", str(get_config_root(config)), value_style="path")
     sync_entries = _list_existing_sync_paths(config)
     if sync_entries:
         _print_resource_table("Djinn Sync Paths", "Path", sync_entries)
@@ -424,7 +445,7 @@ def status() -> None:
     blank()
 
     # Networks
-    header("Networks")
+    rule("Networks")
     result = subprocess.run(
         [
             "docker",
@@ -433,33 +454,31 @@ def status() -> None:
             "--filter",
             "name=djinn",
             "--format",
-            "table {{.Name}}\t{{.Driver}}",
+            "{{.Name}}\t{{.Driver}}",
         ],
         capture_output=True,
         text=True,
         check=False,
     )
-    if result.stdout.strip():
-        console.print(result.stdout.strip())
-    else:
+    if not _print_docker_table("Djinn Networks", ["Name", "Driver"], result.stdout):
         err_console.print("  No networks found")
 
     blank()
 
     # Service Status
-    header("Services")
+    rule("Services")
 
     # Docker Proxy Status
     if is_container_running("djinn-docker-proxy"):
-        success("  Docker Proxy: Running")
+        status_line("Docker Proxy", "Running", "status.enabled")
     else:
-        err_console.print("  [status.disabled]Docker Proxy: Not running[/status.disabled]")
+        status_line("Docker Proxy", "Not running", "status.disabled")
 
     # MCP Gateway Status
     if is_container_running("mcp-gateway"):
-        success("  MCP Gateway: Running")
+        status_line("MCP Gateway", "Running", "status.enabled")
     else:
-        err_console.print("  [status.disabled]MCP Gateway: Not running[/status.disabled]")
+        status_line("MCP Gateway", "Not running", "status.disabled")
 
 
 clean_app = typer.Typer(
@@ -566,15 +585,14 @@ def clean_volumes(
 
     if not selected:
         config = _load_optional_config()
-        info("Volumes by category:")
+        rule("Volumes by category")
         blank()
         volume_entries = _list_existing_volumes()
         if volume_entries:
             _print_resource_table("Djinn Volumes", "Volume", volume_entries)
         else:
             err_console.print("  No volumes found")
-        blank()
-        info("Sync paths by category:")
+        rule("Sync paths by category")
         blank()
         sync_entries = _list_existing_sync_paths(config)
         if sync_entries:
@@ -701,7 +719,7 @@ def audit(
         err_console.print("Start with: djinn start --docker")
         raise typer.Exit(1)
 
-    info(f"Docker Proxy Audit Log (last {tail} lines):")
+    rule(f"Docker Proxy Audit Log (last {tail} lines):")
     blank()
 
     result = subprocess.run(
@@ -734,6 +752,7 @@ def update() -> None:
         error(f"Update failed with exit code {result.returncode}")
         raise typer.Exit(result.returncode)
 
+    blank()
     success("Update completed successfully")
 
 

--- a/src/djinn_in_a_box/commands/doctor.py
+++ b/src/djinn_in_a_box/commands/doctor.py
@@ -17,9 +17,11 @@ from pathlib import Path
 from typing import Annotated
 
 import typer
+from rich.table import Table
+from rich.text import Text
 
 from djinn_in_a_box.config.models import AppConfig
-from djinn_in_a_box.core.console import blank, console, error, header, status_line, warning
+from djinn_in_a_box.core.console import blank, console, error, rule, warning
 from djinn_in_a_box.core.docker import (
     DJINN_NETWORK,
     ensure_host_env,
@@ -319,6 +321,7 @@ _STYLE: dict[Status, str] = {
     Status.FAIL: "status.error",
 }
 _GLYPH: dict[Status, str] = {Status.PASS: "✓", Status.WARN: "⚠", Status.FAIL: "✗"}
+_LABEL: dict[Status, str] = {Status.PASS: "PASS", Status.WARN: "WARN", Status.FAIL: "FAIL"}
 
 
 def _doctor_fix(config: AppConfig) -> bool:
@@ -404,15 +407,33 @@ def doctor(
         config = None
         config_error = str(e)
 
-    header("Djinn Doctor")
-    blank()
+    rule("Djinn Doctor")
 
     checks = run_checks(config, config_error)
+    table = Table(
+        title="Djinn Doctor",
+        title_style="table.title",
+        header_style="table.header",
+        border_style="border",
+    )
+    table.add_column("Check", style="table.category")
+    table.add_column("Status")
+    table.add_column("Detail", style="table.value")
+    table.add_column("Remedy", style="muted")
     for check in checks:
         glyph = _GLYPH[check.status]
-        status_line(check.name, f"{glyph} {check.detail}", _STYLE[check.status])
-        if check.remedy:
-            console.print(f"      [muted]{check.remedy}[/muted]")
+        detail = (
+            Text(check.detail, style="path")
+            if check.name in {"Projects dir", "Config root"}
+            else check.detail
+        )
+        table.add_row(
+            check.name,
+            Text(f"{glyph} {_LABEL[check.status]}", style=_STYLE[check.status]),
+            detail,
+            check.remedy,
+        )
+    console.print(table)
 
     blank()
     failed = [c for c in checks if c.status is Status.FAIL]

--- a/src/djinn_in_a_box/commands/mcp.py
+++ b/src/djinn_in_a_box/commands/mcp.py
@@ -10,7 +10,16 @@ from typing import Annotated
 
 import typer
 
-from djinn_in_a_box.core.console import console, err_console, error, header, info, success, warning
+from djinn_in_a_box.core.console import (
+    console,
+    err_console,
+    error,
+    info,
+    rule,
+    status_line,
+    success,
+    warning,
+)
 from djinn_in_a_box.core.docker import (
     DJINN_NETWORK,
     delete_network,
@@ -87,10 +96,9 @@ def start() -> None:
     if is_container_running(GATEWAY_CONTAINER):
         success("MCP Gateway is running")
         err_console.print()
-        err_console.print(f"Endpoint: {GATEWAY_ENDPOINT_CONTAINER} (from containers)")
-        err_console.print(f"          {GATEWAY_ENDPOINT_HOST} (from host)")
-        err_console.print()
-        err_console.print("Next steps:")
+        status_line("Endpoint", f"{GATEWAY_ENDPOINT_CONTAINER} (from containers)")
+        status_line("Host", f"{GATEWAY_ENDPOINT_HOST} (from host)")
+        rule("Next steps")
         err_console.print("  mcpgateway enable duckduckgo    # Enable web search")
         err_console.print("  mcpgateway enable memory        # Enable persistent memory")
         err_console.print("  mcpgateway servers              # List enabled servers")
@@ -122,10 +130,10 @@ def restart() -> None:
 
 def status() -> None:
     """Show gateway status and enabled servers."""
-    header("MCP Gateway Status")
+    rule("MCP Gateway Status")
 
     if is_container_running(GATEWAY_CONTAINER):
-        err_console.print("Gateway: [status.enabled]Running[/status.enabled]")
+        status_line("Gateway", "Running", "status.enabled")
         err_console.print()
 
         # Show container details
@@ -145,8 +153,7 @@ def status() -> None:
         if result.stdout.strip():
             err_console.print(result.stdout.strip())
 
-        err_console.print()
-        info("Enabled Servers:")
+        rule("Enabled Servers")
         result = subprocess.run(
             ["docker", "mcp", "server", "ls"],
             capture_output=True,
@@ -158,8 +165,7 @@ def status() -> None:
         else:
             err_console.print("  (none)")
 
-        err_console.print()
-        info("Running MCP Containers:")
+        rule("Running MCP Containers")
         result = subprocess.run(
             [
                 "docker",
@@ -186,7 +192,7 @@ def status() -> None:
         else:
             err_console.print("  (none)")
     else:
-        err_console.print("Gateway: [status.error]Stopped[/status.error]")
+        status_line("Gateway", "Stopped", "status.error")
         err_console.print()
         err_console.print("Start with: mcpgateway start")
 
@@ -248,7 +254,7 @@ def disable(
 def servers() -> None:
     """List enabled MCP servers."""
     _require_mcp_cli()
-    header("Enabled MCP Servers")
+    rule("Enabled MCP Servers")
 
     result = subprocess.run(
         ["docker", "mcp", "server", "ls"],
@@ -266,7 +272,7 @@ def servers() -> None:
 def catalog() -> None:
     """Show available servers in the catalog."""
     _require_mcp_cli()
-    header("MCP Server Catalog")
+    rule("MCP Server Catalog")
 
     result = subprocess.run(
         ["docker", "mcp", "catalog", "show", "docker-mcp"],
@@ -286,36 +292,44 @@ def catalog() -> None:
 
 def test() -> None:
     """Test gateway connectivity (container, endpoints, socket, CLI plugin)."""
-    info("Testing MCP Gateway...")
+    rule("Testing MCP Gateway")
     err_console.print()
 
     all_passed = True
 
     # Container status
-    err_console.print("Container status: ", end="")
     if is_container_running(GATEWAY_CONTAINER):
-        err_console.print("[status.enabled]Running[/status.enabled]")
+        status_line("Container", "Running", "status.enabled")
     else:
-        err_console.print("[status.error]Not running[/status.error]")
+        status_line("Container", "Not running", "status.error")
         all_passed = False
 
     # Localhost endpoint
-    err_console.print("Localhost endpoint (host access): ", end="")
     try:
         result = subprocess.run(
-            ["curl", "-s", "--connect-timeout", "2", "-o", "/dev/null",
-             "-w", "%{http_code}", f"{GATEWAY_ENDPOINT_HOST}/"],
-            capture_output=True, text=True, check=False,
+            [
+                "curl",
+                "-s",
+                "--connect-timeout",
+                "2",
+                "-o",
+                "/dev/null",
+                "-w",
+                "%{http_code}",
+                f"{GATEWAY_ENDPOINT_HOST}/",
+            ],
+            capture_output=True,
+            text=True,
+            check=False,
         )
         if result.returncode == 0 and result.stdout in ("200", "404"):
-            err_console.print("[status.enabled]OK[/status.enabled]")
+            status_line("Localhost", "OK", "status.enabled")
         else:
-            err_console.print("[status.disabled]Not responding[/status.disabled]")
+            status_line("Localhost", "Not responding", "status.disabled")
     except FileNotFoundError:
-        err_console.print("[status.disabled]curl not installed[/status.disabled]")
+        status_line("Localhost", "curl not installed", "status.disabled")
 
     # Container endpoint (via docker network)
-    err_console.print("Container endpoint (network access): ", end="")
     result = subprocess.run(
         [
             "docker",
@@ -338,36 +352,31 @@ def test() -> None:
         check=False,
     )
     if result.returncode == 0 and result.stdout in ("200", "404"):
-        err_console.print("[status.enabled]OK[/status.enabled]")
+        status_line("Network", "OK", "status.enabled")
     else:
-        err_console.print(
-            "[status.disabled]Not responding (network may not exist yet)[/status.disabled]"
-        )
+        status_line("Network", "Not responding (network may not exist yet)", "status.disabled")
 
     # Docker socket access
-    err_console.print("Docker socket access: ", end="")
     result = subprocess.run(
         ["docker", "exec", GATEWAY_CONTAINER, "ls", "/var/run/docker.sock"],
         capture_output=True,
         check=False,
     )
     if result.returncode == 0:
-        err_console.print("[status.enabled]OK[/status.enabled]")
+        status_line("Docker sock", "OK", "status.enabled")
     else:
-        err_console.print("[status.error]Failed[/status.error]")
+        status_line("Docker sock", "Failed", "status.error")
         all_passed = False
 
     # CLI plugin
-    err_console.print("docker mcp CLI plugin: ", end="")
     cli_check = subprocess.run(["docker", "mcp", "--help"], capture_output=True, check=False)
     if cli_check.returncode == 0:
-        err_console.print("[status.enabled]Installed[/status.enabled]")
+        status_line("MCP plugin", "Installed", "status.enabled")
     else:
-        err_console.print("[status.disabled]Not installed[/status.disabled]")
+        status_line("MCP plugin", "Not installed", "status.disabled")
 
     # Show endpoint URLs
-    err_console.print()
-    err_console.print("MCP Gateway URLs:")
+    rule("MCP Gateway URLs")
     err_console.print(f"  Streamable HTTP: {GATEWAY_ENDPOINT_CONTAINER}/mcp")
 
     if not all_passed:

--- a/src/djinn_in_a_box/core/banner.py
+++ b/src/djinn_in_a_box/core/banner.py
@@ -1,0 +1,183 @@
+"""Startup banner rendering for the Djinn CLI."""
+
+from __future__ import annotations
+
+import codecs
+from contextlib import suppress
+from enum import Enum
+
+from rich.console import Console
+from rich.table import Table
+from rich.text import Text
+
+from djinn_in_a_box.core.console import err_console
+from djinn_in_a_box.core.theme import PRIMARY, SECONDARY
+
+PLAIN_TITLE = "Djinn in a Box"
+
+BRAILLE_LOGO = """⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⡀⢀⣤⣀⡀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀
+⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⣴⣿⣷⠀⠻⣿⣿⣦⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀
+⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⣿⠟⢁⣴⣦⣈⠻⠿⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀
+⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⢠⣾⣿⣿⣿⣿⣷⡄⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀
+⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠻⣉⡀⢀⣉⠟⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀
+⠀⠀⠀⠀⠀⠀⠀⠀⣠⣤⣶⣶⣦⡈⠃⠘⢁⣴⣶⣦⣤⣀⠀⠀⠀⠀⠀⠀⠀⠀
+⠀⠀⠀⠀⠀⠀⣴⣿⣿⡿⠿⠿⠿⣷⡀⢀⣠⣤⣤⣤⣤⣄⣁⠀⠀⠀⠀⠀⠀⠀
+⠀⠀⠀⠀⠀⣼⣿⣿⣿⣷⣶⣶⠦⠀⢀⡈⠛⠿⣿⣿⣿⣿⣿⣷⣄⠀⠀⠀⠀⠀
+⠀⠀⠀⠀⠀⠉⠙⠛⠉⢉⣁⣤⣴⣾⣿⣿⣷⣦⣤⣈⡉⠙⠛⠛⠉⠀⠀⠀⠀⠀
+⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⢻⣿⣿⣿⣿⣿⣿⣿⣿⣿⠃⠀⠀⠀⠀⠀⠀⠀⠀⠀
+⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠿⢿⣿⣿⣿⣿⠿⠟⠛⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀
+⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⢀⣶⣤⣤⣤⣤⣤⣴⡶⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀
+⠀⠀⠀⠀⠀⠀⠀⠀⣀⣴⣿⣿⣿⣿⣿⣿⣿⡿⠁⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀
+⠀⠀⠀⠀⠐⠲⠿⢿⣿⣿⣿⣿⣿⣿⡿⠟⠋⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀
+⠀⠀⠀⠀⠀⠀⠀⠀⠀⠈⠉⠉⠉⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀"""
+
+WORDMARK = """██████╗      ██╗██╗███╗   ██╗███╗   ██╗
+██╔══██╗     ██║██║████╗  ██║████╗  ██║
+██║  ██║     ██║██║██╔██╗ ██║██╔██╗ ██║
+██║  ██║██   ██║██║██║╚██╗██║██║╚██╗██║
+██████╔╝╚█████╔╝██║██║ ╚████║██║ ╚████║
+╚═════╝  ╚════╝ ╚═╝╚═╝  ╚═══╝╚═╝  ╚═══╝
+            ─── in a box ───"""
+
+_BRAILLE_BLANK = "⠀"
+_FULL_WIDTH = 70
+
+
+class _BannerMode(Enum):
+    FULL = "full"
+    WORDMARK = "wordmark"
+    PLAIN = "plain"
+
+
+def banner() -> None:
+    """Render the best available startup banner to stderr."""
+    try:
+        _render_banner(err_console)
+    except Exception:
+        with suppress(Exception):
+            _render_plain(err_console)
+
+
+def _render_banner(console: Console) -> None:
+    mode = _mode_for_console(console)
+    if mode is _BannerMode.FULL:
+        _render_full(console)
+    elif mode is _BannerMode.WORDMARK:
+        _render_wordmark(console)
+    else:
+        _render_plain(console)
+
+
+def _mode_for_console(console: Console) -> _BannerMode:
+    if _plain_required(console) or not _is_utf8(console):
+        return _BannerMode.PLAIN
+    if _has_color(console) and console.width >= _FULL_WIDTH:
+        return _BannerMode.FULL
+    return _BannerMode.WORDMARK
+
+
+def _plain_required(console: Console) -> bool:
+    return bool(console.no_color) or bool(console.is_dumb_terminal)
+
+
+def _is_utf8(console: Console) -> bool:
+    file = console.file
+    encoding = getattr(file, "encoding", None)
+    if not encoding:
+        return False
+    try:
+        return codecs.lookup(encoding).name == "utf-8"
+    except LookupError:
+        return False
+
+
+def _has_color(console: Console) -> bool:
+    return console.color_system is not None and not console.no_color
+
+
+def _render_full(console: Console) -> None:
+    logo_lines = _trim_logo_lines()
+    logo = _logo_text(logo_lines)
+    top_padding = max(0, (len(logo_lines) - len(WORDMARK.splitlines())) // 2)
+    wordmark = _wordmark_text(top_padding=top_padding)
+
+    grid = Table.grid(padding=(0, 2))
+    grid.add_column()
+    grid.add_column()
+    grid.add_row(logo, wordmark)
+    console.print(grid)
+
+
+def _render_wordmark(console: Console) -> None:
+    console.print(_wordmark_text())
+
+
+def _render_plain(console: Console) -> None:
+    console.print(PLAIN_TITLE)
+
+
+def _trim_logo_lines() -> list[str]:
+    lines: list[str] = list(BRAILLE_LOGO.splitlines())
+    used_columns = [
+        index
+        for line in lines
+        for index, char in enumerate(line)
+        if char != _BRAILLE_BLANK
+    ]
+    if not used_columns:
+        return lines
+
+    start = min(used_columns)
+    end = max(used_columns) + 1
+    return [line[start:end] for line in lines]
+
+
+def _logo_text(lines: list[str]) -> Text:
+    logo = Text()
+    total = len(lines)
+    for index, line in enumerate(lines):
+        if index:
+            logo.append("\n")
+        logo.append(line, style=_gradient_color(index, total))
+    return logo
+
+
+def _wordmark_text(*, top_padding: int = 0) -> Text:
+    text = Text("\n" * top_padding)
+    lines = WORDMARK.splitlines()
+    last_index = len(lines) - 1
+    for index, line in enumerate(lines):
+        if index:
+            text.append("\n")
+        if index == last_index:
+            text.append(line, style="muted bold")
+        else:
+            text.append(line, style="primary.bold")
+    return text
+
+
+def _gradient_color(index: int, total: int) -> str:
+    if total <= 1:
+        return PRIMARY
+
+    ratio = index / (total - 1)
+    return _interpolate_hex(PRIMARY, SECONDARY, ratio)
+
+
+def _interpolate_hex(start: str, end: str, ratio: float) -> str:
+    start_rgb = _hex_to_rgb(start)
+    end_rgb = _hex_to_rgb(end)
+    channels = [
+        round(start_channel + (end_channel - start_channel) * ratio)
+        for start_channel, end_channel in zip(start_rgb, end_rgb, strict=True)
+    ]
+    return f"#{channels[0]:02X}{channels[1]:02X}{channels[2]:02X}"
+
+
+def _hex_to_rgb(value: str) -> tuple[int, int, int]:
+    stripped = value.removeprefix("#")
+    return (
+        int(stripped[0:2], 16),
+        int(stripped[2:4], 16),
+        int(stripped[4:6], 16),
+    )

--- a/src/djinn_in_a_box/core/console.py
+++ b/src/djinn_in_a_box/core/console.py
@@ -4,6 +4,7 @@ Status messages go to stderr to keep stdout clean for agent output.
 """
 
 from rich.console import Console
+from rich.text import Text
 
 from djinn_in_a_box.core.theme import DJINN_THEME, ICONS
 
@@ -14,11 +15,21 @@ err_console: Console = Console(stderr=True, theme=DJINN_THEME)
 """Error console for stderr output (status messages, progress)."""
 
 
-def status_line(label: str, value: str, style: str = "status.enabled") -> None:
+def status_line(
+    label: str,
+    value: str,
+    style: str = "status.enabled",
+    *,
+    value_style: str | None = None,
+) -> None:
     """Print a formatted status line to stderr (e.g., '   Projects:  /path')."""
     # Calculate padding to align values (longest label is ~10 chars)
     padding = max(0, 10 - len(label))
-    err_console.print(f"   [{style}]{label}:[/{style}]{' ' * padding} {value}")
+    line = Text("   ")
+    line.append(f"{label}:", style=style)
+    line.append(f"{' ' * padding} ")
+    line.append(value, style=value_style)
+    err_console.print(line)
 
 
 def error(message: str) -> None:
@@ -43,3 +54,17 @@ def blank() -> None:
 
 def header(title: str) -> None:
     err_console.print(f"[header]{title}:[/header]")
+
+
+def rule(title: str = "") -> None:
+    width = max(getattr(err_console, "width", 80), 20)
+    err_console.print()
+    if not title:
+        err_console.print(Text("─" * width, style="border"))
+        return
+
+    suffix_len = max(width - len(title) - 3, 8)
+    line = Text("─ ", style="border")
+    line.append(title, style="primary.bold")
+    line.append(f" {'─' * suffix_len}", style="border")
+    err_console.print(line)

--- a/src/djinn_in_a_box/core/docker.py
+++ b/src/djinn_in_a_box/core/docker.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import os
 import shutil
 import subprocess
+import sys
 from dataclasses import dataclass
 from enum import Enum
 from pathlib import Path
@@ -168,6 +169,16 @@ def get_compose_files(docker_mode: DockerMode = DockerMode.NONE) -> list[str]:
     return files
 
 
+def _host_terminal_width() -> str | None:
+    if not (sys.stdout.isatty() or sys.stderr.isatty()):
+        return None
+
+    columns = shutil.get_terminal_size().columns
+    if columns <= 0:
+        return None
+    return str(columns)
+
+
 def build_compose_env(config: AppConfig | None) -> dict[str, str]:
     """Render docker-compose interpolation variables from the loaded config.
 
@@ -178,20 +189,25 @@ def build_compose_env(config: AppConfig | None) -> dict[str, str]:
     ``config=None`` → best-effort placeholders for the two guarded vars only,
     for teardown / by-name operations (down/stop/rm act by project/container name).
     """
+    terminal_width = _host_terminal_width()
     if config is None:
-        return {
+        env = {
             "CODE_DIR": str(Path.home()),
             "DJINN_CONFIG_ROOT": str(get_config_root()),
         }
-    return {
-        "CODE_DIR": str(config.code_dir),
-        "DJINN_CONFIG_ROOT": str(get_config_root(config)),
-        "TZ": config.timezone,
-        "CPU_LIMIT": str(config.resources.cpu_limit),
-        "MEMORY_LIMIT": config.resources.memory_limit,
-        "CPU_RESERVATION": str(config.resources.cpu_reservation),
-        "MEMORY_RESERVATION": config.resources.memory_reservation,
-    }
+    else:
+        env = {
+            "CODE_DIR": str(config.code_dir),
+            "DJINN_CONFIG_ROOT": str(get_config_root(config)),
+            "TZ": config.timezone,
+            "CPU_LIMIT": str(config.resources.cpu_limit),
+            "MEMORY_LIMIT": config.resources.memory_limit,
+            "CPU_RESERVATION": str(config.resources.cpu_reservation),
+            "MEMORY_RESERVATION": config.resources.memory_reservation,
+        }
+    if terminal_width is not None:
+        env["DJINN_TERM_WIDTH"] = terminal_width
+    return env
 
 
 def _compose_host_env(config: AppConfig | None) -> dict[str, str]:

--- a/src/djinn_in_a_box/core/theme.py
+++ b/src/djinn_in_a_box/core/theme.py
@@ -3,30 +3,45 @@
 from rich.style import Style
 from rich.theme import Theme
 
+PRIMARY = "#69B9A1"
+SECONDARY = "#226666"
+SUCCESS = "#C1FF62"
+ERROR = "#F53263"
+WARNING = "#FAF870"
+# Deliberately ANSI blue color 4, matching the old shell \033[0;34m rendering.
+INFO = "blue"
+PATH = "#8608B8"
+MUTED = "#333676"
+BORDER = "#29526D"
+
 DJINN_THEME: Theme = Theme(
     {
         # Semantic Message Styles
-        "success": Style(color="#03b971"),
-        "error": Style(color="#9c0136", bold=True),
-        "warning": Style(color="#f5b332"),
-        "info": Style(color="#0e8ac8"),
-        "info.bold": Style(color="#0e8ac8", bold=True),
+        "success": Style(color=SUCCESS),
+        "error": Style(color=ERROR),
+        "warning": Style(color=WARNING),
+        "info": Style(color=INFO),
+        "info.bold": Style(color=INFO, bold=True),
+        "path": Style(color=PATH),
         # Primary/Accent Styles
-        "primary": Style(color="#69B9A1"),
-        "primary.bold": Style(color="#69B9A1", bold=True),
+        "primary": Style(color=PRIMARY),
+        "primary.bold": Style(color=PRIMARY, bold=True),
+        "secondary": Style(color=SECONDARY),
+        "secondary.bold": Style(color=SECONDARY, bold=True),
         # Text Styles
-        "muted": Style(color="#b2bec3"),
+        "muted": Style(color=MUTED),
+        "border": Style(color=BORDER),
         # Header Styles
-        "header": Style(color="#0e8ac8", bold=True),
+        "header": Style(color=PRIMARY, bold=True),
         # Status Indicator Styles
-        "status.enabled": Style(color="#03b971"),
-        "status.disabled": Style(color="#f5b332"),
-        "status.error": Style(color="#9c0136"),
+        "status.enabled": Style(color=SUCCESS),
+        "status.disabled": Style(color=WARNING),
+        "status.error": Style(color=ERROR),
         # Table Styles
-        "table.title": Style(color="#0e8ac8", bold=True),
-        "table.header": Style(bold=True),
-        "table.category": Style(color="#f5b332"),
-        "table.value": Style(color="#b2bec3"),
+        "table.title": Style(color=PRIMARY, bold=True),
+        "table.header": Style(color=PRIMARY, bold=True),
+        "table.category": Style(color=SECONDARY),
+        "table.value": Style(color=MUTED),
     }
 )
 

--- a/tests/test_cli_djinn.py
+++ b/tests/test_cli_djinn.py
@@ -61,7 +61,9 @@ class TestDjinnVersion:
     def test_version_short_flag(self) -> None:
         result = runner.invoke(app, ["-V"])
         assert result.exit_code == 0
-        assert f"djinn {__version__}" in result.stdout
+        assert "djinn" in result.stdout
+        assert __version__ in result.stdout
+        assert "\n" in result.stdout
 
 
 class TestInitCommand:
@@ -231,8 +233,12 @@ class TestConfigShowCommand:
 
         assert result.exit_code == 0
         combined = result.stdout + result.output
-        assert "projects" in combined
-        assert "UTC" in combined
+        # Long paths soft-wrap inside Rich table cells with indented
+        # continuation lines (CI runners have longer tmp paths) — strip all
+        # whitespace so a break mid-word cannot split the expected token.
+        unwrapped = "".join(combined.split())
+        assert "projects" in unwrapped
+        assert "UTC" in unwrapped
 
     def test_config_show_json_output(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         projects_dir = tmp_path / "projects"

--- a/tests/test_commands/test_container.py
+++ b/tests/test_commands/test_container.py
@@ -1,6 +1,7 @@
 """Tests for container lifecycle commands."""
 
 import io
+import re
 from collections.abc import Generator
 from pathlib import Path
 from typing import Any
@@ -66,6 +67,14 @@ class TestStartCommand:
     @pytest.fixture
     def start_mocks(self) -> Generator[dict[str, Any]]:
         """Common mocks for start command tests."""
+        err_output = io.StringIO()
+        test_err_console = Console(
+            file=err_output,
+            force_terminal=True,
+            no_color=True,
+            width=100,
+            theme=DJINN_THEME,
+        )
         with (
             patch("djinn_in_a_box.commands.container.load_config") as mock_load,
             patch("djinn_in_a_box.commands.container.preflight"),
@@ -74,6 +83,8 @@ class TestStartCommand:
             patch("djinn_in_a_box.commands.container.cleanup_docker_proxy") as mock_cleanup,
             patch("djinn_in_a_box.commands.container.get_shell_mount_args", return_value=[]),
             patch("djinn_in_a_box.commands.container.get_audio_mount_args", return_value=[]),
+            patch("djinn_in_a_box.commands.container.banner") as mock_banner,
+            patch("djinn_in_a_box.core.console.err_console", test_err_console),
         ):
             mock_config = MagicMock()
             mock_config.code_dir = Path("/projects")
@@ -85,6 +96,8 @@ class TestStartCommand:
                 "run": mock_run,
                 "cleanup": mock_cleanup,
                 "config": mock_config,
+                "banner": mock_banner,
+                "err_output": err_output,
             }
 
     def test_start_with_docker_flag(self, start_mocks: dict[str, Any]) -> None:
@@ -92,6 +105,7 @@ class TestStartCommand:
             container.start(docker=True)
         options = start_mocks["run"].call_args[0][1]
         assert options.docker_mode is DockerMode.PROXY
+        start_mocks["banner"].assert_called_once_with()
         start_mocks["cleanup"].assert_called_once_with(DockerMode.PROXY, start_mocks["config"])
 
     def test_start_with_firewall_flag(self, start_mocks: dict[str, Any]) -> None:
@@ -133,6 +147,22 @@ class TestStartCommand:
         options = start_mocks["run"].call_args[0][1]
         assert options.docker_mode is DockerMode.DIRECT
         start_mocks["cleanup"].assert_called_once_with(DockerMode.DIRECT, start_mocks["config"])
+
+    def test_start_renders_environment_and_container_rules(
+        self, start_mocks: dict[str, Any]
+    ) -> None:
+        with pytest.raises(typer.Exit):
+            container.start()
+
+        rendered = start_mocks["err_output"].getvalue()
+        assert "Environment" in rendered
+        assert "Container" in rendered
+        rendered_plain = re.sub(r"\x1b\[[0-9;]*m", "", rendered)
+        assert "\n\n─ Container" in rendered_plain
+        assert "\n\n\n─ Container" not in rendered_plain
+        start_mocks["run"].assert_called_once()
+        assert start_mocks["run"].call_args.args[0] is start_mocks["config"]
+        assert start_mocks["run"].call_args.kwargs["interactive"] is True
 
     def test_start_docker_and_direct_mutually_exclusive(self) -> None:
         with pytest.raises(typer.Exit) as exc_info:

--- a/tests/test_core/test_banner.py
+++ b/tests/test_core/test_banner.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+from io import StringIO
+from typing import Any
+
+import pytest
+from rich.console import Console
+
+from djinn_in_a_box.core import banner as banner_mod
+from djinn_in_a_box.core.theme import DJINN_THEME
+
+
+class RecordingFile(StringIO):
+    def __init__(self, *, encoding: str) -> None:
+        super().__init__()
+        self._encoding = encoding
+
+    @property
+    def encoding(self) -> str:
+        return self._encoding
+
+
+def _recording_console(
+    *,
+    width: int = 80,
+    encoding: str = "utf-8",
+    color_system: str | None = "truecolor",
+    no_color: bool | None = False,
+    environ: dict[str, str] | None = None,
+) -> tuple[Console, RecordingFile]:
+    output = RecordingFile(encoding=encoding)
+    console = Console(
+        file=output,
+        force_terminal=True,
+        color_system=color_system,
+        no_color=no_color,
+        width=width,
+        theme=DJINN_THEME,
+        _environ={} if environ is None else environ,
+    )
+    return console, output
+
+
+def _render(monkeypatch: pytest.MonkeyPatch, console: Console, output: StringIO) -> str:
+    monkeypatch.setattr(banner_mod, "err_console", console)
+    banner_mod.banner()
+    return output.getvalue()
+
+
+def _has_braille(value: str) -> bool:
+    return any("\u2800" <= char <= "\u28ff" for char in value)
+
+
+def test_full_banner_contains_braille_and_wordmark(monkeypatch: pytest.MonkeyPatch) -> None:
+    console, output = _recording_console(width=80)
+
+    rendered = _render(monkeypatch, console, output)
+
+    assert _has_braille(rendered)
+    assert "in a box" in rendered and "██" in rendered
+
+
+def test_wordmark_mode_omits_braille_when_narrow(monkeypatch: pytest.MonkeyPatch) -> None:
+    console, output = _recording_console(width=50)
+
+    rendered = _render(monkeypatch, console, output)
+
+    assert not _has_braille(rendered)
+    assert "in a box" in rendered and "██" in rendered
+
+
+@pytest.mark.parametrize(
+    "console_kwargs",
+    [
+        {"no_color": True},
+        {"environ": {"TERM": "dumb"}},
+    ],
+)
+def test_plain_mode_uses_single_title_line(
+    monkeypatch: pytest.MonkeyPatch,
+    console_kwargs: dict[str, Any],
+) -> None:
+    console, output = _recording_console(**console_kwargs)
+
+    rendered = _render(monkeypatch, console, output)
+
+    assert rendered.splitlines() == ["Djinn in a Box"]
+    assert not _has_braille(rendered)
+
+
+def test_ascii_console_never_raises_and_uses_plain_title(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    console, output = _recording_console(encoding="ascii")
+
+    rendered = _render(monkeypatch, console, output)
+
+    assert rendered.splitlines() == ["Djinn in a Box"]
+    assert not _has_braille(rendered)

--- a/tests/test_core/test_console.py
+++ b/tests/test_core/test_console.py
@@ -1,0 +1,28 @@
+import re
+from io import StringIO
+
+from rich.console import Console
+
+from djinn_in_a_box.core import console as console_mod
+from djinn_in_a_box.core.theme import DJINN_THEME
+
+
+def test_rule_renders_title_to_err_console(monkeypatch) -> None:
+    output = StringIO()
+    test_console = Console(
+        file=output,
+        force_terminal=True,
+        no_color=True,
+        theme=DJINN_THEME,
+        width=40,
+    )
+    monkeypatch.setattr(console_mod, "err_console", test_console)
+
+    console_mod.rule("Environment")
+
+    rendered = output.getvalue()
+    rendered_plain = re.sub(r"\x1b\[[0-9;]*m", "", rendered)
+    lines = rendered_plain.splitlines()
+    assert lines[0] == ""
+    assert lines[1].startswith("─ Environment ─")
+    assert len(lines[1]) == 40

--- a/tests/test_core/test_theme.py
+++ b/tests/test_core/test_theme.py
@@ -1,0 +1,204 @@
+import ast
+import re
+from pathlib import Path
+
+import pytest
+
+from djinn_in_a_box.core.theme import (
+    BORDER,
+    DJINN_THEME,
+    ERROR,
+    INFO,
+    MUTED,
+    PATH,
+    PRIMARY,
+    SECONDARY,
+    SUCCESS,
+    WARNING,
+)
+
+ROOT = Path(__file__).resolve().parents[2]
+THEME_SOURCE = ROOT / "src" / "djinn_in_a_box" / "core" / "theme.py"
+HEX_COLOR_PATTERN = re.compile(r"#[0-9a-fA-F]{6}\b")
+NAMED_COLOR_RICH_TAG_PATTERN = re.compile(
+    r"\[/?(?:[a-z]+\s+)*(cyan|magenta|green|red|yellow|blue|white|black)"
+    r"(?:\s+[a-z]+)*\]",
+    re.IGNORECASE,
+)
+NAMED_COLOR_STYLE_TOKENS = {
+    "cyan",
+    "magenta",
+    "green",
+    "red",
+    "yellow",
+    "blue",
+    "white",
+    "black",
+}
+RICH_STYLE_MODIFIER_TOKENS = {
+    "bold",
+    "dim",
+    "italic",
+    "underline",
+    "blink",
+    "blink2",
+    "reverse",
+    "strike",
+    "not",
+    "overline",
+}
+
+EXPECTED_PALETTE = {
+    "primary": "#69B9A1",
+    "secondary": "#226666",
+    "success": "#C1FF62",
+    "error": "#F53263",
+    "warning": "#FAF870",
+    "info": "blue",
+    "path": "#8608B8",
+    "muted": "#333676",
+    "border": "#29526D",
+}
+
+PALETTE_VALUES = frozenset(EXPECTED_PALETTE.values())
+HEX_PALETTE_VALUES = frozenset(
+    value for value in EXPECTED_PALETTE.values() if value.startswith("#")
+)
+DJINN_ROLE_NAMES = (
+    "success",
+    "error",
+    "warning",
+    "info",
+    "info.bold",
+    "path",
+    "primary",
+    "primary.bold",
+    "secondary",
+    "secondary.bold",
+    "muted",
+    "border",
+    "header",
+    "status.enabled",
+    "status.disabled",
+    "status.error",
+    "table.title",
+    "table.header",
+    "table.category",
+    "table.value",
+)
+
+
+def _style_color_value(role_name: str) -> str:
+    style = DJINN_THEME.styles[role_name]
+    assert style.color is not None
+    triplet = style.color.triplet
+    if triplet is None:
+        return style.color.name
+    return f"#{triplet.red:02X}{triplet.green:02X}{triplet.blue:02X}"
+
+
+@pytest.mark.parametrize("role_name", DJINN_ROLE_NAMES)
+def test_theme_role_color_comes_from_palette(role_name: str) -> None:
+    assert role_name in DJINN_THEME.styles
+    assert _style_color_value(role_name) in PALETTE_VALUES
+
+
+def test_palette_constants_are_authoritative_values() -> None:
+    assert {
+        "primary": PRIMARY,
+        "secondary": SECONDARY,
+        "success": SUCCESS,
+        "error": ERROR,
+        "warning": WARNING,
+        "info": INFO,
+        "path": PATH,
+        "muted": MUTED,
+        "border": BORDER,
+    } == EXPECTED_PALETTE
+
+
+def test_theme_role_remappings_follow_spec() -> None:
+    assert _style_color_value("header") == PRIMARY
+    assert DJINN_THEME.styles["header"].bold is True
+    assert _style_color_value("table.title") == PRIMARY
+    assert DJINN_THEME.styles["table.title"].bold is True
+    assert _style_color_value("table.category") == SECONDARY
+    assert _style_color_value("table.value") == MUTED
+    assert _style_color_value("status.enabled") == SUCCESS
+    assert _style_color_value("status.disabled") == WARNING
+    assert _style_color_value("status.error") == ERROR
+    assert _style_color_value("path") == PATH
+    assert _style_color_value("info") == INFO
+    assert DJINN_THEME.styles["info"].color is not None
+    assert DJINN_THEME.styles["info"].color.number == 4
+    assert DJINN_THEME.styles["info"].bold is not True
+    assert DJINN_THEME.styles["info.bold"].bold is True
+
+
+@pytest.mark.parametrize("hex_value", HEX_PALETTE_VALUES)
+def test_each_palette_hex_appears_once_in_theme_source(hex_value: str) -> None:
+    source = THEME_SOURCE.read_text(encoding="utf-8").casefold()
+    assert source.count(hex_value.casefold()) == 1
+
+
+@pytest.mark.parametrize(
+    "relative_directory",
+    [
+        Path("src") / "djinn_in_a_box" / "commands",
+        Path("src") / "djinn_in_a_box" / "cli",
+    ],
+)
+def test_no_command_or_cli_hex_color_literals(relative_directory: Path) -> None:
+    directory = ROOT / relative_directory
+    if not directory.exists():
+        return
+
+    matches: list[str] = []
+    for path in directory.rglob("*.py"):
+        for line_number, line in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
+            if HEX_COLOR_PATTERN.search(line):
+                matches.append(f"{path.relative_to(ROOT)}:{line_number}: {line.strip()}")
+
+    assert matches == []
+
+
+def _is_named_color_style_literal(value: str) -> bool:
+    tokens = value.strip().casefold().split()
+    if not tokens:
+        return False
+    if not any(token in NAMED_COLOR_STYLE_TOKENS for token in tokens):
+        return False
+    return all(
+        token in NAMED_COLOR_STYLE_TOKENS or token in RICH_STYLE_MODIFIER_TOKENS
+        for token in tokens
+    )
+
+
+@pytest.mark.parametrize(
+    "relative_directory",
+    [
+        Path("src") / "djinn_in_a_box" / "commands",
+        Path("src") / "djinn_in_a_box" / "cli",
+    ],
+)
+def test_no_command_or_cli_named_color_style_literals(relative_directory: Path) -> None:
+    directory = ROOT / relative_directory
+    if not directory.exists():
+        return
+
+    matches: list[str] = []
+    for path in directory.rglob("*.py"):
+        source = path.read_text(encoding="utf-8")
+        for line_number, line in enumerate(source.splitlines(), start=1):
+            if NAMED_COLOR_RICH_TAG_PATTERN.search(line):
+                matches.append(f"{path.relative_to(ROOT)}:{line_number}: {line.strip()}")
+        tree = ast.parse(source, filename=str(path))
+        for node in ast.walk(tree):
+            if (
+                isinstance(node, ast.Constant)
+                and isinstance(node.value, str)
+                and _is_named_color_style_literal(node.value)
+            ):
+                matches.append(f"{path.relative_to(ROOT)}:{node.lineno}: {node.value!r}")
+
+    assert matches == []

--- a/tests/test_docker.py
+++ b/tests/test_docker.py
@@ -1,5 +1,6 @@
 """Tests for djinn_in_a_box.core.docker module."""
 
+import os
 from collections.abc import Generator
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -13,6 +14,7 @@ from djinn_in_a_box.core.docker import (
     DockerMode,
     backup_sync_path,
     backup_volume,
+    build_compose_env,
     cleanup_docker_proxy,
     clear_sync_path,
     compose_build,
@@ -103,6 +105,49 @@ class TestGetComposeFiles:
         file_paths = [f for f in files if f != "-f"]
         assert any("docker-compose.yml" in f for f in file_paths)
         assert any("docker-compose.docker-direct.yml" in f for f in file_paths)
+
+
+class TestBuildComposeEnv:
+    """Tests for docker compose host interpolation environment."""
+
+    def test_sets_terminal_width_when_output_is_tty(self, tmp_path: Path) -> None:
+        config = AppConfig(code_dir=tmp_path)
+        stdout = MagicMock()
+        stdout.isatty.return_value = True
+        stderr = MagicMock()
+        stderr.isatty.return_value = False
+
+        with (
+            patch("djinn_in_a_box.core.docker.sys.stdout", stdout),
+            patch("djinn_in_a_box.core.docker.sys.stderr", stderr),
+            patch(
+                "djinn_in_a_box.core.docker.shutil.get_terminal_size",
+                return_value=os.terminal_size((123, 40)),
+            ),
+        ):
+            env = build_compose_env(config)
+
+        assert env["DJINN_TERM_WIDTH"] == "123"
+
+    def test_does_not_set_terminal_width_without_tty(self, tmp_path: Path) -> None:
+        config = AppConfig(code_dir=tmp_path)
+        stdout = MagicMock()
+        stdout.isatty.return_value = False
+        stderr = MagicMock()
+        stderr.isatty.return_value = False
+
+        with (
+            patch("djinn_in_a_box.core.docker.sys.stdout", stdout),
+            patch("djinn_in_a_box.core.docker.sys.stderr", stderr),
+            patch(
+                "djinn_in_a_box.core.docker.shutil.get_terminal_size",
+                return_value=os.terminal_size((80, 24)),
+            ) as get_terminal_size,
+        ):
+            env = build_compose_env(config)
+
+        assert "DJINN_TERM_WIDTH" not in env
+        get_terminal_size.assert_not_called()
 
 
 class TestGetShellMountArgs:

--- a/tests/test_entrypoint_mcp.py
+++ b/tests/test_entrypoint_mcp.py
@@ -4,15 +4,28 @@ from __future__ import annotations
 
 import json
 import os
+import shlex
 import shutil
 import subprocess
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 SCRIPT = ROOT / "scripts" / "mcp-register.sh"
+RAW_UI_MARKERS = ("✓", "⚠", "✗", "ℹ", "↻", "⊕", "✕")
 
 
-def run_register(tmp_path: Path, config: dict[str, object]) -> subprocess.CompletedProcess[str]:
+def assert_plain_startup_output(output: str) -> None:
+    assert "\x1b[" not in output
+    for marker in RAW_UI_MARKERS:
+        assert marker not in output
+
+
+def run_register(
+    tmp_path: Path,
+    config: dict[str, object],
+    env_updates: dict[str, str] | None = None,
+    bin_scripts: dict[str, str] | None = None,
+) -> subprocess.CompletedProcess[str]:
     config_path = tmp_path / "mcp-servers.json"
     config_path.write_text(json.dumps(config), encoding="utf-8")
 
@@ -21,6 +34,11 @@ def run_register(tmp_path: Path, config: dict[str, object]) -> subprocess.Comple
     curl = bin_dir / "curl"
     curl.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
     curl.chmod(0o755)
+    if bin_scripts is not None:
+        for name, content in bin_scripts.items():
+            script = bin_dir / name
+            script.write_text(content, encoding="utf-8")
+            script.chmod(0o755)
 
     jq = shutil.which("jq")
     assert jq is not None
@@ -32,14 +50,19 @@ def run_register(tmp_path: Path, config: dict[str, object]) -> subprocess.Comple
         "HOME": str(tmp_path),
         "CODEX_CONFIG": str(tmp_path / ".codex" / "config.toml"),
         "MCP_SERVERS_CONFIG": str(config_path),
+        "NO_COLOR": "1",
         "PATH": f"{bin_dir}:{Path(jq).parent}:/usr/bin:/bin",
     }
+    env.pop("DJINN_FORCE_UI_COLOR", None)
+    if env_updates is not None:
+        env.update(env_updates)
 
     return subprocess.run(
         [
             zsh,
             "-c",
-            f"set -euo pipefail; source {SCRIPT}; register_mcp_servers",
+            "set -euo pipefail; "
+            f"source {shlex.quote(str(SCRIPT))}; register_mcp_servers",
         ],
         check=False,
         capture_output=True,
@@ -72,14 +95,16 @@ def test_registers_each_canonical_server_individually(tmp_path: Path) -> None:
     )
 
     assert result.returncode == 0, result.stderr
-    assert "✓ docker-gateway (streamable-http)" in result.stdout
-    assert "✓ local-http (streamable-http)" in result.stdout
-    assert "- local-sse (disabled)" in result.stdout
+    assert result.stdout == ""
+    assert_plain_startup_output(result.stderr)
+    assert "[ok] docker-gateway (streamable-http)" in result.stderr
+    assert "[ok] local-http (streamable-http)" in result.stderr
+    assert "[off] local-sse (disabled)" in result.stderr
     assert (
         "Skipping invalid server name: local-sse\ndocker-gateway\nlocal-http"
-        not in result.stdout
+        not in result.stderr
     )
-    assert "Summary: 2 registered, 1 disabled, 0 skipped, 0 legacy" in result.stdout
+    assert "Summary: 2 registered, 1 disabled, 0 skipped, 0 legacy" in result.stderr
 
     codex_config = tmp_path / ".codex" / "config.toml"
     content = codex_config.read_text(encoding="utf-8")
@@ -108,10 +133,12 @@ def test_legacy_type_schema_is_normalized_with_warning(tmp_path: Path) -> None:
     )
 
     assert result.returncode == 0, result.stderr
-    assert "legacy 'type' key detected" in result.stdout
-    assert "✓ local-http (streamable-http)" in result.stdout
-    assert "✓ old-sse (sse)" in result.stdout
-    assert "Summary: 2 registered, 0 disabled, 0 skipped, 2 legacy" in result.stdout
+    assert result.stdout == ""
+    assert_plain_startup_output(result.stderr)
+    assert "legacy 'type' key detected" in result.stderr
+    assert "[ok] local-http (streamable-http)" in result.stderr
+    assert "[ok] old-sse (sse)" in result.stderr
+    assert "Summary: 2 registered, 0 disabled, 0 skipped, 2 legacy" in result.stderr
 
     codex_config = tmp_path / ".codex" / "config.toml"
     content = codex_config.read_text(encoding="utf-8")
@@ -148,6 +175,8 @@ trust_level = "trusted"
     )
 
     assert result.returncode == 0, result.stderr
+    assert result.stdout == ""
+    assert_plain_startup_output(result.stderr)
     content = codex_config.read_text(encoding="utf-8")
     assert content.count("[mcp_servers.local-http]") == 1
     assert 'url = "http://old.example/mcp"' not in content
@@ -170,5 +199,69 @@ def test_invalid_timeout_is_skipped(tmp_path: Path) -> None:
     )
 
     assert result.returncode == 0, result.stderr
-    assert "Skipping invalid tool_timeout_sec for local-http: soon" in result.stdout
-    assert "Summary: 0 registered, 0 disabled, 1 skipped, 0 legacy" in result.stdout
+    assert result.stdout == ""
+    assert_plain_startup_output(result.stderr)
+    assert "Skipping invalid tool_timeout_sec for local-http: soon" in result.stderr
+    assert "Summary: 0 registered, 0 disabled, 1 skipped, 0 legacy" in result.stderr
+
+
+def test_claude_mcp_output_is_boxed_without_changing_status_flow(tmp_path: Path) -> None:
+    result = run_register(
+        tmp_path,
+        {
+            "local-http": {
+                "transport": "streamable-http",
+                "url": "http://mcp.example:8847/mcp",
+                "enabled": True,
+            },
+        },
+        bin_scripts={
+            "claude": """#!/bin/sh
+if [ "$1" = "mcp" ] && [ "$2" = "remove" ]; then
+  printf 'Removed MCP server %s\\n' "$5"
+  printf 'File modified: %s/.claude.json\\n' "$HOME" >&2
+  exit 17
+fi
+if [ "$1" = "mcp" ] && [ "$2" = "add" ]; then
+  printf 'Added HTTP MCP server %s with URL: %s\\n' "$7" "$8"
+  exit 19
+fi
+exit 64
+""",
+        },
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout == ""
+    assert_plain_startup_output(result.stderr)
+    assert "  | Removed MCP server local-http" in result.stderr
+    assert f"  | File modified: {tmp_path}/.claude.json" in result.stderr
+    assert (
+        "  | Added HTTP MCP server local-http with URL: "
+        "http://mcp.example:8847/mcp"
+    ) in result.stderr
+    assert "\nRemoved MCP server local-http" not in result.stderr
+    assert "\nFile modified:" not in result.stderr
+    assert "\nAdded HTTP MCP server" not in result.stderr
+    assert "[ok] local-http (streamable-http)" in result.stderr
+    assert "Summary: 1 registered, 0 disabled, 0 skipped, 0 legacy" in result.stderr
+
+
+def test_plain_fallback_when_output_lib_is_absent(tmp_path: Path) -> None:
+    result = run_register(
+        tmp_path,
+        {
+            "local-http": {
+                "transport": "streamable-http",
+                "url": "http://mcp.example:8847/mcp",
+                "enabled": True,
+            },
+        },
+        {"OUTPUT_LIB": str(tmp_path / "missing-output-lib.sh")},
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout == ""
+    assert_plain_startup_output(result.stderr)
+    assert "[warn] output library not found" in result.stderr
+    assert "[ok] local-http (streamable-http)" in result.stderr

--- a/tests/test_output_lib.py
+++ b/tests/test_output_lib.py
@@ -1,0 +1,423 @@
+"""Tests for the sourceable shell output library."""
+
+from __future__ import annotations
+
+import os
+import re
+import shlex
+import shutil
+import subprocess
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "output-lib.sh"
+RAW_UI_MARKERS = ("✓", "⚠", "✗", "ℹ", "↻", "⊕", "✕", "🔒", "📡", "🌐")
+ANSI_RE = re.compile(r"\x1b\[[0-9;]*m")
+
+
+def assert_plain_startup_output(output: str) -> None:
+    assert "\x1b[" not in output
+    for marker in RAW_UI_MARKERS:
+        assert marker not in output
+
+
+def strip_ansi(output: str) -> str:
+    return ANSI_RE.sub("", output)
+
+
+def run_output_lib(env_updates: dict[str, str | None]) -> subprocess.CompletedProcess[str]:
+    zsh = shutil.which("zsh")
+    assert zsh is not None
+
+    env = {**os.environ}
+    for key, value in env_updates.items():
+        if value is None:
+            env.pop(key, None)
+        else:
+            env[key] = value
+
+    return subprocess.run(
+        [
+            zsh,
+            "-c",
+            (
+                f"set -euo pipefail; source {shlex.quote(str(SCRIPT))}; "
+                "ui_section 'Section'; ui_ok 'Ready'; ui_warn 'Careful'; "
+                "ui_err 'Broken'; ui_info 'Details'; ui_item '↻' 'Synced'"
+            ),
+        ],
+        check=False,
+        capture_output=True,
+        env=env,
+        text=True,
+    )
+
+
+def run_output_lib_command(
+    command: str, env_updates: dict[str, str | None]
+) -> subprocess.CompletedProcess[str]:
+    zsh = shutil.which("zsh")
+    assert zsh is not None
+
+    env = {**os.environ}
+    for key, value in env_updates.items():
+        if value is None:
+            env.pop(key, None)
+        else:
+            env[key] = value
+
+    return subprocess.run(
+        [
+            zsh,
+            "-c",
+            f"set -euo pipefail; source {shlex.quote(str(SCRIPT))}; {command}",
+        ],
+        check=False,
+        capture_output=True,
+        env=env,
+        text=True,
+    )
+
+
+def test_no_color_forces_plain_ascii_markers() -> None:
+    result = run_output_lib({"NO_COLOR": "1", "DJINN_FORCE_UI_COLOR": "1"})
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout == ""
+    assert_plain_startup_output(result.stderr)
+    assert "\n- Section" in result.stderr
+    assert "[ok] Ready" in result.stderr
+    assert "[warn] Careful" in result.stderr
+    assert "[err] Broken" in result.stderr
+    assert "[info] Details" in result.stderr
+    assert "[sync] Synced" in result.stderr
+
+
+def test_empty_no_color_still_allows_forced_ansi_256_color() -> None:
+    result = run_output_lib(
+        {"NO_COLOR": "", "DJINN_FORCE_UI_COLOR": "1", "COLORTERM": None}
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout == ""
+    assert "\x1b[38;5;24m" in result.stderr
+    assert "\n\x1b[38;5;24m─ " in result.stderr
+    assert "\x1b[38;5;155m✓\x1b[0m Ready" in result.stderr
+
+
+def test_non_tty_stderr_defaults_to_plain_ascii_markers() -> None:
+    result = run_output_lib({"NO_COLOR": None, "DJINN_FORCE_UI_COLOR": None})
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout == ""
+    assert "\x1b[" not in result.stderr
+    assert "[ok] Ready" in result.stderr
+    assert "[warn] Careful" in result.stderr
+    assert "[err] Broken" in result.stderr
+    assert "[info] Details" in result.stderr
+
+
+def test_force_ui_color_test_hook_emits_ansi_256_and_icons_without_colorterm() -> None:
+    result = run_output_lib(
+        {"NO_COLOR": None, "DJINN_FORCE_UI_COLOR": "1", "COLORTERM": None}
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout == ""
+    assert "\x1b[38;5;24m" in result.stderr
+    assert "\x1b[38;5;73mSection" in result.stderr
+    assert "\x1b[38;5;155m✓\x1b[0m Ready" in result.stderr
+    assert "\x1b[38;5;227m⚠\x1b[0m Careful" in result.stderr
+    assert "\x1b[38;5;203m✗\x1b[0m Broken" in result.stderr
+    assert "\x1b[0;34mℹ\x1b[0m Details" in result.stderr
+    assert "\x1b[0;34m↻\x1b[0m Synced" in result.stderr
+
+
+def test_force_ui_color_uses_truecolor_when_colorterm_supports_it() -> None:
+    result = run_output_lib(
+        {"NO_COLOR": None, "DJINN_FORCE_UI_COLOR": "1", "COLORTERM": "truecolor"}
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout == ""
+    assert "\x1b[38;2;41;82;109m" in result.stderr
+    assert "\x1b[38;2;105;185;161mSection" in result.stderr
+    assert "\x1b[38;2;193;255;98m✓\x1b[0m Ready" in result.stderr
+    assert "\x1b[0;34mℹ\x1b[0m Details" in result.stderr
+    assert "\x1b[0;34m↻\x1b[0m Synced" in result.stderr
+
+
+def test_ui_section_uses_full_columns_width() -> None:
+    result = run_output_lib(
+        {
+            "NO_COLOR": None,
+            "DJINN_FORCE_UI_COLOR": "1",
+            "COLORTERM": "truecolor",
+            "COLUMNS": "100",
+            "DJINN_TERM_WIDTH": None,
+        }
+    )
+
+    assert result.returncode == 0, result.stderr
+    section_line = strip_ansi(result.stderr).splitlines()[1]
+    assert section_line.startswith("─ Section ")
+    assert len(section_line) == 100
+
+
+def test_ui_section_prefers_djinn_term_width_over_columns() -> None:
+    result = run_output_lib(
+        {
+            "NO_COLOR": None,
+            "DJINN_FORCE_UI_COLOR": "1",
+            "COLORTERM": "truecolor",
+            "COLUMNS": "100",
+            "DJINN_TERM_WIDTH": "97",
+        }
+    )
+
+    assert result.returncode == 0, result.stderr
+    section_line = strip_ansi(result.stderr).splitlines()[1]
+    assert section_line.startswith("─ Section ")
+    assert len(section_line) == 97
+
+
+def test_ui_info_and_default_item_markers_are_basic_blue() -> None:
+    result = run_output_lib(
+        {"NO_COLOR": None, "DJINN_FORCE_UI_COLOR": "1", "COLORTERM": "truecolor"}
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "\x1b[0;34mℹ\x1b[0m Details" in result.stderr
+    assert "\x1b[0;34m↻\x1b[0m Synced" in result.stderr
+    assert "\x1b[38;2;134;8;184m↻" not in result.stderr
+    assert "\x1b[38;5;91m↻" not in result.stderr
+
+
+def test_ui_boxed_uses_muted_truecolor_for_head_body_and_foot() -> None:
+    result = run_output_lib_command(
+        "printf 'Removed MCP server local-http\\nFile modified: /home/dev/.claude.json\\n' | "
+        "ui_boxed 'claude mcp'",
+        {"NO_COLOR": None, "DJINN_FORCE_UI_COLOR": "1", "COLORTERM": "truecolor"},
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout == ""
+    muted = "\x1b[38;2;51;54;118m"
+    lines = result.stderr.splitlines()
+    assert lines[0].startswith(f"  {muted}╭─\x1b[0m claude mcp {muted}─")
+    assert lines[1] == f"  {muted}│\x1b[0m Removed MCP server local-http"
+    assert lines[2] == f"  {muted}│\x1b[0m File modified: /home/dev/.claude.json"
+    assert lines[3].startswith(f"  {muted}╰")
+
+
+def test_ui_boxed_uses_muted_ansi_256_without_truecolor() -> None:
+    result = run_output_lib_command(
+        "printf 'Added HTTP MCP server local-http with URL: http://mcp.example:8847/mcp\\n' | "
+        "ui_boxed 'claude mcp'",
+        {"NO_COLOR": None, "DJINN_FORCE_UI_COLOR": "1", "COLORTERM": None},
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout == ""
+    assert "\x1b[38;5;60m╭─\x1b[0m claude mcp \x1b[38;5;60m─" in result.stderr
+    assert (
+        "\x1b[38;5;60m│\x1b[0m Added HTTP MCP server local-http with URL: "
+        "http://mcp.example:8847/mcp"
+    ) in result.stderr
+    assert "\x1b[38;5;60m╰" in result.stderr
+
+
+def test_ui_boxed_plain_mode_uses_ascii_frame() -> None:
+    result = run_output_lib_command(
+        "printf 'Removed MCP server local-http\\n' | ui_boxed 'claude mcp'",
+        {"NO_COLOR": "1", "DJINN_FORCE_UI_COLOR": "1"},
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout == ""
+    assert result.stderr.splitlines() == [
+        "  +- claude mcp ----------------------------",
+        "  | Removed MCP server local-http",
+        "  +---------------------------------------",
+    ]
+
+
+def test_ui_boxed_empty_input_renders_nothing() -> None:
+    result = run_output_lib_command(
+        "printf '' | ui_boxed 'claude mcp'",
+        {"NO_COLOR": None, "DJINN_FORCE_UI_COLOR": "1", "COLORTERM": "truecolor"},
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout == ""
+    assert result.stderr == ""
+
+
+def test_ui_boxed_long_line_has_no_right_edge() -> None:
+    long_url = "http://mcp.example:8847/" + ("very-long-path/" * 12) + "mcp"
+    result = run_output_lib_command(
+        f"printf '%s\\n' {shlex.quote(long_url)} | ui_boxed 'claude mcp'",
+        {"NO_COLOR": None, "DJINN_FORCE_UI_COLOR": "1", "COLORTERM": "truecolor"},
+    )
+
+    assert result.returncode == 0, result.stderr
+    body_line = strip_ansi(result.stderr).splitlines()[1]
+    assert body_line == f"  │ {long_url}"
+    assert not body_line.endswith("│")
+
+
+def test_entrypoint_continues_with_plain_startup_messages_when_output_lib_absent(
+    tmp_path: Path,
+) -> None:
+    zsh = shutil.which("zsh")
+    assert zsh is not None
+
+    missing_output_lib = tmp_path / "missing-output-lib.sh"
+    missing_seed_lib = tmp_path / "missing-seed-lib.sh"
+    env = {
+        **os.environ,
+        "HOME": str(tmp_path),
+        "OUTPUT_LIB": str(missing_output_lib),
+        "SEED_LIB": str(missing_seed_lib),
+        "ENABLE_FIREWALL": "false",
+    }
+
+    result = subprocess.run(
+        [zsh, "-n", str(ROOT / "scripts" / "entrypoint.sh")],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stderr
+
+    result = subprocess.run(
+        [zsh, str(ROOT / "scripts" / "entrypoint.sh")],
+        check=False,
+        capture_output=True,
+        env=env,
+        text=True,
+    )
+
+    assert result.returncode == 1
+    assert "[warn] output library not found" in result.stderr
+    assert "[info] Seed & Config" in result.stderr
+    assert "[err] seed library not found" in result.stderr
+
+
+def test_entrypoint_security_section_uses_plain_ascii_markers(tmp_path: Path) -> None:
+    zsh = shutil.which("zsh")
+    jq = shutil.which("jq")
+    assert zsh is not None
+    assert jq is not None
+
+    mcp_config = tmp_path / "mcp-servers.json"
+    mcp_config.write_text("{}", encoding="utf-8")
+
+    env = {
+        **os.environ,
+        "HOME": str(tmp_path),
+        "OUTPUT_LIB": str(ROOT / "scripts" / "output-lib.sh"),
+        "SEED_LIB": str(ROOT / "scripts" / "seed-lib.sh"),
+        "MCP_REGISTER": str(ROOT / "scripts" / "mcp-register.sh"),
+        "MCP_SERVERS_CONFIG": str(mcp_config),
+        "NO_COLOR": "1",
+        "ENABLE_FIREWALL": "false",
+        "DOCKER_DIRECT": "false",
+        "PATH": f"{Path(jq).parent}:{os.environ['PATH']}",
+    }
+    env.pop("DOCKER_HOST", None)
+    env.pop("DJINN_FORCE_UI_COLOR", None)
+
+    result = subprocess.run(
+        [zsh, str(ROOT / "scripts" / "entrypoint.sh"), "-c", "true"],
+        check=False,
+        capture_output=True,
+        env=env,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout == ""
+    assert_plain_startup_output(result.stderr)
+    assert "\n- Security" in result.stderr
+    assert "[warn] Firewall:     Disabled" in result.stderr
+    assert "[warn] Docker Access: Disabled" in result.stderr
+    assert "[info] Enable with: djinn start --docker" in result.stderr
+    assert "[warn] MCP Gateway:  Not connected" in result.stderr
+
+
+def test_firewall_startup_uses_plain_ascii_markers(tmp_path: Path) -> None:
+    bash = shutil.which("bash")
+    assert bash is not None
+
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    iptables = bin_dir / "iptables"
+    iptables.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+    iptables.chmod(0o755)
+    getent = bin_dir / "getent"
+    getent.write_text(
+        "#!/bin/sh\n"
+        "if [ \"$1\" = \"ahostsv4\" ]; then\n"
+        "  printf '203.0.113.10 STREAM %s\\n' \"$2\"\n"
+        "  exit 0\n"
+        "fi\n"
+        "exec /usr/bin/getent \"$@\"\n",
+        encoding="utf-8",
+    )
+    getent.chmod(0o755)
+
+    env = {
+        **os.environ,
+        "OUTPUT_LIB": str(ROOT / "scripts" / "output-lib.sh"),
+        "NO_COLOR": "1",
+        "PATH": f"{bin_dir}:/usr/bin:/bin",
+    }
+    env.pop("DJINN_FORCE_UI_COLOR", None)
+
+    result = subprocess.run(
+        [bash, str(ROOT / "scripts" / "init-firewall.sh")],
+        check=False,
+        capture_output=True,
+        env=env,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout == ""
+    assert_plain_startup_output(result.stderr)
+    assert "[info] Initializing firewall..." in result.stderr
+    assert "[ok] Allowed network: 172.16.0.0/12" in result.stderr
+    assert "[ok] Allowed: registry.npmjs.org (203.0.113.10)" in result.stderr
+    assert "[ok] Firewall initialized. Outbound traffic restricted to whitelist." in result.stderr
+
+
+def test_output_lib_is_bash_compatible_and_resource_safe() -> None:
+    """The lib is sourced by zsh (container) AND bash (host scripts like
+    update-agents.sh); a re-source must not trip the readonly constants."""
+    bash = shutil.which("bash")
+    assert bash is not None
+
+    syntax = subprocess.run(
+        [bash, "-n", str(ROOT / "scripts" / "output-lib.sh")],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert syntax.returncode == 0, syntax.stderr
+
+    script = (
+        f'source "{ROOT}/scripts/output-lib.sh" && '
+        f'source "{ROOT}/scripts/output-lib.sh" && '
+        'DJINN_FORCE_UI_COLOR=1 ui_ok "bash works" && COLUMNS=50 ui_section "Test"'
+    )
+    result = subprocess.run(
+        [bash, "-c", script],
+        check=False,
+        capture_output=True,
+        text=True,
+        env={"PATH": "/usr/bin:/bin"},
+    )
+    assert result.returncode == 0, result.stderr
+    assert "bash works" in result.stderr
+    assert "Test" in result.stderr

--- a/tests/test_seed_lib.py
+++ b/tests/test_seed_lib.py
@@ -11,6 +11,14 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 SCRIPT = ROOT / "scripts" / "seed-lib.sh"
+OUTPUT_LIB = ROOT / "scripts" / "output-lib.sh"
+RAW_UI_MARKERS = ("✓", "⚠", "✗", "ℹ", "↻", "⊕", "✕")
+
+
+def assert_plain_startup_output(output: str) -> None:
+    assert "\x1b[" not in output
+    for marker in RAW_UI_MARKERS:
+        assert marker not in output
 
 
 def run_seed_lib(tmp_path: Path, command: str) -> subprocess.CompletedProcess[str]:
@@ -22,14 +30,18 @@ def run_seed_lib(tmp_path: Path, command: str) -> subprocess.CompletedProcess[st
     env = {
         **os.environ,
         "HOME": str(tmp_path),
+        "NO_COLOR": "1",
         "PATH": f"{Path(jq).parent}:/usr/bin:/bin",
     }
+    env.pop("DJINN_FORCE_UI_COLOR", None)
 
     return subprocess.run(
         [
             zsh,
             "-c",
-            f"set -euo pipefail; source {shlex.quote(str(SCRIPT))}; {command}",
+            "set -euo pipefail; "
+            f"source {shlex.quote(str(OUTPUT_LIB))}; "
+            f"source {shlex.quote(str(SCRIPT))}; {command}",
         ],
         check=False,
         capture_output=True,
@@ -40,6 +52,35 @@ def run_seed_lib(tmp_path: Path, command: str) -> subprocess.CompletedProcess[st
 
 def write_json(path: Path, data: dict[str, object]) -> None:
     path.write_text(json.dumps(data), encoding="utf-8")
+
+
+def test_sync_seed_uses_plain_ascii_markers_for_seed_sync_path(tmp_path: Path) -> None:
+    seed_dir = tmp_path / "seed"
+    target_dir = tmp_path / "target"
+    (seed_dir / "commands").mkdir(parents=True)
+    target_dir.mkdir()
+    (seed_dir / "commands" / "build.md").write_text("build\n", encoding="utf-8")
+    (seed_dir / "notes.md").write_text("notes\n", encoding="utf-8")
+    write_json(seed_dir / "settings.json", {"seed": True})
+    write_json(target_dir / "settings.json", {"volume": True})
+    (target_dir / "old.md").write_text("old\n", encoding="utf-8")
+    (target_dir / ".seed-manifest").write_text("old.md\n", encoding="utf-8")
+
+    result = run_seed_lib(
+        tmp_path,
+        "sync_seed "
+        f"gemini {shlex.quote(str(seed_dir))} {shlex.quote(str(target_dir))} "
+        f"{shlex.quote(str(target_dir / 'settings.json'))}",
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout == ""
+    assert_plain_startup_output(result.stderr)
+    assert "[info] [seed-sync] gemini:" in result.stderr
+    assert "[sync] commands/" in result.stderr
+    assert "[sync] notes.md" in result.stderr
+    assert "[stale] old.md (stale)" in result.stderr
+    assert "[merge] settings.json (merged)" in result.stderr
 
 
 def test_minimal_claude_seed_without_skills_dir_merges_settings(tmp_path: Path) -> None:
@@ -94,6 +135,8 @@ def test_claude_settings_local_overlay_wins_over_baseline(tmp_path: Path) -> Non
     )
 
     assert result.returncode == 0, result.stderr
+    assert_plain_startup_output(result.stderr)
+    assert "[merge] settings.json (baseline + local)" in result.stderr
     merged = json.loads(target_settings.read_text(encoding="utf-8"))
     assert merged == {
         "env": {"mode": "local", "kept": True},

--- a/tests/test_ws2_defaults.py
+++ b/tests/test_ws2_defaults.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import yaml
+
 from djinn_in_a_box.config.defaults import SYNC_PATHS
 from djinn_in_a_box.config.models import AppConfig, ResourceLimits
 
@@ -28,6 +30,15 @@ def test_compose_defaults_are_generic() -> None:
     assert "pulumi" not in compose_text
     assert "sops" not in compose_text
     assert "DBUS" not in compose_text
+
+
+def test_compose_common_environment_forwards_terminal_ui_env() -> None:
+    compose_file = project_root() / "docker-compose.yml"
+    compose = yaml.safe_load(compose_file.read_text())
+
+    common_env = compose["x-common-environment"]
+    assert common_env["NO_COLOR"] == "${NO_COLOR:-}"
+    assert common_env["DJINN_TERM_WIDTH"] == "${DJINN_TERM_WIDTH:-}"
 
 
 def test_app_config_default_timezone_is_utc(tmp_path: Path) -> None:

--- a/tools/install.sh
+++ b/tools/install.sh
@@ -12,6 +12,20 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 TOOLS_FILE="${TOOLS_FILE:-$SCRIPT_DIR/tools.txt}"
 CACHE_DIR="$HOME/.cache/djinn-tools"
 INSTALLERS_DIR="$SCRIPT_DIR/installers"
+OUTPUT_LIB="${OUTPUT_LIB:-/home/dev/output-lib.sh}"
+
+define_plain_ui_fallbacks() {
+    ui_info() { echo "[info] $1" >&2; }
+    ui_ok() { echo "[ok] $1" >&2; }
+    ui_warn() { echo "[warn] $1" >&2; }
+    ui_err() { echo "[err] $1" >&2; }
+}
+
+if [[ -r "$OUTPUT_LIB" ]] && source "$OUTPUT_LIB"; then
+    :
+else
+    define_plain_ui_fallbacks
+fi
 
 # Persistent tool directories (available to all installers)
 export TOOLS_DIR="$CACHE_DIR"
@@ -43,7 +57,7 @@ if [[ -z "$tools" ]]; then
     exit 0
 fi
 
-echo "[tools] Checking optional tools..."
+ui_info "[tools] Checking optional tools..."
 
 installed=0
 skipped=0
@@ -53,7 +67,7 @@ for tool in $tools; do
     cache_marker="$CACHE_DIR/${tool}.installed"
 
     if [[ ! -f "$installer" ]]; then
-        echo "[tools] Unknown tool: $tool (no installer found)"
+        ui_warn "[tools] Unknown tool: $tool (no installer found)"
         continue
     fi
 
@@ -70,25 +84,25 @@ for tool in $tools; do
         fi
         # Loud diagnostic: without it a nonconforming installer (binary name !=
         # installer name, or no --version) reinstalls silently on EVERY start.
-        echo "[tools] Cache check failed for $tool ($bin_path missing or '--version' failed) — reinstalling"
+        ui_warn "[tools] Cache check failed for $tool ($bin_path missing or '--version' failed) — reinstalling"
         rm -f "$cache_marker"
     fi
 
-    echo "[tools] Installing $tool..."
+    ui_info "[tools] Installing $tool..."
 
     if output=$("$installer" 2>&1); then
         version=$(echo "$output" | tail -1)
         echo "$version" > "$cache_marker"
-        echo "[tools] ✓ $tool installed ($version)"
+        ui_ok "[tools] $tool installed ($version)"
         installed=$((installed + 1))
     else
-        echo "[tools] ✗ Failed to install $tool"
+        ui_err "[tools] Failed to install $tool"
         echo "$output" | tail -3 | sed 's/^/    /'
     fi
 done
 
 if [[ $installed -gt 0 ]]; then
-    echo "[tools] $installed tool(s) installed, $skipped already installed"
+    ui_ok "[tools] $installed tool(s) installed, $skipped already installed"
 elif [[ $skipped -gt 0 ]]; then
-    echo "[tools] $skipped tool(s) already installed (cached)"
+    ui_ok "[tools] $skipped tool(s) already installed (cached)"
 fi


### PR DESCRIPTION
The CLI output is the product's UI — this lands one coherent design system across it.

- **feat(theme)**: eight single-source palette constants behind semantic roles (incl. terminal-adaptive ANSI-blue info and a path role); rule() helper; test gates against color literals in command modules
- **feat(banner)**: Braille djinn banner with gradient and a strict degradation chain (full → wordmark → plain title)
- **feat(startup)**: rules-based sections across both output worlds — Python pre-compose framing + a zsh/bash-portable shell UI library (truecolor with ANSI-256 fallback, NO_COLOR per no-color.org, host terminal width propagated for deterministic rule width, boxed frame for captured third-party output)
- **refactor(ui)**: every djinn command and the mcpgateway CLI adopt the system; CLI_DESIGN_SYSTEM.md documents it

405 tests, ruff/pyright clean, zsh+bash syntax-checked. Live terminal sign-off completed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)