### PR TITLE
feat: configure default models per agent

### DIFF
--- a/IMPLEMENTATION.md
+++ b/IMPLEMENTATION.md
@@ -200,7 +200,9 @@ uppercase suffix. Reservations cannot exceed limits.
 - `omp_theme_path = None`
 
 `AgentConfig` defines CLI agent invocation shape: binary, headless flags,
-read-only flags, write flags, JSON flags, model flag, and prompt template.
+read-only flags, write flags, JSON flags, model flag, optional default model,
+and prompt template. The bundled defaults pin Claude to `sonnet` and Codex to
+`gpt-5.6-terra`.
 
 ## Config File Loading
 
@@ -501,7 +503,8 @@ This keeps Docker-down failures from creating unrelated host artifacts.
 
 `build_agent_command(agent_config, write, json_output, model)` assembles a shell
 command string from `AgentConfig`. It appends the prompt template, which expands
-`$AGENT_PROMPT` inside the container.
+`$AGENT_PROMPT` inside the container. An explicit `model` takes precedence;
+otherwise the command uses `AgentConfig.default_model` when configured.
 
 `run()` loads app config and agent config, validates the requested agent, ensures
 the Docker network, mounts the current directory by default, and calls
@@ -512,6 +515,10 @@ the Docker network, mounts the current directory by default, and calls
 ## Session Workspace Contract
 
 `commands/session.py` exposes `djinn session`.
+
+`--model` is optional. Interactive and headless sessions use the selected
+agent's `default_model` when the caller omits it, so a non-Claude agent never
+receives the former session-wide `sonnet` fallback.
 
 Host workspaces live under:
 

--- a/IMPLEMENTATION.md
+++ b/IMPLEMENTATION.md
@@ -201,8 +201,7 @@ uppercase suffix. Reservations cannot exceed limits.
 
 `AgentConfig` defines CLI agent invocation shape: binary, headless flags,
 read-only flags, write flags, JSON flags, model flag, optional default model,
-and prompt template. The bundled defaults pin Claude to `sonnet` and Codex to
-`gpt-5.6-terra`.
+and prompt template.
 
 ## Config File Loading
 

--- a/README.md
+++ b/README.md
@@ -234,9 +234,9 @@ Djinn has four built-in agent definitions:
 
 | Agent name | Binary | Default headless mode | Notes |
 | --- | --- | --- | --- |
-| `claude` | `claude` | `claude -p` | default model is `sonnet`; read-only uses `--permission-mode plan`; write mode uses `--dangerously-skip-permissions` |
+| `claude` | `claude` | `claude -p` | read-only uses `--permission-mode plan`; write mode uses `--dangerously-skip-permissions` |
 | `gemini` | `gemini` | `gemini -p` | model flag is `-m` |
-| `codex` | `codex` | `codex exec` | default model is `gpt-5.6-terra`; write mode uses `--full-auto` |
+| `codex` | `codex` | `codex exec` | write mode uses `--full-auto` |
 | `opencode` | `opencode` | `opencode run` | read-only uses `--agent plan`; model flag is `-m` |
 
 List the effective definitions:

--- a/README.md
+++ b/README.md
@@ -234,9 +234,9 @@ Djinn has four built-in agent definitions:
 
 | Agent name | Binary | Default headless mode | Notes |
 | --- | --- | --- | --- |
-| `claude` | `claude` | `claude -p` | read-only uses `--permission-mode plan`; write mode uses `--dangerously-skip-permissions` |
+| `claude` | `claude` | `claude -p` | default model is `sonnet`; read-only uses `--permission-mode plan`; write mode uses `--dangerously-skip-permissions` |
 | `gemini` | `gemini` | `gemini -p` | model flag is `-m` |
-| `codex` | `codex` | `codex exec` | write mode uses `--full-auto` |
+| `codex` | `codex` | `codex exec` | default model is `gpt-5.6-terra`; write mode uses `--full-auto` |
 | `opencode` | `opencode` | `opencode run` | read-only uses `--agent plan`; model flag is `-m` |
 
 List the effective definitions:
@@ -270,7 +270,8 @@ djinn agents --verbose
 
 Define agents under `[agents.<name>]`. Supported fields are `binary`,
 `description`, `headless_flags`, `read_only_flags`, `write_flags`, `json_flags`,
-`model_flag`, and `prompt_template`.
+`model_flag`, `default_model`, and `prompt_template`. An explicit `--model`
+value overrides `default_model` for that invocation.
 
 ## Container Entry Points
 

--- a/docs/headless-cheatsheet.md
+++ b/docs/headless-cheatsheet.md
@@ -13,9 +13,9 @@ the selected agent CLI; otherwise it uses that agent's configured
 
 | Agent | Model flag forwarded by Djinn | Notes |
 |-------|-------------------------------|-------|
-| `claude` | `--model <name>` | Bundled default: `sonnet`. |
+| `claude` | `--model <name>` | Example aliases depend on the installed Claude Code CLI. |
 | `gemini` | `-m <name>` | Use a model supported by the installed Gemini CLI. |
-| `codex` | `--model <name>` | Bundled default: `gpt-5.6-terra`; uses `codex exec` for headless runs. |
+| `codex` | `--model <name>` | Uses `codex exec` for headless runs. |
 | `opencode` | `-m <name>` | Uses `opencode run` for headless runs. |
 
 Check available models with the agent's own documentation or CLI help.
@@ -35,7 +35,7 @@ djinn run claude "Fix the bug in main.py" --write --model sonnet
 djinn run gemini "Refactor the auth flow" --write --model gemini-2.5-pro
 
 # Codex in headless mode
-djinn run codex "Review this change"
+djinn run codex "Review this change" --model gpt-5
 
 # OpenCode in read-only plan mode
 djinn run opencode "Plan a cleanup for this module" --model default

--- a/docs/headless-cheatsheet.md
+++ b/docs/headless-cheatsheet.md
@@ -7,14 +7,15 @@ the session-oriented `djinn session --prompt` path.
 
 ## Model Handling
 
-Djinn does not validate model names. It forwards the value you pass with
-`--model` to the selected agent CLI:
+Djinn does not validate model names. It forwards an explicit `--model` value to
+the selected agent CLI; otherwise it uses that agent's configured
+`default_model` when present:
 
 | Agent | Model flag forwarded by Djinn | Notes |
 |-------|-------------------------------|-------|
-| `claude` | `--model <name>` | Example aliases depend on the installed Claude Code CLI. |
+| `claude` | `--model <name>` | Bundled default: `sonnet`. |
 | `gemini` | `-m <name>` | Use a model supported by the installed Gemini CLI. |
-| `codex` | `--model <name>` | Uses `codex exec` for headless runs. |
+| `codex` | `--model <name>` | Bundled default: `gpt-5.6-terra`; uses `codex exec` for headless runs. |
 | `opencode` | `-m <name>` | Uses `opencode run` for headless runs. |
 
 Check available models with the agent's own documentation or CLI help.
@@ -34,7 +35,7 @@ djinn run claude "Fix the bug in main.py" --write --model sonnet
 djinn run gemini "Refactor the auth flow" --write --model gemini-2.5-pro
 
 # Codex in headless mode
-djinn run codex "Review this change" --model gpt-5
+djinn run codex "Review this change"
 
 # OpenCode in read-only plan mode
 djinn run opencode "Plan a cleanup for this module" --model default
@@ -119,7 +120,7 @@ still fail at invocation if its binary is missing.
 |------|-------------|
 | `--project <name>`, `-p <name>` | Session namespace under `~/.djinn/sessions/`. Defaults to `default`. |
 | `--agent <name>`, `-a <name>` | Agent to run. Defaults to `claude`. |
-| `--model <name>`, `-m <name>` | Model override. Defaults to `sonnet`. |
+| `--model <name>`, `-m <name>` | Model override. When omitted, the selected agent's `default_model` applies. |
 | `--prompt <text>` | Run headless. Omit this flag for interactive mode. |
 | `--timeout <sec>`, `-t <sec>` | Headless timeout. Defaults to `300`. |
 | `--create` | Create the session workspace if it does not exist. |

--- a/src/djinn_in_a_box/commands/agent.py
+++ b/src/djinn_in_a_box/commands/agent.py
@@ -49,8 +49,11 @@ def build_agent_command(
     parts: list[str] = [shlex.quote(agent_config.binary)]
     parts.extend(shlex.quote(f) for f in agent_config.headless_flags)
 
-    if model:
-        parts.extend([shlex.quote(agent_config.model_flag), shlex.quote(model)])
+    effective_model = model if model is not None else agent_config.default_model
+    if effective_model:
+        parts.extend(
+            [shlex.quote(agent_config.model_flag), shlex.quote(effective_model)]
+        )
 
     if write:
         parts.extend(shlex.quote(f) for f in agent_config.write_flags)
@@ -272,6 +275,8 @@ def agents(
             table.add_row("Description", cfg.description or cfg.binary)
             table.add_row("Binary", cfg.binary)
             table.add_row("Model flag", cfg.model_flag)
+            if cfg.default_model:
+                table.add_row("Default model", cfg.default_model)
             if cfg.headless_flags:
                 table.add_row("Headless", " ".join(cfg.headless_flags))
             if cfg.write_flags:

--- a/src/djinn_in_a_box/commands/session.py
+++ b/src/djinn_in_a_box/commands/session.py
@@ -24,9 +24,9 @@ def session(
         typer.Option("--agent", "-a", help="Agent to use (claude, gemini, codex, opencode)"),
     ] = "claude",
     model: Annotated[
-        str,
+        str | None,
         typer.Option("--model", "-m", help="Model override"),
-    ] = "sonnet",
+    ] = None,
     prompt: Annotated[
         str | None,
         typer.Option("--prompt", help="Prompt for headless mode (omit for interactive)"),

--- a/src/djinn_in_a_box/config/defaults.py
+++ b/src/djinn_in_a_box/config/defaults.py
@@ -48,6 +48,7 @@ DEFAULT_AGENTS: Final[dict[str, AgentConfig]] = {
         write_flags=["--dangerously-skip-permissions"],
         json_flags=["--output-format", "json"],
         model_flag="--model",
+        default_model="sonnet",
     ),
     "gemini": AgentConfig(
         binary="gemini",
@@ -63,6 +64,7 @@ DEFAULT_AGENTS: Final[dict[str, AgentConfig]] = {
         write_flags=["--full-auto"],
         json_flags=["--json"],
         model_flag="--model",
+        default_model="gpt-5.6-terra",
     ),
     "opencode": AgentConfig(
         binary="opencode",

--- a/src/djinn_in_a_box/config/defaults.py
+++ b/src/djinn_in_a_box/config/defaults.py
@@ -48,7 +48,6 @@ DEFAULT_AGENTS: Final[dict[str, AgentConfig]] = {
         write_flags=["--dangerously-skip-permissions"],
         json_flags=["--output-format", "json"],
         model_flag="--model",
-        default_model="sonnet",
     ),
     "gemini": AgentConfig(
         binary="gemini",
@@ -64,7 +63,6 @@ DEFAULT_AGENTS: Final[dict[str, AgentConfig]] = {
         write_flags=["--full-auto"],
         json_flags=["--json"],
         model_flag="--model",
-        default_model="gpt-5.6-terra",
     ),
     "opencode": AgentConfig(
         binary="opencode",

--- a/src/djinn_in_a_box/config/models.py
+++ b/src/djinn_in_a_box/config/models.py
@@ -57,6 +57,9 @@ class AgentConfig(BaseModel):
     model_flag: str = "--model"
     """Flag for specifying the model (e.g., '--model', '-m')."""
 
+    default_model: Annotated[str, Field(min_length=1)] | None = None
+    """Model used when the invocation does not provide an explicit override."""
+
     prompt_template: str = '"$AGENT_PROMPT"'
     """Shell template for prompt injection. Uses env var expansion at runtime."""
 

--- a/src/djinn_in_a_box/core/session.py
+++ b/src/djinn_in_a_box/core/session.py
@@ -72,7 +72,7 @@ class SessionManager:
         *,
         workspace_dir: Path,
         agent: str = "claude",
-        model: str = "sonnet",
+        model: str | None = None,
         initial_prompt: str | None = None,
     ) -> SessionResult:
         agent_config = self._resolve_agent(agent)
@@ -125,7 +125,7 @@ class SessionManager:
         workspace_dir: Path,
         prompt: str,
         agent: str = "claude",
-        model: str = "sonnet",
+        model: str | None = None,
         timeout: int = 300,
     ) -> SessionResult:
         from djinn_in_a_box.commands.agent import build_agent_command
@@ -296,12 +296,15 @@ class SessionManager:
     def _build_interactive_command(
         self,
         agent_config: AgentConfig,
-        model: str,
+        model: str | None,
         initial_prompt: str | None,
     ) -> str:
         parts: list[str] = [shlex.quote(agent_config.binary)]
-        if model:
-            parts.extend([shlex.quote(agent_config.model_flag), shlex.quote(model)])
+        effective_model = model if model is not None else agent_config.default_model
+        if effective_model:
+            parts.extend(
+                [shlex.quote(agent_config.model_flag), shlex.quote(effective_model)]
+            )
         parts.extend(shlex.quote(f) for f in agent_config.write_flags)
         if initial_prompt is not None:
             parts.append(shlex.quote(initial_prompt))
@@ -310,12 +313,13 @@ class SessionManager:
     def _build_host_interactive_command(
         self,
         agent_config: AgentConfig,
-        model: str,
+        model: str | None,
         initial_prompt: str | None,
     ) -> list[str]:
         cmd: list[str] = [agent_config.binary]
-        if model:
-            cmd.extend([agent_config.model_flag, model])
+        effective_model = model if model is not None else agent_config.default_model
+        if effective_model:
+            cmd.extend([agent_config.model_flag, effective_model])
         cmd.extend(agent_config.write_flags)
         if initial_prompt is not None:
             cmd.append(initial_prompt)
@@ -324,11 +328,12 @@ class SessionManager:
     def _build_host_headless_command(
         self,
         agent_config: AgentConfig,
-        model: str,
+        model: str | None,
         prompt: str,
     ) -> list[str]:
         cmd: list[str] = [agent_config.binary, *agent_config.headless_flags]
-        if model:
-            cmd.extend([agent_config.model_flag, model])
+        effective_model = model if model is not None else agent_config.default_model
+        if effective_model:
+            cmd.extend([agent_config.model_flag, effective_model])
         cmd.append(prompt)
         return cmd

--- a/templates/seed/config/agents.toml.example
+++ b/templates/seed/config/agents.toml.example
@@ -24,7 +24,6 @@
 # write_flags = ["--dangerously-skip-permissions"]
 # json_flags = ["--output-format", "json"]
 # model_flag = "--model"
-# default_model = "sonnet"
 #
 # [agents.gemini]
 # binary = "gemini"
@@ -40,7 +39,6 @@
 # write_flags = ["--full-auto"]
 # json_flags = ["--json"]
 # model_flag = "--model"
-# default_model = "gpt-5.6-terra"
 #
 # [agents.opencode]
 # binary = "opencode"

--- a/templates/seed/config/agents.toml.example
+++ b/templates/seed/config/agents.toml.example
@@ -12,6 +12,7 @@
 # write_flags = ["--write"]
 # json_flags = ["--json"]
 # model_flag = "--model"
+# default_model = "example-model"
 #
 # Built-in defaults, shown as commented examples:
 #
@@ -23,6 +24,7 @@
 # write_flags = ["--dangerously-skip-permissions"]
 # json_flags = ["--output-format", "json"]
 # model_flag = "--model"
+# default_model = "sonnet"
 #
 # [agents.gemini]
 # binary = "gemini"
@@ -38,6 +40,7 @@
 # write_flags = ["--full-auto"]
 # json_flags = ["--json"]
 # model_flag = "--model"
+# default_model = "gpt-5.6-terra"
 #
 # [agents.opencode]
 # binary = "opencode"

--- a/tests/test_commands/test_agent.py
+++ b/tests/test_commands/test_agent.py
@@ -76,6 +76,21 @@ class TestBuildAgentCommand:
         assert "--model" in cmd
         assert "sonnet" in cmd
 
+    def test_uses_configured_default_model(self) -> None:
+        config = AgentConfig(binary="codex", default_model="gpt-5.6-terra")
+
+        cmd = build_agent_command(config)
+
+        assert "--model gpt-5.6-terra" in cmd
+
+    def test_explicit_model_overrides_configured_default(self) -> None:
+        config = AgentConfig(binary="codex", default_model="gpt-5.6-terra")
+
+        cmd = build_agent_command(config, model="gpt-5.6")
+
+        assert "--model gpt-5.6" in cmd
+        assert "gpt-5.6-terra" not in cmd
+
     def test_with_json_output(self, claude_config: AgentConfig) -> None:
         """Test command generation with JSON output enabled."""
         cmd = build_agent_command(claude_config, json_output=True)

--- a/tests/test_commands/test_agent.py
+++ b/tests/test_commands/test_agent.py
@@ -77,19 +77,19 @@ class TestBuildAgentCommand:
         assert "sonnet" in cmd
 
     def test_uses_configured_default_model(self) -> None:
-        config = AgentConfig(binary="codex", default_model="gpt-5.6-terra")
+        config = AgentConfig(binary="codex", default_model="configured-model")
 
         cmd = build_agent_command(config)
 
-        assert "--model gpt-5.6-terra" in cmd
+        assert "--model configured-model" in cmd
 
     def test_explicit_model_overrides_configured_default(self) -> None:
-        config = AgentConfig(binary="codex", default_model="gpt-5.6-terra")
+        config = AgentConfig(binary="codex", default_model="configured-model")
 
         cmd = build_agent_command(config, model="gpt-5.6")
 
         assert "--model gpt-5.6" in cmd
-        assert "gpt-5.6-terra" not in cmd
+        assert "configured-model" not in cmd
 
     def test_with_json_output(self, claude_config: AgentConfig) -> None:
         """Test command generation with JSON output enabled."""

--- a/tests/test_commands/test_session.py
+++ b/tests/test_commands/test_session.py
@@ -59,6 +59,7 @@ class TestSessionCommand:
 
             runner.invoke(app, ["session", "--project", "testproj"])
             mock_instance.run_interactive.assert_called_once()
+            assert mock_instance.run_interactive.call_args.kwargs["model"] is None
 
     def test_headless_calls_run_headless(self, tmp_path: Path) -> None:
         workspace = tmp_path / ".djinn" / "sessions" / "testproj"
@@ -75,3 +76,4 @@ class TestSessionCommand:
 
             runner.invoke(app, ["session", "--project", "testproj", "--prompt", "hello"])
             mock_instance.run_headless.assert_called_once()
+            assert mock_instance.run_headless.call_args.kwargs["model"] is None

--- a/tests/test_config_loader.py
+++ b/tests/test_config_loader.py
@@ -144,7 +144,6 @@ class TestLoadAgents:
         assert "claude" in agents
         assert "gemini" in agents
         assert "codex" in agents
-        assert agents["codex"].default_model == "gpt-5.6-terra"
         assert "opencode" in agents
 
     def test_raises_validation_error_for_invalid_agents(self, tmp_path: Path) -> None:

--- a/tests/test_config_loader.py
+++ b/tests/test_config_loader.py
@@ -30,6 +30,7 @@ read_only_flags = ["--readonly"]
 write_flags = ["--write"]
 json_flags = ["--json"]
 model_flag = "-m"
+default_model = "test-model"
 prompt_template = "$PROMPT"
 """
     )
@@ -129,6 +130,7 @@ class TestLoadAgents:
         assert "test-agent" in agents
         assert agents["test-agent"].binary == "test-cli"
         assert agents["test-agent"].description == "Test Agent"
+        assert agents["test-agent"].default_model == "test-model"
 
     def test_falls_back_to_defaults(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Should fall back to DEFAULT_AGENTS when no files exist."""
@@ -142,6 +144,7 @@ class TestLoadAgents:
         assert "claude" in agents
         assert "gemini" in agents
         assert "codex" in agents
+        assert agents["codex"].default_model == "gpt-5.6-terra"
         assert "opencode" in agents
 
     def test_raises_validation_error_for_invalid_agents(self, tmp_path: Path) -> None:

--- a/tests/test_core/test_session.py
+++ b/tests/test_core/test_session.py
@@ -367,16 +367,16 @@ class TestSessionModelResolution:
     def test_interactive_command_uses_agent_default_model(
         self, session_mgr: SessionManager
     ) -> None:
-        config = AgentConfig(binary="codex", default_model="gpt-5.6-terra")
+        config = AgentConfig(binary="codex", default_model="configured-model")
 
         command = session_mgr._build_host_interactive_command(config, None, None)
 
-        assert command == ["codex", "--model", "gpt-5.6-terra"]
+        assert command == ["codex", "--model", "configured-model"]
 
     def test_interactive_command_prefers_explicit_model(
         self, session_mgr: SessionManager
     ) -> None:
-        config = AgentConfig(binary="codex", default_model="gpt-5.6-terra")
+        config = AgentConfig(binary="codex", default_model="configured-model")
 
         command = session_mgr._build_host_interactive_command(
             config, "gpt-5.6", None

--- a/tests/test_core/test_session.py
+++ b/tests/test_core/test_session.py
@@ -361,3 +361,25 @@ class TestResolveAgent:
     def test_raises_for_unknown_agent(self, session_mgr: SessionManager) -> None:
         with pytest.raises(ValueError, match="Unknown agent: unknown"):
             session_mgr._resolve_agent("unknown")
+
+
+class TestSessionModelResolution:
+    def test_interactive_command_uses_agent_default_model(
+        self, session_mgr: SessionManager
+    ) -> None:
+        config = AgentConfig(binary="codex", default_model="gpt-5.6-terra")
+
+        command = session_mgr._build_host_interactive_command(config, None, None)
+
+        assert command == ["codex", "--model", "gpt-5.6-terra"]
+
+    def test_interactive_command_prefers_explicit_model(
+        self, session_mgr: SessionManager
+    ) -> None:
+        config = AgentConfig(binary="codex", default_model="gpt-5.6-terra")
+
+        command = session_mgr._build_host_interactive_command(
+            config, "gpt-5.6", None
+        )
+
+        assert command == ["codex", "--model", "gpt-5.6"]


### PR DESCRIPTION
## Summary
- add an optional default model to each agent definition
- let explicit model overrides take precedence across run and session paths
- keep concrete model policy out of bundled agent defaults

## Verification
- uv run ruff check src/ tests/
- uv run pyright src/ (0 errors; 1 pre-existing private-usage warning)
- uv run pytest -q (413 passed)
- uvx bandit -r src/ --severity-level medium --confidence-level medium (no issues identified)