### PR TITLE
fix(firewall): allow what Gemini CLI and OpenCode actually need

### DIFF
--- a/README.md
+++ b/README.md
@@ -413,6 +413,22 @@ Common `start` options:
 
 `--docker` and `--docker-direct` are mutually exclusive.
 
+### What `--firewall` allows
+
+The firewall denies outbound traffic by default and permits a fixed domain list
+in `scripts/init-firewall.sh`: package registries, the four bundled CLIs' API and
+sign-in endpoints, GitHub, and the Docker networks. Every address a domain
+resolves to is permitted.
+
+Two limits are worth knowing before you rely on it. The list is resolved **once**
+at container start, so an address a provider rotates in later is denied until you
+restart. And only IPv4 is covered. If a tool fails in unusual ways under
+`--firewall`, that list is the first place to look — add the domain you need at
+the marked spot near the end of the array.
+
+Third-party model providers you configure yourself (OpenRouter, x.ai, and the
+like) are deliberately absent; add the ones you actually use.
+
 ## Docker Access Modes
 
 The base mode gives the container no Docker socket access. This is the safest

--- a/scripts/init-firewall.sh
+++ b/scripts/init-firewall.sh
@@ -62,6 +62,14 @@ ALLOWED_DOMAINS=(
     # AI APIs (for direct API usage, not via MCP)
     "api.anthropic.com"
     "api.openai.com"
+    # Gemini CLI: model endpoint, plus the Code Assist backend it uses when
+    # signed in with a Google account rather than an API key.
+    "generativelanguage.googleapis.com"
+    "cloudcode-pa.googleapis.com"
+    # OpenCode's own service (auth, updates). Third-party providers a user may
+    # configure (openrouter, x.ai, …) are deliberately not listed — add the ones
+    # you actually use.
+    "opencode.ai"
     
     # Code hosting
     "github.com"
@@ -78,6 +86,11 @@ ALLOWED_DOMAINS=(
     # OAuth endpoints (for authentication)
     "console.anthropic.com"
     "auth.openai.com"
+    # Google sign-in for Gemini CLI: consent screen, token exchange, and the
+    # host its pasted-code flow redirects to.
+    "accounts.google.com"
+    "oauth2.googleapis.com"
+    "codeassist.google.com"
     
     # Add project-specific domains below:
     # "api.example.com"
@@ -96,7 +109,22 @@ DOCKER_NETWORKS=(
 # Resolve domains to IPs
 # -----------------------------------------------------------------------------
 resolve_domain() {
-    getent ahostsv4 "$1" 2>/dev/null | awk '{print $1}' | head -1
+    # Every A record, not just the first.
+    #
+    # Taking only the first worked, but only by relying on something nothing
+    # guarantees: that the resolver returns addresses in a stable order and that
+    # every client then picks the same one. Measured here, glibc returns the
+    # same first address on repeated lookups and curl connects to it — so a
+    # single allowed IP sufficed. That breaks with `options rotate` in
+    # resolv.conf, a different resolver, or a client that walks the address list
+    # itself (Node's happy-eyeballs does), where the connection lands on an
+    # address that was never allowed and is dropped.
+    #
+    # Allowing the full set removes that dependency. It does not make the
+    # allowlist correct: the set is resolved once at container start, so an
+    # address the provider rotates in later is still denied, and IPv6 is not
+    # covered at all. See the tracking issue.
+    getent ahostsv4 "$1" 2>/dev/null | awk '{print $1}' | sort -u
 }
 
 # -----------------------------------------------------------------------------
@@ -134,10 +162,21 @@ done
 echo "" >&2
 ui_info "Allowing whitelisted domains..."
 for domain in "${ALLOWED_DOMAINS[@]}"; do
-    ip=$(resolve_domain "$domain")
-    if [ -n "$ip" ]; then
-        iptables -A OUTPUT -d "$ip" -j ACCEPT
-        ui_ok "Allowed: $domain ($ip)"
+    ips=$(resolve_domain "$domain")
+    if [ -n "$ips" ]; then
+        count=0
+        for ip in $ips; do
+            iptables -A OUTPUT -d "$ip" -j ACCEPT
+            count=$((count + 1))
+        done
+        if [ "$count" -eq 1 ]; then
+            ui_ok "Allowed: $domain ($ips)"
+        else
+            # Listing all of them would run to ~180 characters for a registry
+            # with a dozen records; the count is what tells you the allowlist
+            # widened as intended.
+            ui_ok "Allowed: $domain ($count addresses)"
+        fi
     else
         ui_warn "Could not resolve: $domain"
     fi


### PR DESCRIPTION
Refs #17 — ships part 1 of the rewritten issue; part 2 stays open there.

## The problem

Under `djinn start --firewall` — the mode the README recommends when an agent
handles untrusted content — two of the four bundled agents could neither sign in
nor run. `ALLOWED_DOMAINS` covered Anthropic and OpenAI only.

Measured inside the image with the previous allowlist active:

```
generativelanguage.googleapis.com   BLOCKED
accounts.google.com                 BLOCKED
oauth2.googleapis.com               BLOCKED
cloudcode-pa.googleapis.com         BLOCKED
opencode.ai                         BLOCKED
```

After: all five reachable, unlisted hosts (`example.com`, `cloudflare.com`)
still dropped.

Domains came from the shipped bundles, not from guesswork —
`oauth2.googleapis.com` 51 references, `accounts.google.com` 37,
`cloudcode-pa.googleapis.com` 12, `generativelanguage.googleapis.com` 9,
`codeassist.google.com` 3 in `@google/gemini-cli`; `opencode.ai` 126 in the
OpenCode binary. Third-party providers a user may configure (OpenRouter, x.ai,
…) are deliberately not listed; the README now says so.

## A correction worth reading

The issue originally claimed `head -1` was itself a bug: one A record allowed out
of eight would block most connections. **That is wrong, and I verified it is
wrong before shipping the change.**

glibc returns a stable first address across repeated lookups, and curl connects
to that address — 12/12 successful against `generativelanguage.googleapis.com`
(8 records), `pypi.org` (4) and `registry.npmjs.org` (12), with only the first
address allowed. `/etc/resolv.conf` in the image carries no `options rotate`.

`resolve_domain` still changes to allow the full set, but as hardening rather
than a bug fix, and the code comment states that plainly. It removes a dependency
on resolver behaviour nothing guarantees: `options rotate`, a different resolver,
or a client that walks the address list itself (Node's happy-eyeballs) all land
on an address that was never allowed. The rewritten #17 records the disproven
theory so nobody re-derives it.

## Also

Startup output prints the address when a domain resolves to one and a count when
it resolves to several — listing twelve would run to about 180 characters.
`test_firewall_startup_uses_plain_ascii_markers` went green again on its own,
since its stub resolves to a single address; no test was adjusted to fit the
change.

README gains a short section on what the mode allows and its two real limits:
resolution happens once at container start, and IPv6 is not covered at all. Both
are tracked in #17 part 2.

## Verification

Everything above was measured in a throwaway container from the actual image
with `NET_ADMIN` and the real script, not reasoned about:

- before/after reachability of the five domains, plus two unlisted control hosts
- old-vs-new resolution counts (1 → 2, 4, 8, 12 depending on domain)
- 12 repeated requests per domain under each resolution mode
- full script run: 75 ACCEPT rules, `DROP` last

`ruff check` clean · `pyright src` 0 errors · 638 tests pass · `bash -n` clean.
`shellcheck` could not be installed in this environment (dpkg lock held); CI does
not run it either.
