### PR TITLE
fix: verify cached tools via declared command, not assumed --version

### DIFF
--- a/tests/test_tools_install.py
+++ b/tests/test_tools_install.py
@@ -1,0 +1,163 @@
+"""Regression tests for the optional tools installer cache checks."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import textwrap
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "tools" / "install.sh"
+
+
+def write_executable(path: Path, content: str) -> None:
+    path.write_text(textwrap.dedent(content).lstrip(), encoding="utf-8")
+    path.chmod(0o755)
+
+
+def write_install_fixture(tmp_path: Path, tools: list[str]) -> tuple[Path, Path, Path]:
+    home = tmp_path / "home"
+    cache_dir = tmp_path / "cache"
+    installers_dir = tmp_path / "installers"
+    tools_file = tmp_path / "tools.txt"
+
+    home.mkdir()
+    (cache_dir / "bin").mkdir(parents=True)
+    (cache_dir / "lib").mkdir()
+    installers_dir.mkdir()
+    tools_file.write_text("\n".join(tools) + "\n", encoding="utf-8")
+
+    build_timestamp = "test-build\n"
+    (home / ".build-timestamp").write_text(build_timestamp, encoding="utf-8")
+    (cache_dir / ".build-timestamp").write_text(build_timestamp, encoding="utf-8")
+
+    return home, cache_dir, installers_dir
+
+
+def run_install(
+    home: Path,
+    cache_dir: Path,
+    installers_dir: Path,
+    tools_file: Path,
+) -> subprocess.CompletedProcess[str]:
+    env = {
+        **os.environ,
+        "HOME": str(home),
+        "TOOLS_FILE": str(tools_file),
+        "CACHE_DIR": str(cache_dir),
+        "INSTALLERS_DIR": str(installers_dir),
+        "OUTPUT_LIB": str(home / "missing-output-lib.sh"),
+        "NO_COLOR": "1",
+    }
+    env.pop("DJINN_FORCE_UI_COLOR", None)
+
+    return subprocess.run(
+        ["bash", str(SCRIPT)],
+        check=False,
+        capture_output=True,
+        env=env,
+        text=True,
+    )
+
+
+def test_verify_override_skips_cached_tool_with_nonmatching_binary_name(
+    tmp_path: Path,
+) -> None:
+    tools_file = tmp_path / "tools.txt"
+    home, cache_dir, installers_dir = write_install_fixture(tmp_path, ["azure-cli"])
+    (cache_dir / "azure-cli.installed").write_text("cached\n", encoding="utf-8")
+
+    write_executable(
+        cache_dir / "bin" / "az",
+        """
+        #!/bin/bash
+        if [[ "${1:-}" == "version" ]]; then
+            echo "azure-cli 1.0"
+            exit 0
+        fi
+        exit 2
+        """,
+    )
+    write_executable(
+        installers_dir / "azure-cli.sh",
+        """
+        #!/bin/bash
+        # djinn-verify: az version
+        touch "$TOOLS_DIR/azure-cli-reinstalled"
+        echo "azure-cli installed"
+        """,
+    )
+
+    result = run_install(home, cache_dir, installers_dir, tools_file)
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout == ""
+    assert "[ok] [tools] 1 tool(s) already installed (cached)" in result.stderr
+    assert "[tools] Installing azure-cli" not in result.stderr
+    assert not (cache_dir / "azure-cli-reinstalled").exists()
+
+
+def test_fallback_verify_skips_cached_conforming_tool(tmp_path: Path) -> None:
+    tools_file = tmp_path / "tools.txt"
+    home, cache_dir, installers_dir = write_install_fixture(tmp_path, ["bun"])
+    (cache_dir / "bun.installed").write_text("cached\n", encoding="utf-8")
+
+    write_executable(
+        cache_dir / "bin" / "bun",
+        """
+        #!/bin/bash
+        if [[ "${1:-}" == "--version" ]]; then
+            echo "bun 1.0"
+            exit 0
+        fi
+        exit 2
+        """,
+    )
+    write_executable(
+        installers_dir / "bun.sh",
+        """
+        #!/bin/bash
+        touch "$TOOLS_DIR/bun-reinstalled"
+        echo "bun installed"
+        """,
+    )
+
+    result = run_install(home, cache_dir, installers_dir, tools_file)
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout == ""
+    assert "[ok] [tools] 1 tool(s) already installed (cached)" in result.stderr
+    assert "[tools] Installing bun" not in result.stderr
+    assert not (cache_dir / "bun-reinstalled").exists()
+
+
+def test_failed_verify_reinstalls_and_warns(tmp_path: Path) -> None:
+    tools_file = tmp_path / "tools.txt"
+    home, cache_dir, installers_dir = write_install_fixture(tmp_path, ["broken-tool"])
+    (cache_dir / "broken-tool.installed").write_text("cached\n", encoding="utf-8")
+
+    write_executable(
+        installers_dir / "broken-tool.sh",
+        """
+        #!/bin/bash
+        cat > "$TOOLS_BIN/broken-tool" <<'EOF'
+        #!/bin/bash
+        echo "broken-tool 1.0"
+        EOF
+        chmod +x "$TOOLS_BIN/broken-tool"
+        touch "$TOOLS_DIR/broken-tool-reinstalled"
+        echo "broken-tool 1.0"
+        """,
+    )
+
+    result = run_install(home, cache_dir, installers_dir, tools_file)
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout == ""
+    assert "[warn] [tools] Cache check failed for broken-tool" in result.stderr
+    assert "verify command failed:" in result.stderr
+    assert "broken-tool --version" in result.stderr
+    assert "[info] [tools] Installing broken-tool" in result.stderr
+    assert "[ok] [tools] broken-tool installed (broken-tool 1.0)" in result.stderr
+    assert (cache_dir / "broken-tool-reinstalled").exists()

--- a/tools/install.sh
+++ b/tools/install.sh
@@ -10,8 +10,8 @@ set -e
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 TOOLS_FILE="${TOOLS_FILE:-$SCRIPT_DIR/tools.txt}"
-CACHE_DIR="$HOME/.cache/djinn-tools"
-INSTALLERS_DIR="$SCRIPT_DIR/installers"
+CACHE_DIR="${CACHE_DIR:-$HOME/.cache/djinn-tools}"
+INSTALLERS_DIR="${INSTALLERS_DIR:-$SCRIPT_DIR/installers}"
 OUTPUT_LIB="${OUTPUT_LIB:-/home/dev/output-lib.sh}"
 
 define_plain_ui_fallbacks() {
@@ -71,20 +71,32 @@ for tool in $tools; do
         continue
     fi
 
-    # Check cache: marker exists AND binary executes successfully.
-    # Convention: the installer name matches the binary name and the binary
-    # supports --version (installers with different semantics should implement
-    # their own idempotence check).
+    # Check cache: marker exists AND the verify command succeeds.
+    # Default convention: the installer name matches the binary name and the
+    # binary supports --version. Installers with different semantics can declare
+    # an override near the top of the installer script:
+    #   # djinn-verify: <command>
     if [[ -f "$cache_marker" ]]; then
-        bin_path="$TOOLS_BIN/$tool"
-        version_cmd=("$bin_path" --version)
-        if [[ -f "$bin_path" ]] && "${version_cmd[@]}" &>/dev/null; then
+        verify_label=""
+        verify_cmd=()
+        if verify_line=$(grep -m 1 '^# djinn-verify:' "$installer"); then
+            verify_label="${verify_line#\# djinn-verify:}"
+            read -ra verify_cmd <<< "$verify_label"
+            verify_label="${verify_cmd[*]}"
+        else
+            bin_path="$TOOLS_BIN/$tool"
+            verify_cmd=("$bin_path" --version)
+            verify_label="${verify_cmd[*]}"
+        fi
+
+        if [[ ${#verify_cmd[@]} -gt 0 ]] && "${verify_cmd[@]}" &>/dev/null; then
             skipped=$((skipped + 1))
             continue
         fi
-        # Loud diagnostic: without it a nonconforming installer (binary name !=
-        # installer name, or no --version) reinstalls silently on EVERY start.
-        ui_warn "[tools] Cache check failed for $tool ($bin_path missing or '--version' failed) — reinstalling"
+        # Loud diagnostic: without it a stale or incorrect verifier can reinstall
+        # silently on EVERY start.
+        ui_warn \
+            "[tools] Cache check failed for $tool (verify command failed: $verify_label) — reinstalling"
         rm -f "$cache_marker"
     fi
 


### PR DESCRIPTION
## Problem

The startup tools installer (`tools/install.sh`) skipped a reinstall only when
`"$TOOLS_BIN/<tool>" --version` succeeded. Two installers break that assumption and
therefore reinstalled on **every** container start (expensive network downloads):

- **azure-cli** installs a binary named `az`, so `$TOOLS_BIN/azure-cli` never exists.
- **pulumi** has no `--version` flag (it uses the `pulumi version` subcommand), so the
  check always failed.

The marker file was present in both cases; only the hard-coded binary verification failed.

## Fix

- Introduce an optional installer-header directive `# djinn-verify: <command>` that declares
  the verification command. When absent, the existing `$TOOLS_BIN/<tool> --version` convention
  is used as a fallback, so the conforming installers (bun, playwright, psql) are unaffected.
- Parsing is `set -e`-safe (guarded `grep`) and uses `read -ra` — no `eval`.
- Make `CACHE_DIR` / `INSTALLERS_DIR` env-overridable (same treatment as `TOOLS_FILE` /
  `OUTPUT_LIB`) so the behavior is hermetically testable.
- Add `tests/test_tools_install.py`: override-skip, fallback-skip, and genuine-failure-reinstall.

The two affected installer scripts live outside this repo (privately synced); they need the
matching header line (`# djinn-verify: az version` / `# djinn-verify: pulumi version`) plus an
image rebuild for the fix to take effect at runtime.

## Verification

- `bash -n tools/install.sh` — passes
- `uv run ruff check src/ tests/` — passes
- `uv run pytest` — 408 passed
- End-to-end with the real `az` / `pulumi` binaries: with the header the tools are skipped
  (cached); without it the original per-start reinstall is reproduced exactly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
