### PR TITLE
fix(tests): make the suite independent of git-ignored local state

### DIFF
--- a/src/djinn_in_a_box/commands/config.py
+++ b/src/djinn_in_a_box/commands/config.py
@@ -421,6 +421,7 @@ def _set_and_save_config_value(key: str, value: str) -> None:
     success(f"{key} = {_format_config_value(updated, key)}")
 
 
+@handle_config_errors
 def config_edit() -> None:
     """Open the configuration file in $EDITOR and validate it afterward."""
     config_dir = get_project_root() / "config"

--- a/src/djinn_in_a_box/core/config_lock.py
+++ b/src/djinn_in_a_box/core/config_lock.py
@@ -18,8 +18,11 @@ def config_directory_lock(config_dir: Path, *, exclusive: bool) -> Iterator[int]
     try:
         descriptor = os.open(config_dir, os.O_RDONLY | os.O_DIRECTORY)
     except OSError as error:
+        # Name the directory: the most common cause is a clone that has never
+        # run `djinn init`, since config/ is git-ignored blank space. A generic
+        # message leaves that user with nothing to act on.
         raise ConfigDirectoryLockError(
-            "Configuration directory cannot be locked safely."
+            f"Configuration directory cannot be locked safely: {config_dir} ({error.strerror})"
         ) from error
     locked = False
     try:

--- a/src/djinn_in_a_box/core/decorators.py
+++ b/src/djinn_in_a_box/core/decorators.py
@@ -8,7 +8,8 @@ from typing import ParamSpec, TypeVar
 
 import typer
 
-from djinn_in_a_box.core.console import error
+from djinn_in_a_box.core.config_lock import ConfigDirectoryLockError
+from djinn_in_a_box.core.console import error, warning
 from djinn_in_a_box.core.exceptions import ConfigNotFoundError, ConfigValidationError
 
 P = ParamSpec("P")
@@ -18,14 +19,19 @@ R = TypeVar("R")
 def handle_config_errors(func: Callable[P, R]) -> Callable[P, R]:
     """Decorator to handle config loading errors uniformly.
 
-    Catches ConfigNotFoundError and ConfigValidationError, converts them
-    to a typer.Exit(1) with an appropriate error message.
+    Catches ConfigNotFoundError, ConfigValidationError, and
+    ConfigDirectoryLockError, converting them to a typer.Exit(1) with an
+    actionable message instead of a traceback.
     """
 
     @wraps(func)
     def wrapper(*args: P.args, **kwargs: P.kwargs) -> R:
         try:
             return func(*args, **kwargs)
+        except ConfigDirectoryLockError as e:
+            error(str(e))
+            warning("Run `djinn init` to create it, then retry.")
+            raise typer.Exit(1) from None
         except (ConfigNotFoundError, ConfigValidationError) as e:
             error(str(e))
             raise typer.Exit(1) from None

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,7 @@
 """Pytest configuration and fixtures for Djinn in a Box tests."""
 
 import os
+from collections.abc import Iterator
 from pathlib import Path
 
 import pytest
@@ -12,6 +13,24 @@ import pytest
 os.environ.pop("FORCE_COLOR", None)
 
 from djinn_in_a_box.config.models import AppConfig, ResourceLimits, ShellConfig
+from djinn_in_a_box.core.paths import get_project_root
+
+
+@pytest.fixture(autouse=True)
+def _clear_project_root_cache() -> Iterator[None]:
+    """Keep the ``get_project_root`` cache from carrying between tests.
+
+    ``get_project_root`` is ``@functools.cache``d and walks upward looking for
+    ``docker-compose.yml``. A test that stubs ``Path.exists`` therefore poisons
+    the cache process-wide: with ``True`` it caches the first candidate it hits,
+    and every later test reaching the real function is served that wrong value.
+    The inverse is just as bad — a test can pass only because an earlier test
+    warmed the cache, which makes it fail under ``-k``, ``--lf`` or xdist while
+    the full sequential run stays green.
+    """
+    get_project_root.cache_clear()
+    yield
+    get_project_root.cache_clear()
 
 
 @pytest.fixture

--- a/tests/test_cli_djinn.py
+++ b/tests/test_cli_djinn.py
@@ -58,6 +58,23 @@ def _write_test_config(config_file: Path, projects_dir: Path) -> AppConfig:
     return config
 
 
+@pytest.fixture
+def config_edit_project(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> Iterator[Path]:
+    """Provide the project-local config directory required by ``config edit``."""
+    project_root = tmp_path / "project"
+    config_dir = project_root / "config"
+    config_dir.mkdir(parents=True)
+    get_project_root = MagicMock(return_value=project_root)
+    monkeypatch.setattr("djinn_in_a_box.commands.config.get_project_root", get_project_root)
+
+    yield config_dir
+
+    assert config_dir.is_dir()
+    get_project_root.assert_called_once_with()
+
+
 class TestDjinnVersion:
     """Tests for the --version flag."""
 
@@ -500,7 +517,7 @@ class TestConfigEditCommand:
     """Tests for the config edit command."""
 
     def test_config_edit_warns_when_editor_corrupts_file(
-        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, config_edit_project: Path
     ) -> None:
         config_file = tmp_path / "config.toml"
         projects_dir = tmp_path / "projects"
@@ -523,7 +540,7 @@ class TestConfigEditCommand:
         assert "Invalid TOML" in combined
 
     def test_config_edit_splits_editor_command_with_arguments(
-        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, config_edit_project: Path
     ) -> None:
         config_file = tmp_path / "config.toml"
         projects_dir = tmp_path / "projects"
@@ -547,7 +564,7 @@ class TestConfigEditCommand:
         assert "# edited" in config_file.read_text()
 
     def test_config_edit_holds_exclusive_config_directory_lock(
-        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, config_edit_project: Path
     ) -> None:
         config_file = tmp_path / "config.toml"
         projects_dir = tmp_path / "projects"
@@ -555,15 +572,11 @@ class TestConfigEditCommand:
         _write_test_config(config_file, projects_dir)
         monkeypatch.setattr("djinn_in_a_box.commands.config.CONFIG_FILE", config_file)
         monkeypatch.setattr("djinn_in_a_box.config.loader.CONFIG_FILE", config_file)
-        project_root = tmp_path / "project"
-        config_dir = project_root / "config"
-        config_dir.mkdir(parents=True)
-        monkeypatch.setattr("djinn_in_a_box.commands.config.get_project_root", lambda: project_root)
         events: list[str] = []
 
         @contextmanager
         def record_lock(path: Path, *, exclusive: bool) -> Iterator[None]:
-            assert path == config_dir
+            assert path == config_edit_project
             assert exclusive is True
             events.append("lock")
             yield
@@ -582,7 +595,7 @@ class TestConfigEditCommand:
         assert events == ["lock", "editor", "unlock"]
 
     def test_config_edit_warns_when_editor_deletes_file(
-        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, config_edit_project: Path
     ) -> None:
         config_file = tmp_path / "config.toml"
         projects_dir = tmp_path / "projects"
@@ -605,7 +618,7 @@ class TestConfigEditCommand:
         assert not config_file.exists()
 
     def test_config_edit_bad_editor_exits_cleanly(
-        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, config_edit_project: Path
     ) -> None:
         config_file = tmp_path / "config.toml"
         projects_dir = tmp_path / "projects"

--- a/tests/test_cli_djinn.py
+++ b/tests/test_cli_djinn.py
@@ -71,8 +71,13 @@ def config_edit_project(
 
     yield config_dir
 
+    # Both halves must be load-bearing. Without the mkdir check the stubbed-lock
+    # test would pass with no directory; without the call check, dropping the
+    # patch would leave every test green locally — on the real ./config — which
+    # is exactly how this bug reached CI. `assert_called` rather than
+    # `assert_called_once`: the count carries no signal, only coupling.
     assert config_dir.is_dir()
-    get_project_root.assert_called_once_with()
+    get_project_root.assert_called()
 
 
 class TestDjinnVersion:
@@ -513,8 +518,18 @@ class TestConfigSetCommand:
         assert "Traceback" not in combined
 
 
+@pytest.mark.usefixtures("config_edit_project")
 class TestConfigEditCommand:
-    """Tests for the config edit command."""
+    """Tests for the config edit command.
+
+    The class-level usefixtures is deliberate: `config edit` locks the
+    project-local `config/`, which is git-ignored and therefore present on every
+    developer machine and absent on a fresh checkout. A test that forgets the
+    fixture locks the real one, passes locally and fails on CI — which is how
+    this class went red for ten days. Applying it class-wide means a new test
+    cannot reintroduce that by omission. Tests needing the path still request
+    the fixture by name and get the same instance.
+    """
 
     def test_config_edit_warns_when_editor_corrupts_file(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, config_edit_project: Path
@@ -635,6 +650,42 @@ class TestConfigEditCommand:
         assert "Cannot run editor" in combined
         assert "$EDITOR" in combined
         assert "No closing quotation" in combined
+        assert "Traceback" not in combined
+
+class TestConfigEditWithoutProjectConfig:
+    """`config edit` on a clone that never ran `djinn init`.
+
+    Deliberately outside `TestConfigEditCommand`: that class applies
+    `config_edit_project` to every test, and the whole point here is the
+    directory's absence.
+    """
+
+    def test_config_edit_without_project_config_dir_is_actionable(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A clone that never ran `djinn init` must get guidance, not a traceback.
+
+        `config/` is git-ignored blank space, so this is the state of every fresh
+        clone.
+        """
+        config_file = tmp_path / "config.toml"
+        projects_dir = tmp_path / "projects"
+        projects_dir.mkdir()
+        _write_test_config(config_file, projects_dir)
+        monkeypatch.setattr("djinn_in_a_box.commands.config.CONFIG_FILE", config_file)
+        monkeypatch.setattr("djinn_in_a_box.config.loader.CONFIG_FILE", config_file)
+        bare_root = tmp_path / "bare-project"
+        bare_root.mkdir()
+        monkeypatch.setattr(
+            "djinn_in_a_box.commands.config.get_project_root", lambda: bare_root
+        )
+
+        result = runner.invoke(app, ["config", "edit"])
+
+        assert result.exit_code == 1
+        combined = result.stdout + result.output
+        assert "config" in combined
+        assert "djinn init" in combined
         assert "Traceback" not in combined
 
 

--- a/tests/test_commands/test_mcp.py
+++ b/tests/test_commands/test_mcp.py
@@ -207,11 +207,16 @@ class TestCleanCommand:
         with patch("typer.confirm", return_value=False), pytest.raises(typer.Abort):
             mcp.clean()
 
-    def test_clean_stops_gateway_and_removes_network(self) -> None:
+    def test_clean_stops_gateway_and_removes_network(self, tmp_path: Path) -> None:
+        # get_project_root is patched explicitly: the global Path.exists stub
+        # below would otherwise reach it too, making it raise on a cold cache and
+        # skip the compose call this test asserts on. That made the test pass
+        # only when an earlier test in the file had warmed the cache.
         with (
             patch("typer.confirm", return_value=True),
             patch("subprocess.run") as mock_run,
             patch("shutil.rmtree"),
+            patch("djinn_in_a_box.commands.mcp.get_project_root", return_value=tmp_path),
             patch("pathlib.Path.exists", return_value=False),
         ):
             mock_run.return_value = MagicMock(returncode=0)
@@ -224,11 +229,15 @@ class TestCleanCommand:
                 DJINN_NETWORK,
             ]
 
-    def test_clean_removes_mcp_config_dir(self) -> None:
+    def test_clean_removes_mcp_config_dir(self, tmp_path: Path) -> None:
+        # Same reason as above, inverted: with Path.exists stubbed True, an
+        # unpatched get_project_root caches the first directory it probes and
+        # serves that wrong root to every later test in the process.
         with (
             patch("typer.confirm", return_value=True),
             patch("subprocess.run", return_value=MagicMock(returncode=0)),
             patch("shutil.rmtree") as mock_rmtree,
+            patch("djinn_in_a_box.commands.mcp.get_project_root", return_value=tmp_path),
             patch("pathlib.Path.exists", return_value=True),
             patch("pathlib.Path.home", return_value=Path("/fake/home")),
         ):

--- a/tests/test_ws0.py
+++ b/tests/test_ws0.py
@@ -219,6 +219,10 @@ class TestEnsureHostEnv:
         self, mock_home: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         monkeypatch.delenv("DJINN_CONFIG_ROOT", raising=False)
+        # ensure_host_env touches get_project_root()/config/claude. Without this
+        # patch that is the real checkout — this test created the repo's own
+        # config/claude/AGENTS.md. Tests must not write into the working copy.
+        monkeypatch.setattr(docker_mod, "get_project_root", lambda: mock_home / "project")
         config = AppConfig(code_dir=mock_home, config_root=mock_home / ".djinn" / "config")
 
         ensure_host_env(config)
@@ -241,6 +245,7 @@ class TestEnsureHostEnv:
         self, mock_home: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         monkeypatch.delenv("DJINN_CONFIG_ROOT", raising=False)
+        monkeypatch.setattr(docker_mod, "get_project_root", lambda: mock_home / "project")
         gitconfig = mock_home / ".gitconfig"
         gitconfig.write_text("[user]\n  name = existing\n")
         config = AppConfig(code_dir=mock_home, config_root=mock_home / ".djinn" / "config")


### PR DESCRIPTION
Closes #21.

## Why CI was red

`djinn config edit` locks the **project-local** `config/` directory before
editing (`commands/config.py`), and `config_directory_lock` opens it with
`os.open(..., O_DIRECTORY)` without creating it. `/config/` is git-ignored
(`.gitignore:26`) — Djinn's deliberately local-only "blank space", created by
`djinn init`.

So it exists on every developer machine and never on a fresh checkout. Four
`TestConfigEditCommand` tests patched `CONFIG_FILE` but never
`get_project_root`, so they locked the real checkout's directory: green locally
by accident, red on CI since 2026-07-18.

Reproduced in both directions before writing any fix — a tracked-only export
without `config/` fails those four; `mkdir config` alone turns them green.

## What changed

**1 — the fixture (`67d6d8d`).** `config_edit_project` owns both halves of the
prerequisite: it creates a temporary `project/config` *and* patches
`get_project_root` to it. Applied class-wide via `usefixtures`, so a new test
written from the old mental template cannot reintroduce the bug by omission —
verified by adding exactly such a forgetful test and confirming it passes in a
clean-tree export.

The fixture asserts after yield that `get_project_root` was actually called.
Without that, dropping the patch would leave the tests green locally, on the
real `config/`, which is precisely how this reached CI. Mutation-tested: removing
either half fails *locally*, where the original bug hid.

**2 — the unhandled path (`0716b94`).** The fixture creates `config/`
unconditionally, so no test could ever again reach the state where it is
missing — and that state was unhandled. `config_edit` was the only config
command without `@handle_config_errors`, and the decorator caught just
`ConfigNotFoundError`/`ConfigValidationError`, so a clone that never ran
`djinn init` got a bare `ConfigDirectoryLockError`: empty output under
`CliRunner`, a traceback in a real terminal. That is the state of every fresh
clone, including the OSS users this project targets.

The lock error now names the directory and its errno, the decorator handles it
with a pointer to `djinn init`, and `config_set` gets the same treatment for
free since it was already decorated. Covered by a test in its own class,
deliberately outside the fixture's reach.

**3 — the same bug class, one level deeper (`d0e4647`).** `get_project_root` is
`@functools.cache`d. Two `mcp clean` tests stub `Path.exists` globally, which
reaches it too: with `exists=False` on a cold cache it raises, `clean()` swallows
that, the compose call never happens, and the assertion fails — so those tests
passed only when an earlier test in the file had warmed the cache. **Running
`TestCleanCommand` on its own failed before this PR.** With `exists=True` the
inverse happens: the first probed directory is cached process-wide and served to
every later test as the project root.

Both now patch `commands.mcp.get_project_root` directly, and an autouse fixture
clears the cache around every test.

Two `ensure_host_env` tests did not patch `get_project_root` at all and wrote
into the working copy — the repo's own `config/claude/AGENTS.md`, 0 bytes, was
created that way. Verified by deleting it and confirming a full run no longer
recreates it.

## Verification

- Clean-tree full suite (tracked files only, no `config/`): **637 passed, 1
  skipped**. The skip is the private-token leak gate, which correctly treats its
  git-ignored input as a precondition.
- `TestCleanCommand`, `TestEnsureHostEnv` and `TestConfigEditCommand` now each
  pass **in isolation** — the property that was missing.
- Mutation tests on the fixture: removing either half fails locally.
- `ruff check` clean · `pyright src` 0 errors · full suite 638 passed.

## Deliberately not in scope

Nothing currently fails if the lock stops being *exclusive* — `LOCK_EX` →
`LOCK_SH` leaves the suite green. That is a gap in coverage of a production
behaviour this PR does not touch, and closing it needs a process-forking test
whose timing characteristics deserve their own review. Filed as #22.
