### PR TITLE
fix(credentials): persist age identities across container runs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ Versioning before and after the first stable release.
 
 ### Added
 
+- Persistent `age` encryption identity store: `${DJINN_CONFIG_ROOT}/age` is
+  provisioned as a credential directory and bind-mounted at `~/.config/age`, so
+  `age` keys survive container restarts and are captured by `djinn backup`
+  (SOPS users set `SOPS_AGE_KEY_FILE` to a key under that path).
 - Shared CLI output design system with a central palette, semantic Rich roles,
   path styling, and terminal-adaptive informational output.
 - Startup banner with degraded wordmark and plain-text modes for narrow,
@@ -31,6 +35,15 @@ Versioning before and after the first stable release.
   example Azure CLI's `az` binary and Pulumi's `version` subcommand). Installer
   scripts can declare a `# djinn-verify: <command>` header; the cache check
   falls back to `<tool> --version` when the header is absent.
+
+### Security
+
+- Credential directories under the config root are created with mode `0700`,
+  matching the `~/.ssh` precedent. The mode applies on creation only; existing
+  directories are not tightened retroactively.
+- Documented the credential trust model: credentials are stored unencrypted,
+  are readable by every agent in the container, and `djinn backup` archives are
+  unencrypted.
 
 ## [0.1.0] - 2026-07-03
 

--- a/IMPLEMENTATION.md
+++ b/IMPLEMENTATION.md
@@ -290,6 +290,8 @@ variable is left to inherited host environment or Compose defaults.
 the Docker daemon does not auto-create missing paths as root-owned directories.
 It creates credential subdirectories from `SYNC_PATHS["credentials"]`,
 `~/.djinn/sessions`, `~/.djinn/backups`, `~/.ssh`, and `~/.gitconfig`.
+Credential subdirectories and `~/.ssh` are created with mode `0700`. The mode
+applies on creation only; directories that already exist are left unchanged.
 
 ## Host-Side Seeding
 
@@ -394,6 +396,7 @@ Common mounts include:
 - `${DJINN_CONFIG_ROOT}/codex` to `/home/dev/.codex`
 - `${DJINN_CONFIG_ROOT}/opencode` to `/home/dev/.opencode`
 - `${DJINN_CONFIG_ROOT}/gh` to `/home/dev/.config/gh`
+- `${DJINN_CONFIG_ROOT}/age` to `/home/dev/.config/age`
 - named volumes for caches, OpenCode data, VS Code server state, and workspace
   metadata
 - read-only `~/.ssh` and `~/.gitconfig`
@@ -552,7 +555,7 @@ Category definitions come from `config/defaults.py`:
   `djinn-vscode-server`
 - `VOLUME_CATEGORIES["data"]`: `djinn-opencode-data`,
   `djinn-vscode-workspaces`
-- `SYNC_PATHS["credentials"]`: `claude`, `gemini`, `codex`, `opencode`, `gh`
+- `SYNC_PATHS["credentials"]`: `claude`, `gemini`, `codex`, `opencode`, `gh`, `age`
 - `SYNC_PATHS["repo-dotfiles"]`: `repo-dotfiles`
 
 `backup()` refuses to run while Djinn containers are active. It stages one

--- a/README.md
+++ b/README.md
@@ -36,7 +36,9 @@ Djinn gives you one repeatable container image and several ways to use it:
 Credentials are separated by CLI. By default, Claude Code, Gemini CLI, Codex CLI,
 OpenCode, and the GitHub CLI each get their own host directory under the
 configured Djinn config root. The container sees those directories at the paths
-each CLI expects.
+each CLI expects. An `age` encryption identity directory is provisioned the same
+way and appears at `~/.config/age`, so plain `age` keys persist across runs
+(`age -i ~/.config/age/keys.txt`); SOPS users set `SOPS_AGE_KEY_FILE` to that path.
 
 ## Requirements
 
@@ -323,6 +325,7 @@ Bind mounts are host paths that you can inspect and manage directly:
 | `${DJINN_CONFIG_ROOT}/codex` | `/home/dev/.codex` | Codex CLI credentials and state |
 | `${DJINN_CONFIG_ROOT}/opencode` | `/home/dev/.opencode` | OpenCode state |
 | `${DJINN_CONFIG_ROOT}/gh` | `/home/dev/.config/gh` | GitHub CLI state |
+| `${DJINN_CONFIG_ROOT}/age` | `/home/dev/.config/age` | age encryption identities (`keys.txt`) |
 | `${CODE_DIR}` | `/home/dev/projects` | Your projects directory |
 | `${HOME}/.djinn/sessions` | `/home/dev/sessions` | Session workspaces |
 | `~/.ssh` | `/home/dev/.ssh:ro` | Read-only SSH access |
@@ -348,6 +351,29 @@ Named volumes are Docker-managed and host-local:
 The backup command includes credentials, repo-dotfiles, and data by default. It
 does not include cache volumes unless you explicitly request the `cache`
 category.
+
+## Credential Security
+
+Djinn isolates credentials per CLI. It does not encrypt them. Understand the
+model before you store a high-value key such as an `age` identity.
+
+- **Cleartext on the host.** Credential directories under the config root are
+  ordinary files guarded by filesystem permissions. Djinn creates new credential
+  directories with mode `0700`. Directories that already exist are not tightened
+  retroactively.
+- **Readable by every agent in the container.** Each credential is mounted where
+  its tool expects it, so the `dev` user — and therefore every coding agent you
+  run — can read all of them. An `age` identity is a master decryption key. An
+  agent running in write mode (`--dangerously-skip-permissions`, `--full-auto`)
+  acts without approval, so a prompt injection reaching that agent can read the
+  key. Run `djinn start --firewall` when an agent processes untrusted content, so
+  a leaked secret cannot be sent outbound.
+- **Backups are unencrypted.** `djinn backup` writes a plain `tar.gz` under
+  `~/.djinn/backups/` that contains the credential directories. Protect that
+  directory as carefully as the credentials themselves.
+
+Read [DOCKER-SOCKET-SECURITY.md](DOCKER-SOCKET-SECURITY.md) before enabling
+Docker socket access, which widens this surface further.
 
 ## Resources
 
@@ -397,7 +423,7 @@ djinn backup
 By default, this backs up:
 
 - `credentials`: config-root directories for Claude Code, Gemini CLI, Codex CLI,
-  OpenCode, and the GitHub CLI
+  OpenCode, the GitHub CLI, and the `age` encryption identity store
 - `repo-dotfiles`: the optional config-root `repo-dotfiles` directory if present
 - `data`: the OpenCode data and VS Code workspace named volumes
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,6 +25,8 @@ x-common-volumes: &common-volumes
   - ${DJINN_CONFIG_ROOT}/opencode:/home/dev/.opencode
   - opencode-data:/home/dev/.local/share/opencode
   - ${DJINN_CONFIG_ROOT}/gh:/home/dev/.config/gh
+  # age encryption identities (e.g. age -i ~/.config/age/keys.txt)
+  - ${DJINN_CONFIG_ROOT}/age:/home/dev/.config/age
   # Cache (host-local named volumes, rebuildable)
   - uv-cache:/home/dev/.cache/uv
   - tools-cache:/home/dev/.cache/djinn-tools

--- a/docs/sync-across-machines.md
+++ b/docs/sync-across-machines.md
@@ -70,7 +70,7 @@ djinn restore
 ```
 
 By default, `djinn backup` archives existing credential/config-root paths
-(`claude`, `gemini`, `codex`, `opencode`, `gh`), `repo-dotfiles`, and data
+(`claude`, `gemini`, `codex`, `opencode`, `gh`, `age`), `repo-dotfiles`, and data
 volumes (`djinn-opencode-data`, `djinn-vscode-workspaces`). Cache volumes are
 not included by default because they are rebuildable.
 

--- a/src/djinn_in_a_box/commands/container.py
+++ b/src/djinn_in_a_box/commands/container.py
@@ -518,7 +518,7 @@ def clean_volumes(
         bool,
         typer.Option(
             "--credentials",
-            help="Clear credential sync paths (claude, gemini, codex, opencode, gh)",
+            help="Clear credential sync paths (claude, gemini, codex, opencode, gh, age)",
         ),
     ] = False,
     repo_dotfiles: Annotated[

--- a/src/djinn_in_a_box/config/defaults.py
+++ b/src/djinn_in_a_box/config/defaults.py
@@ -27,6 +27,9 @@ SYNC_PATHS: Final[dict[str, list[str]]] = {
         "codex",
         "opencode",
         "gh",
+        # "age" persists age encryption identities at ~/.config/age (age -i);
+        # SOPS users point SOPS_AGE_KEY_FILE here. A key store, not a coding CLI.
+        "age",
     ],
     "repo-dotfiles": [
         "repo-dotfiles",

--- a/src/djinn_in_a_box/core/docker.py
+++ b/src/djinn_in_a_box/core/docker.py
@@ -555,7 +555,9 @@ def ensure_host_env(config: AppConfig | None = None) -> None:
     """
     root = get_config_root(config)
     for name in SYNC_PATHS.get("credentials", []):
-        (root / name).mkdir(parents=True, exist_ok=True)
+        # 0700: credential stores hold secrets (OAuth tokens, age identities).
+        # Applies on creation only, matching the ~/.ssh precedent below.
+        (root / name).mkdir(parents=True, exist_ok=True, mode=0o700)
 
     djinn_dir = Path.home() / ".djinn"
     for sub in ("sessions", "backups"):

--- a/tests/test_ws0.py
+++ b/tests/test_ws0.py
@@ -211,8 +211,10 @@ class TestEnsureHostEnv:
         ensure_host_env(config)
 
         root = get_config_root(config)
-        for name in SYNC_PATHS["credentials"]:  # full set incl. azure/pulumi/sops
+        for name in SYNC_PATHS["credentials"]:  # claude, gemini, codex, opencode, gh, age
             assert (root / name).is_dir()
+            # Credential stores hold secrets: no group/other access.
+            assert (root / name).stat().st_mode & 0o077 == 0
         assert (mock_home / ".djinn" / "sessions").is_dir()
         assert (mock_home / ".djinn" / "backups").is_dir()
         assert (mock_home / ".ssh").is_dir()

--- a/tests/test_ws2_defaults.py
+++ b/tests/test_ws2_defaults.py
@@ -54,4 +54,19 @@ def test_resource_limit_defaults_are_conservative() -> None:
 
 
 def test_credentials_sync_paths_are_decoupled_from_work_tools() -> None:
-    assert SYNC_PATHS["credentials"] == ["claude", "gemini", "codex", "opencode", "gh"]
+    assert SYNC_PATHS["credentials"] == [
+        "claude",
+        "gemini",
+        "codex",
+        "opencode",
+        "gh",
+        "age",
+    ]
+
+
+def test_compose_mounts_age_credential_store() -> None:
+    """The age identity store is bind-mounted so age keys persist across runs."""
+    compose_file = project_root() / "docker-compose.yml"
+    compose = yaml.safe_load(compose_file.read_text())
+    dev_volumes = compose["services"]["dev"]["volumes"]
+    assert "${DJINN_CONFIG_ROOT}/age:/home/dev/.config/age" in dev_volumes


### PR DESCRIPTION
## Summary

An `age` encryption key did not survive a container restart. Djinn runs
containers with `docker compose run --rm`, so only bind mounts and named volumes
persist. An age identity landed in the ephemeral writable layer, because
`/home/dev/.config` is not mounted as a whole — only its `gh` and
`mcp-servers.json` children are.

This adds `age` as a first-class credential store: a `${DJINN_CONFIG_ROOT}/age`
bind mount at `~/.config/age`. Because it rides the existing `SYNC_PATHS`
machinery, host provisioning, `djinn backup`/`restore`, `djinn clean
--credentials`, and `djinn status` pick it up with no further code changes.

### Why credentials, not the tools-cache volume

The two persistence models in this repo split along *rebuildable vs. user-owned*:

| | Tool artifacts | Credentials |
| --- | --- | --- |
| Storage | one shared `djinn-tools-cache` volume | `${DJINN_CONFIG_ROOT}/<name>` bind mounts |
| In `djinn backup` | excluded (rebuildable) | included |
| Mirrored across machines | no (host-local) | yes |

An age private key is a user-owned secret that must be backed up and mirrored, so
it belongs in `SYNC_PATHS["credentials"]`. Placing it in the tools cache would
mean it is never backed up and is destroyed by `djinn clean volumes --cache`.

No new named volume is introduced, and the volume set stays decoupled from which
optional tools are installed.

### Security hardening included

- Credential directories are now created with mode `0700`, matching the
  existing `~/.ssh` precedent. The mode applies **on creation only**; existing
  directories are not tightened retroactively.
- New `README.md` section "Credential Security" documents the trust model
  honestly: credentials are stored unencrypted, every agent running in the
  container can read all of them (an age identity is a master decryption key,
  and write-mode agents act without approval), and `djinn backup` archives are
  unencrypted. It points at `--firewall` as the containment lever.

## Implementation

- [x] `config/defaults.py`: add `age` to `SYNC_PATHS["credentials"]`
- [x] `docker-compose.yml`: bind mount `${DJINN_CONFIG_ROOT}/age` → `~/.config/age`
- [x] `core/docker.py`: create credential dirs with mode `0700`
- [x] `commands/container.py`: refresh the `clean --credentials` help text
- [x] Tests: exact credential list, new compose-mount pin, `0700` assertion
- [x] Fix a stale comment in `tests/test_ws0.py` claiming the credential set
      included `azure`/`pulumi`/`sops` — it never did
- [x] Docs: `README.md`, `IMPLEMENTATION.md`, `docs/sync-across-machines.md`,
      `CHANGELOG.md`

No image rebuild is required — bind mounts take effect on the next `djinn start`.

## Quality assurance

- `uv run ruff check .` — passed
- `uv run pyright src/` — 0 errors (the CI gate)
- `uv run pytest` — 409 passed
- Functional: `docker compose config` resolves the mount
  (`source: …/age` → `target: /home/dev/.config/age`)
- Independent review via the Codex CLI confirmed no consumer of `SYNC_PATHS`
  was missed; provisioning, backup collection, restore, clean, and status all
  flow through it

## Architecture impact

Adds one entry to the credential set and one bind mount. No new named volume, no
new persistence mechanism, and no change to the installer/tools-cache contract.
The `templates/devcontainer.json` template is deliberately untouched: it is
documented as experimental and out of scope for v1, and uses its own named-volume
scheme rather than the config-root binds.

## Follow-up

Backup archives remain unencrypted, which now matters more because they can
contain an age master key. Tracked separately in #4.
