### PR TITLE
fix(workflow): report failures as what they are, and pin the lock's exclusivity

### DIFF
--- a/src/djinn_in_a_box/commands/config.py
+++ b/src/djinn_in_a_box/commands/config.py
@@ -22,7 +22,7 @@ from djinn_in_a_box.config.models import (
     ResourceLimits,
     ShellConfig,
 )
-from djinn_in_a_box.core.config_lock import config_directory_lock
+from djinn_in_a_box.core.config_lock import ConfigDirectoryLockError, config_directory_lock
 from djinn_in_a_box.core.config_sync import (
     CANONICAL_REMEDY,
     ConfigSyncAudit,
@@ -54,6 +54,7 @@ ALLOWED_CONFIG_KEYS: tuple[str, ...] = (
     "shell.omp_theme_path",
     "config_sync.source",
 )
+_LOCK_PROBLEM_IDENTIFIER = "canonical-lock-failed"
 
 
 def _print_config_table(
@@ -395,14 +396,23 @@ def config_set(
     """Set one supported configuration value."""
     if key == "config_sync.source":
         config_dir = get_project_root() / "config"
-        with config_directory_lock(config_dir, exclusive=True):
-            _set_and_save_config_value(key, value)
+        value_written = False
+        try:
+            with config_directory_lock(config_dir, exclusive=True):
+                updated = _set_and_save_config_value(key, value)
+                value_written = True
+        except ConfigDirectoryLockError:
+            if value_written:
+                warning("Configuration value was written, but releasing its lock failed.")
+            raise
+        success(f"{key} = {_format_config_value(updated, key)}")
         return
 
-    _set_and_save_config_value(key, value)
+    updated = _set_and_save_config_value(key, value)
+    success(f"{key} = {_format_config_value(updated, key)}")
 
 
-def _set_and_save_config_value(key: str, value: str) -> None:
+def _set_and_save_config_value(key: str, value: str) -> AppConfig:
     config = load_config()
 
     try:
@@ -418,7 +428,7 @@ def _set_and_save_config_value(key: str, value: str) -> None:
         error(f"Failed to write configuration to {CONFIG_FILE}: {e}")
         warning(f"Check that {CONFIG_FILE.parent} is writable, then retry.")
         raise typer.Exit(1) from e
-    success(f"{key} = {_format_config_value(updated, key)}")
+    return updated
 
 
 @handle_config_errors
@@ -569,16 +579,29 @@ def _print_workflow_audit(audit: ConfigSyncAudit) -> None:
             f"({_status_location(drift.tool, drift.relative_path)})"
         )
     for problem in audit.problems:
-        console.print(
+        line = (
             f"Problem: {_status_label(problem.identifier)} "
             f"({_status_location(problem.tool, problem.relative_path)})"
         )
+        if problem.identifier == _LOCK_PROBLEM_IDENTIFIER:
+            line += f": {problem.message}"
+        console.print(line)
 
     if not audit.clean:
-        drift = next(
-            (item.kind for item in audit.drifts if item.kind is not DriftClass.CLEAN), None
+        operational_remedy = next(
+            (problem.remedy for problem in audit.problems if problem.remedy is not None), None
         )
-        remedy = CANONICAL_REMEDY if drift is None else _DRIFT_REMEDIES.get(drift, CANONICAL_REMEDY)
+        if operational_remedy is not None:
+            remedy = operational_remedy
+        else:
+            drift = next(
+                (item.kind for item in audit.drifts if item.kind is not DriftClass.CLEAN), None
+            )
+            remedy = (
+                CANONICAL_REMEDY
+                if drift is None
+                else _DRIFT_REMEDIES.get(drift, CANONICAL_REMEDY)
+            )
         console.print(f"Remedy: {remedy}")
 
 

--- a/src/djinn_in_a_box/commands/session.py
+++ b/src/djinn_in_a_box/commands/session.py
@@ -85,10 +85,17 @@ def session(
             error("Docker daemon/container not reachable.")
             warning("Retry.")
             raise typer.Exit(1)
+        if container_image_compatibility is WorkflowImageCompatibility.MISSING:
+            error("Workflow image is not built.")
+            warning("Run `djinn build`, then retry.")
+            raise typer.Exit(1)
         if container_image_compatibility is WorkflowImageCompatibility.INCOMPATIBLE:
             error("Workflow image is incompatible.")
             warning("Rebuild/recreate required.")
             raise typer.Exit(1)
+        if container_image_compatibility is not WorkflowImageCompatibility.COMPATIBLE:
+            msg = f"Unhandled workflow image compatibility: {container_image_compatibility!r}"
+            raise AssertionError(msg)
 
     config = load_config()
     delivery_targets: tuple[WorkflowDeliveryTarget, ...] = ()

--- a/src/djinn_in_a_box/core/config_lock.py
+++ b/src/djinn_in_a_box/core/config_lock.py
@@ -10,7 +10,14 @@ from pathlib import Path
 
 
 class ConfigDirectoryLockError(OSError):
-    """The config directory could not be opened without following links."""
+    """A config-directory lock operation failed."""
+
+
+def _lock_error(config_dir: Path, error: OSError) -> ConfigDirectoryLockError:
+    return ConfigDirectoryLockError(
+        "Configuration directory lock failed at "
+        f"{config_dir}: {error.strerror or 'OS error'}"
+    )
 
 
 @contextmanager
@@ -18,19 +25,31 @@ def config_directory_lock(config_dir: Path, *, exclusive: bool) -> Iterator[int]
     try:
         descriptor = os.open(config_dir, os.O_RDONLY | os.O_DIRECTORY)
     except OSError as error:
-        # Name the directory: the most common cause is a clone that has never
-        # run `djinn init`, since config/ is git-ignored blank space. A generic
-        # message leaves that user with nothing to act on.
-        raise ConfigDirectoryLockError(
-            f"Configuration directory cannot be locked safely: {config_dir} ({error.strerror})"
-        ) from error
+        raise _lock_error(config_dir, error) from error
     locked = False
     try:
         operation = fcntl.LOCK_EX if exclusive else fcntl.LOCK_SH
-        fcntl.flock(descriptor, operation)
+        try:
+            fcntl.flock(descriptor, operation)
+        except OSError as error:
+            raise _lock_error(config_dir, error) from error
         locked = True
         yield descriptor
     finally:
-        if locked:
+        _release_config_directory_lock(config_dir, descriptor, locked)
+
+
+def _release_config_directory_lock(config_dir: Path, descriptor: int, locked: bool) -> None:
+    release_error: OSError | None = None
+    if locked:
+        try:
             fcntl.flock(descriptor, fcntl.LOCK_UN)
+        except OSError as error:
+            release_error = error
+    try:
         os.close(descriptor)
+    except OSError as error:
+        if release_error is None:
+            release_error = error
+    if release_error is not None:
+        raise _lock_error(config_dir, release_error) from release_error

--- a/src/djinn_in_a_box/core/config_sync.py
+++ b/src/djinn_in_a_box/core/config_sync.py
@@ -148,7 +148,9 @@ def audit_config_sync(
     try:
         with canonical_lock(config_root, exclusive=False):
             return _audit_locked(project_root, source)
-    except (OSError, PublishError):
+    except PublishError:
+        return _audit_for(source, DriftClass.INVALID_OR_SEMANTIC)
+    except OSError:
         return _audit_for(source, DriftClass.INVALID_OR_SEMANTIC)
 
 
@@ -212,7 +214,9 @@ def sync_config(
             _audit_for(source, error.drift),
             retryable=error.drift is DriftClass.SOURCE_CHANGED,
         )
-    except (OSError, PublishError, ValueError):
+    except PublishError:
+        return ConfigSyncResult(False, _audit_for(source, DriftClass.INVALID_OR_SEMANTIC))
+    except (OSError, ValueError):
         return ConfigSyncResult(False, _audit_for(source, DriftClass.INVALID_OR_SEMANTIC))
 
 
@@ -236,7 +240,11 @@ def load_canonical_delivery_view(
             _audit_for(source, error.drift),
             retryable=error.drift is DriftClass.SOURCE_CHANGED,
         )
-    except (KeyError, OSError, PublishError):
+    except PublishError:
+        return CanonicalDeliveryViewResult(
+            False, _audit_for(source, DriftClass.INVALID_OR_SEMANTIC)
+        )
+    except (KeyError, OSError):
         return CanonicalDeliveryViewResult(
             False, _audit_for(source, DriftClass.INVALID_OR_SEMANTIC)
         )

--- a/src/djinn_in_a_box/core/config_sync.py
+++ b/src/djinn_in_a_box/core/config_sync.py
@@ -55,6 +55,10 @@ CANONICAL_REMEDY = (
     "Author or edit the artifact natively in the target tool's view, "
     "or make the source form portable."
 )
+LOCK_REMEDY = (
+    "Check that the canonical workflow root is a readable, lockable directory "
+    "and that no other Djinn process is stuck on it, then retry."
+)
 _TOOLS: tuple[ConfigSyncSource, ...] = ("claude", "codex", "opencode")
 _LEGACY_ARTIFACT_KINDS = frozenset(
     {"instructions", "agent", "skill", "command", "context", "hook"}
@@ -76,6 +80,7 @@ class SyncProblem:
     message: str
     tool: ConfigSyncSource | None = None
     relative_path: PurePosixPath | None = None
+    remedy: str | None = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -148,7 +153,9 @@ def audit_config_sync(
     try:
         with canonical_lock(config_root, exclusive=False):
             return _audit_locked(project_root, source)
-    except PublishError:
+    except PublishError as error:
+        if error.lock_error is not None:
+            return _lock_failure_audit(source, config_root, error.lock_error)
         return _audit_for(source, DriftClass.INVALID_OR_SEMANTIC)
     except OSError:
         return _audit_for(source, DriftClass.INVALID_OR_SEMANTIC)
@@ -214,7 +221,11 @@ def sync_config(
             _audit_for(source, error.drift),
             retryable=error.drift is DriftClass.SOURCE_CHANGED,
         )
-    except PublishError:
+    except PublishError as error:
+        if error.lock_error is not None:
+            return ConfigSyncResult(
+                False, _lock_failure_audit(source, config_root, error.lock_error)
+            )
         return ConfigSyncResult(False, _audit_for(source, DriftClass.INVALID_OR_SEMANTIC))
     except (OSError, ValueError):
         return ConfigSyncResult(False, _audit_for(source, DriftClass.INVALID_OR_SEMANTIC))
@@ -240,7 +251,11 @@ def load_canonical_delivery_view(
             _audit_for(source, error.drift),
             retryable=error.drift is DriftClass.SOURCE_CHANGED,
         )
-    except PublishError:
+    except PublishError as error:
+        if error.lock_error is not None:
+            return CanonicalDeliveryViewResult(
+                False, _lock_failure_audit(source, config_root, error.lock_error)
+            )
         return CanonicalDeliveryViewResult(
             False, _audit_for(source, DriftClass.INVALID_OR_SEMANTIC)
         )
@@ -1098,6 +1113,22 @@ def _invalid_audit(
         None,
         (DriftItem(DriftClass.INVALID_OR_SEMANTIC, "Workflow artifact is invalid."),),
         tuple(problems),
+    )
+
+
+def _lock_failure_audit(
+    source: ConfigSyncSource, config_root: Path, error: OSError
+) -> ConfigSyncAudit:
+    return ConfigSyncAudit(
+        source,
+        None,
+        problems=(
+            SyncProblem(
+                "canonical-lock-failed",
+                f"Canonical workflow lock failed at {config_root}: {error.strerror or 'OS error'}",
+                remedy=LOCK_REMEDY,
+            ),
+        ),
     )
 
 

--- a/src/djinn_in_a_box/core/config_workflow.py
+++ b/src/djinn_in_a_box/core/config_workflow.py
@@ -193,6 +193,8 @@ def prepare_config_workflow(
     for target in targets:
         if _compose_claude_target(config, target, require_compose_host_env):
             retired = retire_legacy_delivery_manifest(target.destination_root)
+            if retired.lock_error is not None:
+                return _publish_lock_failure(target.destination_root, retired.lock_error)
             if retired.write_error is not None:
                 return _publish_write_failure(target.destination_root, retired.write_error)
             if not retired.success:
@@ -227,6 +229,8 @@ def prepare_config_workflow(
             return _canonical_lock_failure(canonical_root, error)
         except OSError:
             return _failure(DriftClass.INVALID_OR_SEMANTIC.value)
+        if published.lock_error is not None:
+            return _publish_lock_failure(target.destination_root, published.lock_error)
         if published.write_error is not None:
             return _publish_write_failure(target.destination_root, published.write_error)
         if not published.success:
@@ -362,6 +366,26 @@ def _canonical_lock_failure(canonical_root: Path, error: PublishError) -> Workfl
                 f"Canonical workflow lock failed at {canonical_root}: {cause}",
                 "Check that the canonical workflow root is a readable, lockable "
                 "directory and that no other Djinn process is stuck on it, then retry.",
+            ),
+        ),
+    )
+
+
+def _publish_lock_failure(destination: Path, error: OSError) -> WorkflowPreparationResult:
+    """A lease failure, not a write failure.
+
+    Kept apart from _publish_write_failure because nothing was published: naming
+    the operation "publish" and advising writable directories with free space
+    would describe neither what failed nor what fixes it.
+    """
+    return WorkflowPreparationResult(
+        False,
+        (
+            WorkflowPreparationProblem(
+                "workflow-lock-failed",
+                f"Failed to lock the workflow destination {destination}: {error}",
+                "Check that the destination is a lockable directory and that no other Djinn "
+                "process is stuck on it, then retry.",
             ),
         ),
     )

--- a/src/djinn_in_a_box/core/config_workflow.py
+++ b/src/djinn_in_a_box/core/config_workflow.py
@@ -330,9 +330,7 @@ def _publish_failure(result: PublishResult) -> WorkflowPreparationResult:
     return _failure(result.drift_class.value)
 
 
-def _canonical_lock_failure(
-    canonical_root: Path, error: OSError | PublishError
-) -> WorkflowPreparationResult:
+def _canonical_lock_failure(canonical_root: Path, error: PublishError) -> WorkflowPreparationResult:
     cause = error.__cause__ if isinstance(error.__cause__, OSError) else error
     return WorkflowPreparationResult(
         False,

--- a/src/djinn_in_a_box/core/config_workflow.py
+++ b/src/djinn_in_a_box/core/config_workflow.py
@@ -141,12 +141,21 @@ def prepare_config_workflow(
                     "Docker daemon/container not reachable.",
                     "Retry.",
                 )
-            else:
+            elif image_compatibility is WorkflowImageCompatibility.MISSING:
+                problem = WorkflowPreparationProblem(
+                    "image-not-built",
+                    "Workflow image is not built.",
+                    "Run `djinn build`, then retry.",
+                )
+            elif image_compatibility is WorkflowImageCompatibility.INCOMPATIBLE:
                 problem = WorkflowPreparationProblem(
                     "image-incompatible",
                     "Workflow image is incompatible.",
                     "Rebuild/recreate required.",
                 )
+            else:
+                msg = f"Unhandled workflow image compatibility: {image_compatibility!r}"
+                raise AssertionError(msg)
             return WorkflowPreparationResult(
                 False,
                 (problem,),

--- a/src/djinn_in_a_box/core/config_workflow.py
+++ b/src/djinn_in_a_box/core/config_workflow.py
@@ -24,6 +24,7 @@ from djinn_in_a_box.core.docker import (
 from djinn_in_a_box.core.workflow_publisher import (
     RUNTIME_MANIFEST_NAME,
     CarrierFragment,
+    PublishError,
     PublishResult,
     WorkflowView,
     canonical_lock,
@@ -219,6 +220,8 @@ def prepare_config_workflow(
                     source_root=canonical_root / loaded.audit.configured_source,
                     source_inputs=loaded.source_inputs,
                 )
+        except PublishError as error:
+            return _canonical_lock_failure(canonical_root, error)
         except OSError:
             return _failure(DriftClass.INVALID_OR_SEMANTIC.value)
         if published.write_error is not None:
@@ -325,6 +328,22 @@ def _audit_failure(audit: ConfigSyncAudit) -> WorkflowPreparationResult:
 
 def _publish_failure(result: PublishResult) -> WorkflowPreparationResult:
     return _failure(result.drift_class.value)
+
+
+def _canonical_lock_failure(
+    canonical_root: Path, error: OSError | PublishError
+) -> WorkflowPreparationResult:
+    cause = error.__cause__ if isinstance(error.__cause__, OSError) else error
+    return WorkflowPreparationResult(
+        False,
+        (
+            WorkflowPreparationProblem(
+                "canonical-lock-failed",
+                f"Failed to acquire the canonical workflow lock at {canonical_root}: {cause}",
+                "Restore the canonical workflow root as a readable directory, then retry.",
+            ),
+        ),
+    )
 
 
 def _publish_write_failure(destination: Path, error: OSError) -> WorkflowPreparationResult:

--- a/src/djinn_in_a_box/core/config_workflow.py
+++ b/src/djinn_in_a_box/core/config_workflow.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import stat
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -218,18 +219,10 @@ def prepare_config_workflow(
                     source_root=canonical_root / loaded.audit.configured_source,
                     source_inputs=loaded.source_inputs,
                 )
-        except OSError as error:
-            return WorkflowPreparationResult(
-                False,
-                (
-                    WorkflowPreparationProblem(
-                        "workflow-publish-failed",
-                        f"Failed to publish workflow to {target.destination_root}: {error}",
-                        "Check that the workflow destination and its parent directories are "
-                        "writable with available space, then retry.",
-                    ),
-                ),
-            )
+        except OSError:
+            return _failure(DriftClass.INVALID_OR_SEMANTIC.value)
+        if published.write_error is not None:
+            return _publish_write_failure(target.destination_root, published.write_error)
         if not published.success:
             return _publish_failure(published)
     return WorkflowPreparationResult(True)
@@ -247,34 +240,46 @@ def _compose_claude_target(
 
 def _prepare_target(target: WorkflowDeliveryTarget) -> WorkflowPreparationProblem | None:
     try:
-        if target.destination_root.is_symlink():
-            return WorkflowPreparationProblem(
-                "target-symlink",
-                f"Workflow destination is a symlink: {target.destination_root}",
-                "Replace the symlink with a directory managed by Djinn, then retry.",
-            )
-        if target.destination_root.exists():
-            if target.destination_root.is_dir():
-                return None
-            return WorkflowPreparationProblem(
-                "target-not-directory",
-                f"Workflow destination is not a directory: {target.destination_root}",
-                "Replace the destination with a directory managed by Djinn, then retry.",
-            )
-        if not target.provision:
-            return WorkflowPreparationProblem(
-                "target-missing",
-                f"Workflow destination does not exist: {target.destination_root}",
-                "Create the destination directory or enable its provisioning, then retry.",
-            )
-        target.destination_root.mkdir(parents=True)
-        return None
+        entry = target.destination_root.lstat()
+    except FileNotFoundError:
+        return _prepare_missing_target(target)
     except OSError as error:
         return WorkflowPreparationProblem(
             "target-provisioning-failed",
             f"Failed to prepare workflow destination {target.destination_root}: {error}",
             "Check that the destination and its parent directories are writable, then retry.",
         )
+    if stat.S_ISLNK(entry.st_mode):
+        return WorkflowPreparationProblem(
+            "target-symlink",
+            f"Workflow destination is a symlink: {target.destination_root}",
+            "Replace the symlink with a directory managed by Djinn, then retry.",
+        )
+    if stat.S_ISDIR(entry.st_mode):
+        return None
+    return WorkflowPreparationProblem(
+        "target-not-directory",
+        f"Workflow destination is not a directory: {target.destination_root}",
+        "Replace the destination with a directory managed by Djinn, then retry.",
+    )
+
+
+def _prepare_missing_target(target: WorkflowDeliveryTarget) -> WorkflowPreparationProblem | None:
+    if not target.provision:
+        return WorkflowPreparationProblem(
+            "target-missing",
+            f"Workflow destination does not exist: {target.destination_root}",
+            "Create the destination directory or enable its provisioning, then retry.",
+        )
+    try:
+        target.destination_root.mkdir(parents=True)
+    except OSError as error:
+        return WorkflowPreparationProblem(
+            "target-provisioning-failed",
+            f"Failed to prepare workflow destination {target.destination_root}: {error}",
+            "Check that the destination and its parent directories are writable, then retry.",
+        )
+    return None
 
 
 def _host_claude_view(
@@ -320,6 +325,20 @@ def _audit_failure(audit: ConfigSyncAudit) -> WorkflowPreparationResult:
 
 def _publish_failure(result: PublishResult) -> WorkflowPreparationResult:
     return _failure(result.drift_class.value)
+
+
+def _publish_write_failure(destination: Path, error: OSError) -> WorkflowPreparationResult:
+    return WorkflowPreparationResult(
+        False,
+        (
+            WorkflowPreparationProblem(
+                "workflow-publish-failed",
+                f"Failed to publish workflow to {destination}: {error}",
+                "Check that the workflow destination and its parent directories are writable "
+                "with available space, then retry.",
+            ),
+        ),
+    )
 
 
 def _failure(identifier: str) -> WorkflowPreparationResult:

--- a/src/djinn_in_a_box/core/config_workflow.py
+++ b/src/djinn_in_a_box/core/config_workflow.py
@@ -184,8 +184,9 @@ def prepare_config_workflow(
             if not retired.success:
                 return _publish_failure(retired)
             continue
-        if not _prepare_target(target):
-            return _failure("invalid-or-semantic")
+        target_problem = _prepare_target(target)
+        if target_problem is not None:
+            return WorkflowPreparationResult(False, (target_problem,))
         try:
             with canonical_lock(canonical_root, exclusive=False) as lease:
                 loaded = load_canonical_delivery_view(
@@ -208,8 +209,18 @@ def prepare_config_workflow(
                     source_root=canonical_root / loaded.audit.configured_source,
                     source_inputs=loaded.source_inputs,
                 )
-        except OSError:
-            return _failure("invalid-or-semantic")
+        except OSError as error:
+            return WorkflowPreparationResult(
+                False,
+                (
+                    WorkflowPreparationProblem(
+                        "workflow-publish-failed",
+                        f"Failed to publish workflow to {target.destination_root}: {error}",
+                        "Check that the workflow destination and its parent directories are "
+                        "writable with available space, then retry.",
+                    ),
+                ),
+            )
         if not published.success:
             return _publish_failure(published)
     return WorkflowPreparationResult(True)
@@ -225,16 +236,36 @@ def _compose_claude_target(
     )
 
 
-def _prepare_target(target: WorkflowDeliveryTarget) -> bool:
+def _prepare_target(target: WorkflowDeliveryTarget) -> WorkflowPreparationProblem | None:
     try:
+        if target.destination_root.is_symlink():
+            return WorkflowPreparationProblem(
+                "target-symlink",
+                f"Workflow destination is a symlink: {target.destination_root}",
+                "Replace the symlink with a directory managed by Djinn, then retry.",
+            )
         if target.destination_root.exists():
-            return target.destination_root.is_dir() and not target.destination_root.is_symlink()
+            if target.destination_root.is_dir():
+                return None
+            return WorkflowPreparationProblem(
+                "target-not-directory",
+                f"Workflow destination is not a directory: {target.destination_root}",
+                "Replace the destination with a directory managed by Djinn, then retry.",
+            )
         if not target.provision:
-            return False
+            return WorkflowPreparationProblem(
+                "target-missing",
+                f"Workflow destination does not exist: {target.destination_root}",
+                "Create the destination directory or enable its provisioning, then retry.",
+            )
         target.destination_root.mkdir(parents=True)
-        return True
-    except OSError:
-        return False
+        return None
+    except OSError as error:
+        return WorkflowPreparationProblem(
+            "target-provisioning-failed",
+            f"Failed to prepare workflow destination {target.destination_root}: {error}",
+            "Check that the destination and its parent directories are writable, then retry.",
+        )
 
 
 def _host_claude_view(

--- a/src/djinn_in_a_box/core/config_workflow.py
+++ b/src/djinn_in_a_box/core/config_workflow.py
@@ -11,6 +11,7 @@ from djinn_in_a_box.core.config_sync import (
     CANONICAL_REMEDY,
     ConfigSyncAudit,
     DriftClass,
+    SyncProblem,
     audit_config_sync,
     load_canonical_delivery_view,
     sync_config,
@@ -192,6 +193,8 @@ def prepare_config_workflow(
     for target in targets:
         if _compose_claude_target(config, target, require_compose_host_env):
             retired = retire_legacy_delivery_manifest(target.destination_root)
+            if retired.write_error is not None:
+                return _publish_write_failure(target.destination_root, retired.write_error)
             if not retired.success:
                 return _publish_failure(retired)
             continue
@@ -319,11 +322,26 @@ def _auto_repairable(audit: ConfigSyncAudit) -> bool:
 
 
 def _audit_failure(audit: ConfigSyncAudit) -> WorkflowPreparationResult:
+    if audit.problems:
+        return _sync_problem_failure(audit.problems[0])
     drift = next(
         (item.kind for item in audit.drifts if item.kind is not DriftClass.CLEAN),
         DriftClass.INVALID_OR_SEMANTIC,
     )
     return _failure(drift.value)
+
+
+def _sync_problem_failure(problem: SyncProblem) -> WorkflowPreparationResult:
+    return WorkflowPreparationResult(
+        False,
+        (
+            WorkflowPreparationProblem(
+                problem.identifier,
+                problem.message,
+                problem.remedy or CANONICAL_REMEDY,
+            ),
+        ),
+    )
 
 
 def _publish_failure(result: PublishResult) -> WorkflowPreparationResult:

--- a/src/djinn_in_a_box/core/config_workflow.py
+++ b/src/djinn_in_a_box/core/config_workflow.py
@@ -337,8 +337,13 @@ def _canonical_lock_failure(canonical_root: Path, error: PublishError) -> Workfl
         (
             WorkflowPreparationProblem(
                 "canonical-lock-failed",
-                f"Failed to acquire the canonical workflow lock at {canonical_root}: {cause}",
-                "Restore the canonical workflow root as a readable directory, then retry.",
+                # Deliberately does not say "acquire": the same channel carries
+                # release failures (an interrupted unlock or close), where the
+                # lease was held successfully and telling the user to restore
+                # directory readability would be false advice.
+                f"Canonical workflow lock failed at {canonical_root}: {cause}",
+                "Check that the canonical workflow root is a readable, lockable "
+                "directory and that no other Djinn process is stuck on it, then retry.",
             ),
         ),
     )

--- a/src/djinn_in_a_box/core/decorators.py
+++ b/src/djinn_in_a_box/core/decorators.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import errno
 from collections.abc import Callable
 from functools import wraps
 from typing import ParamSpec, TypeVar
@@ -30,7 +31,14 @@ def handle_config_errors(func: Callable[P, R]) -> Callable[P, R]:
             return func(*args, **kwargs)
         except ConfigDirectoryLockError as e:
             error(str(e))
-            warning("Run `djinn init` to create it, then retry.")
+            cause = e.__cause__
+            if isinstance(cause, OSError) and cause.errno == errno.ENOENT:
+                warning("Run `djinn init` to create it, then retry.")
+            else:
+                warning(
+                    "Check that the configuration directory is readable and lockable, "
+                    "then retry."
+                )
             raise typer.Exit(1) from None
         except (ConfigNotFoundError, ConfigValidationError) as e:
             error(str(e))

--- a/src/djinn_in_a_box/core/docker.py
+++ b/src/djinn_in_a_box/core/docker.py
@@ -44,6 +44,7 @@ class DockerMode(Enum):
 class WorkflowImageCompatibility(Enum):
     COMPATIBLE = "compatible"
     INCOMPATIBLE = "incompatible"
+    MISSING = "missing"
     UNKNOWN = "unknown"
 
 
@@ -569,12 +570,31 @@ def workflow_image_compatible(
     except (FileNotFoundError, PermissionError, OSError, subprocess.TimeoutExpired):
         return WorkflowImageCompatibility.UNKNOWN
     if result.returncode != 0:
-        return WorkflowImageCompatibility.UNKNOWN
+        return (
+            WorkflowImageCompatibility.MISSING
+            if _docker_daemon_reachable()
+            else WorkflowImageCompatibility.UNKNOWN
+        )
     return (
         WorkflowImageCompatibility.COMPATIBLE
         if result.stdout.strip() == "1"
         else WorkflowImageCompatibility.INCOMPATIBLE
     )
+
+
+def _docker_daemon_reachable() -> bool:
+    """Return whether Docker responds after an image-inspect failure."""
+    try:
+        result = subprocess.run(
+            ["docker", "info"],
+            capture_output=True,
+            text=True,
+            timeout=_WORKFLOW_IMAGE_INSPECT_TIMEOUT,
+            check=False,
+        )
+    except (FileNotFoundError, PermissionError, OSError, subprocess.TimeoutExpired):
+        return False
+    return result.returncode == 0
 
 
 def ensure_host_env(config: AppConfig | None = None) -> None:

--- a/src/djinn_in_a_box/core/session.py
+++ b/src/djinn_in_a_box/core/session.py
@@ -15,7 +15,7 @@ from typing import cast
 
 from djinn_in_a_box.config.loader import load_agents
 from djinn_in_a_box.config.models import AgentConfig
-from djinn_in_a_box.core.config_sync import CANONICAL_REMEDY
+from djinn_in_a_box.core.config_sync import CANONICAL_REMEDY, LOCK_REMEDY
 from djinn_in_a_box.core.docker import (
     WorkflowImageCompatibility,
     _decode_timeout_output,  # pyright: ignore[reportPrivateUsage]
@@ -23,7 +23,11 @@ from djinn_in_a_box.core.docker import (
 from djinn_in_a_box.core.docker import (
     workflow_image_compatible as inspect_workflow_image,
 )
-from djinn_in_a_box.core.workflow_publisher import PUBLISHER_WRITE_ERROR_PREFIX, DriftClass
+from djinn_in_a_box.core.workflow_publisher import (
+    PUBLISHER_LOCK_ERROR_PREFIX,
+    PUBLISHER_WRITE_ERROR_PREFIX,
+    DriftClass,
+)
 
 log = logging.getLogger(__name__)
 
@@ -462,6 +466,9 @@ class SessionManager:
 def _publisher_refresh_error(stderr: str) -> str:
     for line in reversed(stderr.splitlines()):
         value = line.strip()
+        lock_failure = _publisher_lock_failure(value)
+        if lock_failure is not None:
+            return lock_failure
         write_failure = _publisher_write_failure(value)
         if write_failure is not None:
             return write_failure
@@ -474,6 +481,26 @@ def _publisher_refresh_error(stderr: str) -> str:
                     f"Remedy: {_PUBLISHER_REMEDIES[drift]}"
                 )
     return "OpenCode workflow refresh failed"
+
+
+def _publisher_lock_failure(value: str) -> str | None:
+    if not value.startswith(PUBLISHER_LOCK_ERROR_PREFIX):
+        return None
+    try:
+        diagnostic = json.loads(value.removeprefix(PUBLISHER_LOCK_ERROR_PREFIX))
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(diagnostic, dict):
+        return None
+    details = cast(dict[str, object], diagnostic)
+    root = details.get("root")
+    error = details.get("error")
+    if not isinstance(root, str) or not isinstance(error, str):
+        return None
+    return (
+        f"OpenCode workflow refresh failed: Canonical workflow lock failed at {root}: {error}. "
+        f"Remedy: {LOCK_REMEDY}"
+    )
 
 
 def _publisher_write_failure(value: str) -> str | None:

--- a/src/djinn_in_a_box/core/session.py
+++ b/src/djinn_in_a_box/core/session.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import logging
 import os
 import re
@@ -10,6 +11,7 @@ import shutil
 import subprocess
 from dataclasses import dataclass
 from pathlib import Path
+from typing import cast
 
 from djinn_in_a_box.config.loader import load_agents
 from djinn_in_a_box.config.models import AgentConfig
@@ -21,7 +23,7 @@ from djinn_in_a_box.core.docker import (
 from djinn_in_a_box.core.docker import (
     workflow_image_compatible as inspect_workflow_image,
 )
-from djinn_in_a_box.core.workflow_publisher import DriftClass
+from djinn_in_a_box.core.workflow_publisher import PUBLISHER_WRITE_ERROR_PREFIX, DriftClass
 
 log = logging.getLogger(__name__)
 
@@ -460,6 +462,9 @@ class SessionManager:
 def _publisher_refresh_error(stderr: str) -> str:
     for line in reversed(stderr.splitlines()):
         value = line.strip()
+        write_failure = _publisher_write_failure(value)
+        if write_failure is not None:
+            return write_failure
         for drift in DriftClass:
             if drift is DriftClass.CLEAN:
                 continue
@@ -469,3 +474,24 @@ def _publisher_refresh_error(stderr: str) -> str:
                     f"Remedy: {_PUBLISHER_REMEDIES[drift]}"
                 )
     return "OpenCode workflow refresh failed"
+
+
+def _publisher_write_failure(value: str) -> str | None:
+    if not value.startswith(PUBLISHER_WRITE_ERROR_PREFIX):
+        return None
+    try:
+        diagnostic = json.loads(value.removeprefix(PUBLISHER_WRITE_ERROR_PREFIX))
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(diagnostic, dict):
+        return None
+    details = cast(dict[str, object], diagnostic)
+    destination = details.get("destination")
+    error = details.get("error")
+    if not isinstance(destination, str) or not isinstance(error, str):
+        return None
+    return (
+        f"OpenCode workflow refresh failed to publish workflow to {destination}: {error}. "
+        "Remedy: Check that the workflow destination and its parent directories are writable "
+        "with available space, then retry."
+    )

--- a/src/djinn_in_a_box/core/session.py
+++ b/src/djinn_in_a_box/core/session.py
@@ -18,6 +18,9 @@ from djinn_in_a_box.core.docker import (
     WorkflowImageCompatibility,
     _decode_timeout_output,  # pyright: ignore[reportPrivateUsage]
 )
+from djinn_in_a_box.core.docker import (
+    workflow_image_compatible as inspect_workflow_image,
+)
 from djinn_in_a_box.core.workflow_publisher import DriftClass
 
 log = logging.getLogger(__name__)
@@ -113,8 +116,16 @@ class SessionManager:
             return SessionResult(
                 returncode=1, stderr="Docker daemon/container not reachable — retry."
             )
+        if image_compatibility is WorkflowImageCompatibility.MISSING:
+            return SessionResult(
+                returncode=1,
+                stderr="Workflow image is not built — run `djinn build`, then retry.",
+            )
         if image_compatibility is WorkflowImageCompatibility.INCOMPATIBLE:
             return SessionResult(returncode=1, stderr="Rebuild/recreate required.")
+        if image_compatibility is not WorkflowImageCompatibility.COMPATIBLE:
+            msg = f"Unhandled workflow image compatibility: {image_compatibility!r}"
+            raise AssertionError(msg)
         command = [
             "docker",
             "exec",
@@ -167,29 +178,9 @@ class SessionManager:
             if container.returncode != 0 or not container.stdout.strip():
                 return WorkflowImageCompatibility.UNKNOWN
             image = container.stdout.strip()
-            inspected = subprocess.run(
-                [
-                    "docker",
-                    "image",
-                    "inspect",
-                    image,
-                    "--format",
-                    '{{ index .Config.Labels "djinn.workflow.publisher" }}',
-                ],
-                capture_output=True,
-                text=True,
-                timeout=_EXEC_TIMEOUT,
-                check=False,
-            )
         except (FileNotFoundError, PermissionError, OSError, subprocess.TimeoutExpired):
             return WorkflowImageCompatibility.UNKNOWN
-        if inspected.returncode != 0:
-            return WorkflowImageCompatibility.UNKNOWN
-        return (
-            WorkflowImageCompatibility.COMPATIBLE
-            if inspected.stdout.strip() == "1"
-            else WorkflowImageCompatibility.INCOMPATIBLE
-        )
+        return inspect_workflow_image(image)
 
     def run_interactive(
         self,

--- a/src/djinn_in_a_box/core/workflow_publisher.py
+++ b/src/djinn_in_a_box/core/workflow_publisher.py
@@ -83,6 +83,10 @@ class PublishResult:
     changed_paths: tuple[PurePosixPath, ...] = ()
     removed_paths: tuple[PurePosixPath, ...] = ()
     write_error: OSError | None = None
+    lock_error: OSError | None = None
+    """Separate from write_error on purpose: a lease failure means nothing was
+    written, so reporting it as a publish failure would name the wrong operation
+    and offer a remedy about writability that does not apply."""
 
     @property
     def success(self) -> bool:
@@ -363,7 +367,7 @@ def publish_workflow_view(
                 preflight_manifest,
             )
     except PublishError as error:
-        return PublishResult(error.drift_class, write_error=error.lock_error)
+        return PublishResult(error.drift_class, lock_error=error.lock_error)
     except OSError as error:
         return PublishResult(DriftClass.INVALID_OR_SEMANTIC, write_error=error)
     except (UnicodeError, ValueError):
@@ -1093,7 +1097,7 @@ def retire_legacy_delivery_manifest(target_root: Path) -> PublishResult:
             _fsync_directory(target_root)
             return PublishResult(DriftClass.CLEAN)
     except PublishError as error:
-        return PublishResult(error.drift_class, write_error=error.lock_error)
+        return PublishResult(error.drift_class, lock_error=error.lock_error)
     except OSError as error:
         return PublishResult(DriftClass.INVALID_OR_SEMANTIC, write_error=error)
 
@@ -1737,6 +1741,9 @@ def main(argv: Sequence[str] | None = None) -> int:
                 _write_error_diagnostic(Path(arguments.target), result.write_error),
                 file=sys.stderr,
             )
+        # Two sources: a PublishError that reached this frame, and one
+        # publish_workflow_view already converted into the result field.
+        lock_error = lock_error or result.lock_error
         if lock_error is not None:
             print(
                 _lock_error_diagnostic(Path(arguments.canonical_root), lock_error),

--- a/src/djinn_in_a_box/core/workflow_publisher.py
+++ b/src/djinn_in_a_box/core/workflow_publisher.py
@@ -23,6 +23,7 @@ CANONICAL_MANIFEST_NAME = ".djinn-config-sync.json"
 RUNTIME_MANIFEST_NAME = ".djinn-workflow-state.json"
 LEGACY_DELIVERY_MANIFEST_NAME = ".djinn-workflow-delivery.json"
 PUBLISHER_WRITE_ERROR_PREFIX = "workflow publisher write-error: "
+PUBLISHER_LOCK_ERROR_PREFIX = "workflow publisher lock-error: "
 
 
 class DriftClass(StrEnum):
@@ -155,9 +156,10 @@ class _Preflight:
 
 
 class PublishError(RuntimeError):
-    def __init__(self, drift_class: DriftClass) -> None:
+    def __init__(self, drift_class: DriftClass, *, lock_error: OSError | None = None) -> None:
         super().__init__(drift_class)
         self.drift_class = drift_class
+        self.lock_error = lock_error
 
 
 class ManifestError(ValueError):
@@ -262,14 +264,14 @@ def canonical_lock(root: Path, *, exclusive: bool) -> Iterator[CanonicalLockLeas
         try:
             fcntl.flock(descriptor, fcntl.LOCK_EX if exclusive else fcntl.LOCK_SH)
         except OSError as error:
-            raise PublishError(DriftClass.INVALID_OR_SEMANTIC) from error
+            raise PublishError(DriftClass.INVALID_OR_SEMANTIC, lock_error=error) from error
         locked = True
         yield CanonicalLockLease(root.resolve(), descriptor, exclusive)
     finally:
-        _release_canonical_lock(descriptor, locked)
+        _release_directory_lock(descriptor, locked)
 
 
-def _release_canonical_lock(descriptor: int, locked: bool) -> None:
+def _release_directory_lock(descriptor: int, locked: bool) -> None:
     release_error: OSError | None = None
     if locked:
         try:
@@ -282,7 +284,9 @@ def _release_canonical_lock(descriptor: int, locked: bool) -> None:
         if release_error is None:
             release_error = error
     if release_error is not None:
-        raise PublishError(DriftClass.INVALID_OR_SEMANTIC) from release_error
+        raise PublishError(
+            DriftClass.INVALID_OR_SEMANTIC, lock_error=release_error
+        ) from release_error
 
 
 def snapshot_file_view(
@@ -359,7 +363,7 @@ def publish_workflow_view(
                 preflight_manifest,
             )
     except PublishError as error:
-        return PublishResult(error.drift_class)
+        return PublishResult(error.drift_class, write_error=error.lock_error)
     except OSError as error:
         return PublishResult(DriftClass.INVALID_OR_SEMANTIC, write_error=error)
     except (UnicodeError, ValueError):
@@ -517,13 +521,14 @@ def _target_lock(root: Path) -> Iterator[None]:
     descriptor = _open_directory(root)
     locked = False
     try:
-        fcntl.flock(descriptor, fcntl.LOCK_EX)
+        try:
+            fcntl.flock(descriptor, fcntl.LOCK_EX)
+        except OSError as error:
+            raise PublishError(DriftClass.INVALID_OR_SEMANTIC, lock_error=error) from error
         locked = True
         yield
     finally:
-        if locked:
-            fcntl.flock(descriptor, fcntl.LOCK_UN)
-        os.close(descriptor)
+        _release_directory_lock(descriptor, locked)
 
 
 def _validate_lease(
@@ -1088,7 +1093,7 @@ def retire_legacy_delivery_manifest(target_root: Path) -> PublishResult:
             _fsync_directory(target_root)
             return PublishResult(DriftClass.CLEAN)
     except PublishError as error:
-        return PublishResult(error.drift_class)
+        return PublishResult(error.drift_class, write_error=error.lock_error)
     except OSError:
         return PublishResult(DriftClass.INVALID_OR_SEMANTIC)
 
@@ -1496,7 +1501,7 @@ def _open_directory(path: Path) -> int:
     try:
         return os.open(path, os.O_RDONLY | os.O_DIRECTORY)
     except OSError as error:
-        raise PublishError(DriftClass.INVALID_OR_SEMANTIC) from error
+        raise PublishError(DriftClass.INVALID_OR_SEMANTIC, lock_error=error) from error
 
 
 def _same_directory(first: Path, second: Path) -> bool:
@@ -1673,8 +1678,19 @@ def _write_error_diagnostic(destination: Path, error: OSError) -> str:
     )
 
 
+def _lock_error_diagnostic(root: Path, error: OSError) -> str:
+    return PUBLISHER_LOCK_ERROR_PREFIX + json.dumps(
+        {
+            "root": str(root),
+            "error": error.strerror or "OS error",
+        },
+        separators=(",", ":"),
+    )
+
+
 def main(argv: Sequence[str] | None = None) -> int:
     arguments = _parse_args(argv)
+    lock_error: OSError | None = None
     if arguments.fragment:
         result = PublishResult(DriftClass.INVALID_OR_SEMANTIC)
     else:
@@ -1712,12 +1728,18 @@ def main(argv: Sequence[str] | None = None) -> int:
                     source_profile=arguments.profile,
                 )
         except PublishError as error:
+            lock_error = error.lock_error
             result = PublishResult(error.drift_class)
     if not result.success:
         print(f"workflow publisher: {result.drift_class.value}", file=sys.stderr)
         if result.write_error is not None:
             print(
                 _write_error_diagnostic(Path(arguments.target), result.write_error),
+                file=sys.stderr,
+            )
+        if lock_error is not None:
+            print(
+                _lock_error_diagnostic(Path(arguments.canonical_root), lock_error),
                 file=sys.stderr,
             )
     return EXIT_CODES[result.drift_class]

--- a/src/djinn_in_a_box/core/workflow_publisher.py
+++ b/src/djinn_in_a_box/core/workflow_publisher.py
@@ -80,6 +80,7 @@ class PublishResult:
     drift_class: DriftClass
     changed_paths: tuple[PurePosixPath, ...] = ()
     removed_paths: tuple[PurePosixPath, ...] = ()
+    write_error: OSError | None = None
 
     @property
     def success(self) -> bool:
@@ -341,7 +342,9 @@ def publish_workflow_view(
             )
     except PublishError as error:
         return PublishResult(error.drift_class)
-    except (OSError, UnicodeError, ValueError):
+    except OSError as error:
+        return PublishResult(DriftClass.INVALID_OR_SEMANTIC, write_error=error)
+    except (UnicodeError, ValueError):
         return PublishResult(DriftClass.INVALID_OR_SEMANTIC)
 
 

--- a/src/djinn_in_a_box/core/workflow_publisher.py
+++ b/src/djinn_in_a_box/core/workflow_publisher.py
@@ -1094,8 +1094,8 @@ def retire_legacy_delivery_manifest(target_root: Path) -> PublishResult:
             return PublishResult(DriftClass.CLEAN)
     except PublishError as error:
         return PublishResult(error.drift_class, write_error=error.lock_error)
-    except OSError:
-        return PublishResult(DriftClass.INVALID_OR_SEMANTIC)
+    except OSError as error:
+        return PublishResult(DriftClass.INVALID_OR_SEMANTIC, write_error=error)
 
 
 def _load_legacy_delivery_manifest(

--- a/src/djinn_in_a_box/core/workflow_publisher.py
+++ b/src/djinn_in_a_box/core/workflow_publisher.py
@@ -259,13 +259,30 @@ def canonical_lock(root: Path, *, exclusive: bool) -> Iterator[CanonicalLockLeas
     descriptor = _open_directory(root)
     locked = False
     try:
-        fcntl.flock(descriptor, fcntl.LOCK_EX if exclusive else fcntl.LOCK_SH)
+        try:
+            fcntl.flock(descriptor, fcntl.LOCK_EX if exclusive else fcntl.LOCK_SH)
+        except OSError as error:
+            raise PublishError(DriftClass.INVALID_OR_SEMANTIC) from error
         locked = True
         yield CanonicalLockLease(root.resolve(), descriptor, exclusive)
     finally:
-        if locked:
+        _release_canonical_lock(descriptor, locked)
+
+
+def _release_canonical_lock(descriptor: int, locked: bool) -> None:
+    release_error: OSError | None = None
+    if locked:
+        try:
             fcntl.flock(descriptor, fcntl.LOCK_UN)
+        except OSError as error:
+            release_error = error
+    try:
         os.close(descriptor)
+    except OSError as error:
+        if release_error is None:
+            release_error = error
+    if release_error is not None:
+        raise PublishError(DriftClass.INVALID_OR_SEMANTIC) from release_error
 
 
 def snapshot_file_view(

--- a/src/djinn_in_a_box/core/workflow_publisher.py
+++ b/src/djinn_in_a_box/core/workflow_publisher.py
@@ -22,6 +22,7 @@ from typing import cast
 CANONICAL_MANIFEST_NAME = ".djinn-config-sync.json"
 RUNTIME_MANIFEST_NAME = ".djinn-workflow-state.json"
 LEGACY_DELIVERY_MANIFEST_NAME = ".djinn-workflow-delivery.json"
+PUBLISHER_WRITE_ERROR_PREFIX = "workflow publisher write-error: "
 
 
 class DriftClass(StrEnum):
@@ -1645,6 +1646,16 @@ def _parse_args(argv: Sequence[str] | None) -> argparse.Namespace:
     return parser.parse_args(argv)
 
 
+def _write_error_diagnostic(destination: Path, error: OSError) -> str:
+    return PUBLISHER_WRITE_ERROR_PREFIX + json.dumps(
+        {
+            "destination": str(destination),
+            "error": error.strerror or "OS error",
+        },
+        separators=(",", ":"),
+    )
+
+
 def main(argv: Sequence[str] | None = None) -> int:
     arguments = _parse_args(argv)
     if arguments.fragment:
@@ -1687,6 +1698,11 @@ def main(argv: Sequence[str] | None = None) -> int:
             result = PublishResult(error.drift_class)
     if not result.success:
         print(f"workflow publisher: {result.drift_class.value}", file=sys.stderr)
+        if result.write_error is not None:
+            print(
+                _write_error_diagnostic(Path(arguments.target), result.write_error),
+                file=sys.stderr,
+            )
     return EXIT_CODES[result.drift_class]
 
 

--- a/tests/test_cli_djinn.py
+++ b/tests/test_cli_djinn.py
@@ -1,5 +1,6 @@
 """Tests for the djinn CLI entry point."""
 
+import errno
 import subprocess
 from collections.abc import Iterator
 from contextlib import contextmanager
@@ -14,6 +15,7 @@ from djinn_in_a_box.cli.djinn import app
 from djinn_in_a_box.config.loader import load_config as load_config_file
 from djinn_in_a_box.config.loader import save_config as save_config_file
 from djinn_in_a_box.config.models import AppConfig, ResourceLimits, ShellConfig
+from djinn_in_a_box.core import config_lock
 
 runner = CliRunner()
 
@@ -353,6 +355,36 @@ class TestConfigSetCommand:
         assert load_config_file(config_file).config_sync.source == "codex"
         assert lock_calls == [(config_dir, True)]
 
+    def test_config_set_reports_unlock_failure_after_writing_without_success(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        config_file = tmp_path / "config.toml"
+        projects_dir = tmp_path / "projects"
+        projects_dir.mkdir()
+        _write_test_config(config_file, projects_dir)
+        monkeypatch.setattr("djinn_in_a_box.config.loader.CONFIG_FILE", config_file)
+        project_root = tmp_path / "project"
+        config_dir = project_root / "config"
+        config_dir.mkdir(parents=True)
+        monkeypatch.setattr("djinn_in_a_box.commands.config.get_project_root", lambda: project_root)
+        original_flock = config_lock.fcntl.flock
+
+        def fail_unlock(descriptor: int, operation: int) -> None:
+            if operation == config_lock.fcntl.LOCK_UN:
+                raise OSError(errno.EINTR, "Interrupted system call")
+            original_flock(descriptor, operation)
+
+        monkeypatch.setattr(config_lock.fcntl, "flock", fail_unlock)
+
+        result = runner.invoke(app, ["config", "set", "config_sync.source", "codex"])
+
+        assert result.exit_code == 1, result.output
+        assert load_config_file(config_file).config_sync.source == "codex"
+        assert "Configuration value was written, but releasing its lock failed." in result.output
+        assert "Interrupted system call" in result.output
+        assert "config_sync.source = codex" not in result.output
+        assert "Traceback" not in result.output
+
     def test_config_set_rejects_unknown_source_without_writing(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
@@ -608,6 +640,23 @@ class TestConfigEditCommand:
 
         assert result.exit_code == 0, result.output
         assert events == ["lock", "editor", "unlock"]
+
+    def test_config_edit_reports_lock_acquisition_failure_without_traceback(
+        self, monkeypatch: pytest.MonkeyPatch, config_edit_project: Path
+    ) -> None:
+        def fail_acquisition(_descriptor: int, _operation: int) -> None:
+            raise OSError(errno.ENOLCK, "No locks available")
+
+        monkeypatch.setattr(config_lock.fcntl, "flock", fail_acquisition)
+
+        result = runner.invoke(app, ["config", "edit"])
+
+        assert result.exit_code == 1, result.output
+        assert str(config_edit_project) in result.output
+        normalized = " ".join(result.output.split())
+        assert "No locks available" in normalized
+        assert "djinn init" not in normalized
+        assert "Traceback" not in normalized
 
     def test_config_edit_warns_when_editor_deletes_file(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, config_edit_project: Path

--- a/tests/test_commands/test_config_sync_cli.py
+++ b/tests/test_commands/test_config_sync_cli.py
@@ -11,10 +11,12 @@ from djinn_in_a_box.commands import doctor as doctor_module
 from djinn_in_a_box.config.models import AppConfig, ConfigSyncConfig
 from djinn_in_a_box.core.config_sync import (
     CANONICAL_REMEDY,
+    LOCK_REMEDY,
     ConfigSyncAudit,
     ConfigSyncResult,
     DriftClass,
     DriftItem,
+    SyncProblem,
 )
 
 runner = CliRunner()
@@ -108,6 +110,68 @@ def test_config_sync_reports_canonical_nonportable_remedy(
     assert _SENTINEL not in result.output
 
 
+def test_config_status_reports_lock_failure_without_portability_remedy(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    config_root = tmp_path / "project" / "config"
+    audit = ConfigSyncAudit(
+        "claude",
+        None,
+        problems=(
+            SyncProblem(
+                "canonical-lock-failed",
+                f"Canonical workflow lock failed at {config_root}: No locks available",
+                remedy=LOCK_REMEDY,
+            ),
+        ),
+    )
+    service = MagicMock(return_value=audit)
+    monkeypatch.setattr("djinn_in_a_box.commands.config.get_project_root", lambda: tmp_path)
+    monkeypatch.setattr("djinn_in_a_box.commands.config.audit_workflow_config", service)
+
+    result = runner.invoke(app, ["config", "status"])
+
+    assert result.exit_code == 1, result.output
+    assert "canonical-lock-failed" in result.output
+    assert str(config_root) in result.output
+    normalized = " ".join(result.output.split())
+    assert "No locks available" in normalized
+    assert LOCK_REMEDY in normalized
+    assert CANONICAL_REMEDY not in normalized
+    assert _SENTINEL not in normalized
+
+
+def test_config_sync_reports_lock_failure_without_portability_remedy(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    config_root = tmp_path / "project" / "config"
+    audit = ConfigSyncAudit(
+        "claude",
+        None,
+        problems=(
+            SyncProblem(
+                "canonical-lock-failed",
+                f"Canonical workflow lock failed at {config_root}: Interrupted system call",
+                remedy=LOCK_REMEDY,
+            ),
+        ),
+    )
+    service = MagicMock(return_value=ConfigSyncResult(False, audit))
+    monkeypatch.setattr("djinn_in_a_box.commands.config.get_project_root", lambda: tmp_path)
+    monkeypatch.setattr("djinn_in_a_box.commands.config.synchronize_workflow_config", service)
+
+    result = runner.invoke(app, ["config", "sync"])
+
+    assert result.exit_code == 1, result.output
+    assert "canonical-lock-failed" in result.output
+    assert str(config_root) in result.output
+    normalized = " ".join(result.output.split())
+    assert "Interrupted system call" in normalized
+    assert LOCK_REMEDY in normalized
+    assert CANONICAL_REMEDY not in normalized
+    assert "Traceback" not in normalized
+
+
 def test_config_status_missing_canonical_root_is_content_free(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -126,9 +190,13 @@ def test_config_status_missing_canonical_root_is_content_free(
     result = runner.invoke(app, ["config", "status"])
 
     assert result.exit_code == 1
-    assert "Traceback" not in result.output
-    assert "invalid-or-semantic" in result.output
-    assert CANONICAL_REMEDY in " ".join(result.output.split())
+    normalized = " ".join(result.output.split())
+    assert "Traceback" not in normalized
+    assert "canonical-lock-failed" in normalized
+    assert str(tmp_path / "config") in normalized
+    assert "No such file or directory" in normalized
+    assert LOCK_REMEDY in normalized
+    assert CANONICAL_REMEDY not in normalized
 
 
 def test_config_sync_requires_a_clean_reaudit(

--- a/tests/test_commands/test_session.py
+++ b/tests/test_commands/test_session.py
@@ -77,6 +77,9 @@ class TestSessionCommand:
             mock_sys.stdin.isatty.return_value = True
             mock_instance = mock_mgr.return_value
             mock_instance.resolve_target.return_value = target
+            mock_instance.workflow_image_compatible.return_value = (
+                WorkflowImageCompatibility.COMPATIBLE
+            )
             mock_instance.run_interactive.return_value = mock_session_result
             mock_instance.preflight_check.return_value = None
 
@@ -132,6 +135,7 @@ class TestSessionCommand:
 
             instance = mock_mgr.return_value
             instance.resolve_target.return_value = target
+            instance.workflow_image_compatible.return_value = WorkflowImageCompatibility.COMPATIBLE
             instance.refresh_opencode_workflow.side_effect = _refresh
             instance.preflight_check.side_effect = _preflight
             instance.run_headless.side_effect = _run
@@ -169,6 +173,7 @@ class TestSessionCommand:
             workflow.return_value = WorkflowPreparationResult(True)
             instance = mock_mgr.return_value
             instance.resolve_target.return_value = target
+            instance.workflow_image_compatible.return_value = WorkflowImageCompatibility.COMPATIBLE
             instance.run_headless.return_value = SessionResult(0)
 
             result = runner.invoke(
@@ -210,6 +215,7 @@ class TestSessionCommand:
         ):
             instance = mock_mgr.return_value
             instance.resolve_target.return_value = target
+            instance.workflow_image_compatible.return_value = WorkflowImageCompatibility.COMPATIBLE
             result = runner.invoke(
                 app,
                 [
@@ -272,6 +278,7 @@ class TestSessionCommand:
         ):
             instance = mock_mgr.return_value
             instance.resolve_target.return_value = target
+            instance.workflow_image_compatible.return_value = WorkflowImageCompatibility.COMPATIBLE
             instance.refresh_opencode_workflow.return_value = SessionResult(
                 1, stderr="OpenCode workflow refresh failed"
             )
@@ -342,6 +349,32 @@ class TestSessionCommand:
         assert result.exit_code == 1
         assert "Docker daemon/container not reachable" in result.output
         assert "Rebuild/recreate required." not in result.output
+        assert not (tmp_path / ".djinn/sessions/new-project").exists()
+        workflow.assert_not_called()
+        instance.refresh_opencode_workflow.assert_not_called()
+        instance.preflight_check.assert_not_called()
+
+    def test_missing_running_image_stops_with_build_remedy(
+        self, tmp_path: Path
+    ) -> None:
+        target = SessionTarget(container_id="container-123")
+        with (
+            patch("djinn_in_a_box.commands.session.Path.home", return_value=tmp_path),
+            patch("djinn_in_a_box.commands.session.SessionManager") as mock_mgr,
+            patch("djinn_in_a_box.commands.session.prepare_config_workflow") as workflow,
+        ):
+            instance = mock_mgr.return_value
+            instance.resolve_target.return_value = target
+            instance.workflow_image_compatible.return_value = WorkflowImageCompatibility.MISSING
+            result = runner.invoke(
+                app,
+                ["session", "--project", "new-project", "--agent", "opencode", "--create"],
+            )
+
+        assert result.exit_code == 1
+        assert "Workflow image is not built." in result.output
+        assert "Run `djinn build`, then retry." in result.output
+        assert "Docker daemon/container not reachable" not in result.output
         assert not (tmp_path / ".djinn/sessions/new-project").exists()
         workflow.assert_not_called()
         instance.refresh_opencode_workflow.assert_not_called()

--- a/tests/test_core/test_config_lock.py
+++ b/tests/test_core/test_config_lock.py
@@ -1,8 +1,55 @@
 from __future__ import annotations
 
+import fcntl
+import multiprocessing
+import os
+from multiprocessing.connection import Connection
 from pathlib import Path
 
 from djinn_in_a_box.core.config_lock import config_directory_lock
+
+
+def _probe_nonblocking_lock(
+    config_dir: Path, *, exclusive: bool, result: Connection
+) -> None:
+    """Report whether this process can acquire the directory lock immediately."""
+    descriptor = os.open(config_dir, os.O_RDONLY | os.O_DIRECTORY)
+    acquired = False
+    try:
+        operation = fcntl.LOCK_EX if exclusive else fcntl.LOCK_SH
+        try:
+            fcntl.flock(descriptor, operation | fcntl.LOCK_NB)
+        except BlockingIOError:
+            result.send(False)
+        else:
+            acquired = True
+            result.send(True)
+    finally:
+        if acquired:
+            fcntl.flock(descriptor, fcntl.LOCK_UN)
+        os.close(descriptor)
+        result.close()
+
+
+def _can_acquire_nonblocking_lock(config_dir: Path, *, exclusive: bool) -> bool:
+    context = multiprocessing.get_context("spawn")
+    received, sent = context.Pipe(duplex=False)
+    probe = context.Process(
+        target=_probe_nonblocking_lock,
+        kwargs={"config_dir": config_dir, "exclusive": exclusive, "result": sent},
+    )
+    probe.start()
+    sent.close()
+    try:
+        probe.join()
+        assert probe.exitcode == 0
+        return received.recv()
+    finally:
+        received.close()
+        if probe.is_alive():
+            probe.terminate()
+        probe.join()
+        probe.close()
 
 
 def test_config_directory_lock_creates_no_artifact(tmp_path: Path) -> None:
@@ -15,3 +62,20 @@ def test_config_directory_lock_creates_no_artifact(tmp_path: Path) -> None:
     with config_directory_lock(config_dir, exclusive=True) as descriptor:
         assert descriptor >= 0
         assert list(config_dir.iterdir()) == []
+
+
+def test_config_directory_lock_excludes_second_exclusive_holder(tmp_path: Path) -> None:
+    config_dir = tmp_path / "config"
+    config_dir.mkdir()
+
+    with config_directory_lock(config_dir, exclusive=True):
+        assert not _can_acquire_nonblocking_lock(config_dir, exclusive=True)
+        assert not _can_acquire_nonblocking_lock(config_dir, exclusive=False)
+
+
+def test_config_directory_lock_allows_second_shared_holder(tmp_path: Path) -> None:
+    config_dir = tmp_path / "config"
+    config_dir.mkdir()
+
+    with config_directory_lock(config_dir, exclusive=False):
+        assert _can_acquire_nonblocking_lock(config_dir, exclusive=False)

--- a/tests/test_core/test_config_lock.py
+++ b/tests/test_core/test_config_lock.py
@@ -1,12 +1,16 @@
 from __future__ import annotations
 
+import errno
 import fcntl
 import multiprocessing
 import os
 from multiprocessing.connection import Connection
 from pathlib import Path
 
-from djinn_in_a_box.core.config_lock import config_directory_lock
+import pytest
+
+from djinn_in_a_box.core import config_lock
+from djinn_in_a_box.core.config_lock import ConfigDirectoryLockError, config_directory_lock
 
 
 def _probe_nonblocking_lock(
@@ -79,3 +83,60 @@ def test_config_directory_lock_allows_second_shared_holder(tmp_path: Path) -> No
 
     with config_directory_lock(config_dir, exclusive=False):
         assert _can_acquire_nonblocking_lock(config_dir, exclusive=False)
+
+
+def test_config_directory_lock_wraps_acquisition_failure(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    config_dir = tmp_path / "config"
+    config_dir.mkdir()
+
+    def fail_acquisition(_descriptor: int, _operation: int) -> None:
+        raise OSError(errno.ENOLCK, "No locks available")
+
+    monkeypatch.setattr(config_lock.fcntl, "flock", fail_acquisition)
+
+    with pytest.raises(ConfigDirectoryLockError) as exc_info, config_directory_lock(
+        config_dir, exclusive=True
+    ):
+        pass
+
+    assert str(config_dir) in str(exc_info.value)
+    assert "No locks available" in str(exc_info.value)
+    assert isinstance(exc_info.value.__cause__, OSError)
+    assert exc_info.value.__cause__.errno == errno.ENOLCK
+
+
+def test_config_directory_lock_wraps_unlock_failure_and_closes_descriptor(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    config_dir = tmp_path / "config"
+    config_dir.mkdir()
+    original_open = config_lock.os.open
+    original_flock = config_lock.fcntl.flock
+    descriptor: int | None = None
+
+    def record_descriptor(path: Path, flags: int) -> int:
+        nonlocal descriptor
+        descriptor = original_open(path, flags)
+        return descriptor
+
+    def fail_unlock(candidate: int, operation: int) -> None:
+        if candidate == descriptor and operation == config_lock.fcntl.LOCK_UN:
+            raise OSError(errno.EINTR, "Interrupted system call")
+        original_flock(candidate, operation)
+
+    monkeypatch.setattr(config_lock.os, "open", record_descriptor)
+    monkeypatch.setattr(config_lock.fcntl, "flock", fail_unlock)
+
+    with pytest.raises(ConfigDirectoryLockError) as exc_info, config_directory_lock(
+        config_dir, exclusive=True
+    ):
+        pass
+
+    assert descriptor is not None
+    with pytest.raises(OSError) as closed:
+        os.fstat(descriptor)
+    assert closed.value.errno == errno.EBADF
+    assert isinstance(exc_info.value.__cause__, OSError)
+    assert exc_info.value.__cause__.errno == errno.EINTR

--- a/tests/test_core/test_config_sync.py
+++ b/tests/test_core/test_config_sync.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import errno
 import hashlib
 import json
 import multiprocessing
@@ -19,6 +20,7 @@ import djinn_in_a_box.core.workflow_publisher as publisher_module
 from djinn_in_a_box.config.loader import save_config
 from djinn_in_a_box.config.models import AppConfig, ConfigSyncConfig, ConfigSyncSource
 from djinn_in_a_box.core.config_sync import (
+    LOCK_REMEDY,
     MANIFEST_NAME,
     DriftClass,
     audit_config_sync,
@@ -161,6 +163,46 @@ def test_representative_sync_publishes_all_views_and_lean_manifest(tmp_path: Pat
         )
         for item in manifest["items"]
     )
+
+
+def test_audit_reports_canonical_lock_failure_as_an_operational_problem(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    project, config_path = _workspace(tmp_path)
+
+    def fail_acquisition(_descriptor: int, _operation: int) -> None:
+        raise OSError(errno.ENOLCK, "No locks available")
+
+    monkeypatch.setattr(publisher_module.fcntl, "flock", fail_acquisition)
+
+    audit = audit_config_sync(project, config_path=config_path)
+
+    assert not audit.clean
+    assert audit.drift_classes == (DriftClass.CLEAN,)
+    assert audit.problems[0].identifier == "canonical-lock-failed"
+    assert str(project / "config") in audit.problems[0].message
+    assert "No locks available" in audit.problems[0].message
+    assert audit.problems[0].remedy == LOCK_REMEDY
+
+
+def test_sync_reports_canonical_lock_failure_as_an_operational_problem(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    project, config_path = _workspace(tmp_path)
+
+    def fail_acquisition(_descriptor: int, _operation: int) -> None:
+        raise OSError(errno.ENOLCK, "No locks available")
+
+    monkeypatch.setattr(publisher_module.fcntl, "flock", fail_acquisition)
+
+    result = sync_config(project, config_path=config_path)
+
+    assert not result.success
+    assert result.audit.drift_classes == (DriftClass.CLEAN,)
+    assert result.audit.problems[0].identifier == "canonical-lock-failed"
+    assert str(project / "config") in result.audit.problems[0].message
+    assert "No locks available" in result.audit.problems[0].message
+    assert result.audit.problems[0].remedy == LOCK_REMEDY
 
 
 def _change_source(project: Path) -> None:

--- a/tests/test_core/test_config_workflow.py
+++ b/tests/test_core/test_config_workflow.py
@@ -252,6 +252,40 @@ def test_publish_write_error_reports_the_path_not_workflow_drift(tmp_path: Path)
     assert "portable" not in problem.remedy
 
 
+def test_unreadable_canonical_root_reports_lock_failure_without_traceback(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    project, config_path, _runtime = _workspace(tmp_path)
+    assert prepare_config_workflow(project, config_path=config_path).success
+    canonical_root = project / "config"
+    target = WorkflowDeliveryTarget("codex", tmp_path / "host-codex", provision=True)
+    original_audit = workflow_module.audit_config_sync
+    original_mode = stat.S_IMODE(canonical_root.stat().st_mode)
+
+    def make_canonical_root_unreadable_after_audit(
+        project_root: Path, *, config_path: Path | None = None
+    ) -> ConfigSyncAudit:
+        audit = original_audit(project_root, config_path=config_path)
+        canonical_root.chmod(0o000)
+        return audit
+
+    monkeypatch.setattr(
+        workflow_module, "audit_config_sync", make_canonical_root_unreadable_after_audit
+    )
+    try:
+        result = prepare_config_workflow(project, (target,), config_path=config_path)
+    finally:
+        canonical_root.chmod(original_mode)
+
+    assert not result.success
+    problem = result.problems[0]
+    assert problem.identifier == "canonical-lock-failed"
+    assert str(canonical_root) in problem.message
+    assert "Permission denied" in problem.message
+    assert "Traceback" not in repr(result)
+    assert "portable" not in problem.remedy
+
+
 def test_canonical_config_reload_os_error_is_not_reported_as_publish_failure(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/test_core/test_config_workflow.py
+++ b/tests/test_core/test_config_workflow.py
@@ -54,6 +54,25 @@ def _ensure_host_env(_config: AppConfig) -> None:
     return None
 
 
+_IMAGE_GATE_FAILURES = {
+    WorkflowImageCompatibility.UNKNOWN: (
+        "image-unreachable",
+        "Docker daemon/container not reachable.",
+        "Retry.",
+    ),
+    WorkflowImageCompatibility.MISSING: (
+        "image-not-built",
+        "Workflow image is not built.",
+        "Run `djinn build`, then retry.",
+    ),
+    WorkflowImageCompatibility.INCOMPATIBLE: (
+        "image-incompatible",
+        "Workflow image is incompatible.",
+        "Rebuild/recreate required.",
+    ),
+}
+
+
 def _audit_must_not_run(*_args: object, **_kwargs: object) -> NoReturn:
     pytest.fail("audit")
 
@@ -274,6 +293,37 @@ def test_compose_image_gate_blocks_before_audit_or_runtime_write(
     assert result.problems[0].remedy == "Rebuild/recreate required."
     assert sentinel not in repr(result)
     assert not (runtime / "codex").exists()
+
+
+def test_compose_image_gate_handles_every_noncompatible_state(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    assert set(_IMAGE_GATE_FAILURES) == {
+        compatibility
+        for compatibility in WorkflowImageCompatibility
+        if compatibility is not WorkflowImageCompatibility.COMPATIBLE
+    }
+
+    for compatibility, expected in _IMAGE_GATE_FAILURES.items():
+        project, config_path, runtime = _workspace(tmp_path / compatibility.value)
+        monkeypatch.setattr(
+            workflow_module,
+            "workflow_image_compatible",
+            lambda compatibility=compatibility: compatibility,
+        )
+        monkeypatch.setattr(workflow_module, "audit_config_sync", _audit_must_not_run)
+
+        result = prepare_config_workflow(
+            project,
+            (WorkflowDeliveryTarget("codex", runtime / "codex", provision=True),),
+            config_path=config_path,
+            require_compose_host_env=True,
+        )
+
+        assert not result.success
+        problem = result.problems[0]
+        assert (problem.identifier, problem.message, problem.remedy) == expected
+        assert not (runtime / "codex").exists()
 
 
 def test_host_provisioning_failure_reports_the_path_not_workflow_drift(

--- a/tests/test_core/test_config_workflow.py
+++ b/tests/test_core/test_config_workflow.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import errno
 import json
+import os
 import stat
 from pathlib import Path, PurePosixPath
 from typing import NoReturn
@@ -251,6 +252,78 @@ def test_publish_write_error_reports_the_path_not_workflow_drift(tmp_path: Path)
     assert problem.identifier == "workflow-publish-failed"
     assert str(target.destination_root) in problem.message
     assert "Permission denied" in problem.message
+    assert "portable" not in problem.remedy
+
+
+def test_target_lock_acquisition_reports_an_operational_publish_failure(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    project, config_path, _runtime = _workspace(tmp_path)
+    target = WorkflowDeliveryTarget("codex", tmp_path / "host-codex", provision=True)
+    original_open = workflow_publisher._open_directory
+    original_flock = workflow_publisher.fcntl.flock
+    descriptor: int | None = None
+
+    def record_target_descriptor(path: Path) -> int:
+        nonlocal descriptor
+        candidate = original_open(path)
+        if path == target.destination_root:
+            descriptor = candidate
+        return candidate
+
+    def fail_target_acquisition(candidate: int, operation: int) -> None:
+        if candidate == descriptor and operation == workflow_publisher.fcntl.LOCK_EX:
+            raise OSError(errno.ENOLCK, "No locks available")
+        original_flock(candidate, operation)
+
+    monkeypatch.setattr(workflow_publisher, "_open_directory", record_target_descriptor)
+    monkeypatch.setattr(workflow_publisher.fcntl, "flock", fail_target_acquisition)
+
+    result = prepare_config_workflow(project, (target,), config_path=config_path)
+
+    assert not result.success
+    problem = result.problems[0]
+    assert problem.identifier == "workflow-publish-failed"
+    assert str(target.destination_root) in problem.message
+    assert "No locks available" in problem.message
+    assert "portable" not in problem.remedy
+
+
+def test_target_lock_release_reports_an_operational_publish_failure_and_closes_descriptor(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    project, config_path, _runtime = _workspace(tmp_path)
+    target = WorkflowDeliveryTarget("codex", tmp_path / "host-codex", provision=True)
+    original_open = workflow_publisher._open_directory
+    original_flock = workflow_publisher.fcntl.flock
+    descriptor: int | None = None
+
+    def record_target_descriptor(path: Path) -> int:
+        nonlocal descriptor
+        candidate = original_open(path)
+        if path == target.destination_root:
+            descriptor = candidate
+        return candidate
+
+    def fail_target_unlock(candidate: int, operation: int) -> None:
+        if candidate == descriptor and operation == workflow_publisher.fcntl.LOCK_UN:
+            raise OSError(errno.EINTR, "Interrupted system call")
+        original_flock(candidate, operation)
+
+    monkeypatch.setattr(workflow_publisher, "_open_directory", record_target_descriptor)
+    monkeypatch.setattr(workflow_publisher.fcntl, "flock", fail_target_unlock)
+
+    result = prepare_config_workflow(project, (target,), config_path=config_path)
+
+    assert descriptor is not None
+    with pytest.raises(OSError) as closed:
+        os.fstat(descriptor)
+    assert closed.value.errno == errno.EBADF
+    assert not result.success
+    problem = result.problems[0]
+    assert problem.identifier == "workflow-publish-failed"
+    assert str(target.destination_root) in problem.message
+    assert "Interrupted system call" in problem.message
     assert "portable" not in problem.remedy
 
 

--- a/tests/test_core/test_config_workflow.py
+++ b/tests/test_core/test_config_workflow.py
@@ -117,6 +117,103 @@ def test_preflight_does_not_repair_a_missing_managed_canonical_file(tmp_path: Pa
     assert not managed.exists()
 
 
+def test_target_symlink_reports_the_destination_not_workflow_drift(tmp_path: Path) -> None:
+    project, config_path, _runtime = _workspace(tmp_path)
+    managed_by_dotfiles = tmp_path / "dotfiles-claude"
+    managed_by_dotfiles.mkdir()
+    target = WorkflowDeliveryTarget("claude", tmp_path / ".claude", provision=True)
+    target.destination_root.symlink_to(managed_by_dotfiles, target_is_directory=True)
+
+    result = prepare_config_workflow(project, (target,), config_path=config_path)
+
+    assert not result.success
+    problem = result.problems[0]
+    assert problem.identifier == "target-symlink"
+    assert str(target.destination_root) in problem.message
+    assert "symlink" in problem.message
+    assert "portable" not in problem.remedy
+
+
+def test_target_file_reports_not_a_directory_not_workflow_drift(tmp_path: Path) -> None:
+    project, config_path, _runtime = _workspace(tmp_path)
+    target = WorkflowDeliveryTarget("codex", tmp_path / "host-codex", provision=True)
+    target.destination_root.write_text("not a directory")
+
+    result = prepare_config_workflow(project, (target,), config_path=config_path)
+
+    assert not result.success
+    problem = result.problems[0]
+    assert problem.identifier == "target-not-directory"
+    assert str(target.destination_root) in problem.message
+    assert "not a directory" in problem.message
+    assert "portable" not in problem.remedy
+
+
+def test_target_provisioning_os_error_reports_the_path_not_workflow_drift(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    project, config_path, _runtime = _workspace(tmp_path)
+    target = WorkflowDeliveryTarget("codex", tmp_path / "unwritable" / "codex", provision=True)
+    original_mkdir = Path.mkdir
+
+    def refuse_target_mkdir(
+        path: Path,
+        mode: int = 0o777,
+        parents: bool = False,
+        exist_ok: bool = False,
+    ) -> None:
+        if path == target.destination_root:
+            raise PermissionError(13, "Permission denied", path)
+        original_mkdir(path, mode=mode, parents=parents, exist_ok=exist_ok)
+
+    monkeypatch.setattr(Path, "mkdir", refuse_target_mkdir)
+
+    result = prepare_config_workflow(project, (target,), config_path=config_path)
+
+    assert not result.success
+    problem = result.problems[0]
+    assert problem.identifier == "target-provisioning-failed"
+    assert str(target.destination_root) in problem.message
+    assert "Permission denied" in problem.message
+    assert "portable" not in problem.remedy
+
+
+def test_missing_target_reports_the_destination_not_workflow_drift(tmp_path: Path) -> None:
+    project, config_path, _runtime = _workspace(tmp_path)
+    target = WorkflowDeliveryTarget("codex", tmp_path / "missing-codex")
+
+    result = prepare_config_workflow(project, (target,), config_path=config_path)
+
+    assert not result.success
+    problem = result.problems[0]
+    assert problem.identifier == "target-missing"
+    assert str(target.destination_root) in problem.message
+    assert "does not exist" in problem.message
+    assert "portable" not in problem.remedy
+
+
+def test_publish_os_error_reports_the_path_not_workflow_drift(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    project, config_path, _runtime = _workspace(tmp_path)
+    target = WorkflowDeliveryTarget("codex", tmp_path / "host-codex", provision=True)
+    failed_path = target.destination_root / RUNTIME_MANIFEST_NAME
+
+    def no_space(*_args: object, **_kwargs: object) -> NoReturn:
+        raise OSError(28, "No space left on device", failed_path)
+
+    monkeypatch.setattr(workflow_module, "publish_workflow_view", no_space)
+
+    result = prepare_config_workflow(project, (target,), config_path=config_path)
+
+    assert not result.success
+    problem = result.problems[0]
+    assert problem.identifier == "workflow-publish-failed"
+    assert str(failed_path) in problem.message
+    assert "No space left on device" in problem.message
+    assert "portable" not in problem.remedy
+
+
 def test_compose_claude_retires_legacy_without_publisher_and_codex_uses_publisher(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/test_core/test_config_workflow.py
+++ b/tests/test_core/test_config_workflow.py
@@ -15,6 +15,7 @@ from djinn_in_a_box.config.models import AppConfig, ConfigSyncConfig, ConfigSync
 from djinn_in_a_box.core import workflow_publisher
 from djinn_in_a_box.core.config_sync import (
     CANONICAL_REMEDY,
+    LOCK_REMEDY,
     CanonicalDeliveryViewResult,
     ConfigSyncAudit,
     DriftClass,
@@ -386,6 +387,27 @@ def test_flock_acquisition_failure_reports_canonical_lock_failure(
     assert "No locks available" in problem.message
 
 
+def test_initial_audit_lock_failure_reports_the_structured_problem(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    project, config_path, _runtime = _workspace(tmp_path)
+    target = WorkflowDeliveryTarget("codex", tmp_path / "host-codex", provision=True)
+
+    def fail_acquisition(_descriptor: int, _operation: int) -> None:
+        raise OSError(errno.ENOLCK, "No locks available")
+
+    monkeypatch.setattr(workflow_publisher.fcntl, "flock", fail_acquisition)
+    result = prepare_config_workflow(project, (target,), config_path=config_path)
+
+    assert not result.success
+    problem = result.problems[0]
+    assert problem.identifier == "canonical-lock-failed"
+    assert str(project / "config") in problem.message
+    assert "No locks available" in problem.message
+    assert problem.remedy == LOCK_REMEDY
+    assert "portable" not in problem.remedy
+
+
 def test_canonical_unlock_failure_reports_preparation_lock_failure(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -478,6 +500,36 @@ def test_compose_claude_retires_legacy_without_publisher_and_codex_uses_publishe
     assert not (claude_root / ".djinn-workflow-delivery.json").exists()
     assert not (claude_root / RUNTIME_MANIFEST_NAME).exists()
     assert (codex_root / RUNTIME_MANIFEST_NAME).is_file()
+
+
+def test_compose_retirement_write_error_reports_the_destination(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    project, config_path, runtime = _workspace(tmp_path)
+    assert prepare_config_workflow(project, config_path=config_path).success
+    claude_root = runtime / "claude"
+    claude_root.mkdir(parents=True)
+    (claude_root / ".djinn-workflow-delivery.json").write_bytes(_legacy_manifest())
+
+    def fail_fsync(_root: Path) -> None:
+        raise OSError(errno.ENOSPC, "No space left on device")
+
+    monkeypatch.setattr(workflow_module, "ensure_host_env", _ensure_host_env)
+    monkeypatch.setattr(workflow_publisher, "_fsync_directory", fail_fsync)
+    result = prepare_config_workflow(
+        project,
+        (WorkflowDeliveryTarget("claude", claude_root),),
+        config_path=config_path,
+        require_compose_host_env=True,
+        container_image_compatibility=WorkflowImageCompatibility.COMPATIBLE,
+    )
+
+    assert not result.success
+    problem = result.problems[0]
+    assert problem.identifier == "workflow-publish-failed"
+    assert str(claude_root) in problem.message
+    assert "No space left on device" in problem.message
+    assert "portable" not in problem.remedy
 
 
 def test_compose_image_gate_blocks_before_audit_or_runtime_write(

--- a/tests/test_core/test_config_workflow.py
+++ b/tests/test_core/test_config_workflow.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import errno
+import fcntl
 import json
 import os
 import stat
@@ -237,6 +238,44 @@ def test_non_traversable_target_parent_reports_preparation_failure(tmp_path: Pat
     assert "portable" not in problem.remedy
 
 
+def test_target_lock_failure_is_not_reported_as_a_publish_failure(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A lease failure must not borrow the publish wording.
+
+    Nothing was published, so "Failed to publish ... check the directory is
+    writable with available space" names the wrong operation and offers a remedy
+    that does not apply to a missing lock. Mock-based: ENOLCK cannot be provoked
+    reliably on an ordinary filesystem.
+    """
+    project, config_path, _runtime = _workspace(tmp_path)
+    target = WorkflowDeliveryTarget("codex", tmp_path / "host-codex", provision=True)
+    assert prepare_config_workflow(project, (target,), config_path=config_path).success
+
+    real_flock = fcntl.flock
+    seen = {"count": 0}
+
+    def fail_target_acquisition(descriptor: int, operation: int) -> None:
+        seen["count"] += 1
+        # The canonical shared lock comes first; fail only the later exclusive
+        # acquisition, which is the target lock.
+        if seen["count"] > 2 and operation == fcntl.LOCK_EX:
+            raise OSError(37, "No locks available")
+        real_flock(descriptor, operation)
+
+    monkeypatch.setattr(fcntl, "flock", fail_target_acquisition)
+
+    result = prepare_config_workflow(project, (target,), config_path=config_path)
+
+    assert not result.success
+    problem = result.problems[0]
+    assert problem.identifier == "workflow-lock-failed"
+    assert "No locks available" in problem.message
+    assert "lock" in problem.message
+    assert "publish" not in problem.message
+    assert "writable" not in problem.remedy
+
+
 def test_publish_write_error_reports_the_path_not_workflow_drift(tmp_path: Path) -> None:
     project, config_path, _runtime = _workspace(tmp_path)
     target = WorkflowDeliveryTarget("codex", tmp_path / "host-codex", provision=True)
@@ -256,7 +295,7 @@ def test_publish_write_error_reports_the_path_not_workflow_drift(tmp_path: Path)
     assert "portable" not in problem.remedy
 
 
-def test_target_lock_acquisition_reports_an_operational_publish_failure(
+def test_target_lock_acquisition_reports_a_lock_failure_not_a_publish_failure(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     project, config_path, _runtime = _workspace(tmp_path)
@@ -284,13 +323,14 @@ def test_target_lock_acquisition_reports_an_operational_publish_failure(
 
     assert not result.success
     problem = result.problems[0]
-    assert problem.identifier == "workflow-publish-failed"
+    assert problem.identifier == "workflow-lock-failed"
     assert str(target.destination_root) in problem.message
     assert "No locks available" in problem.message
     assert "portable" not in problem.remedy
+    assert "writable" not in problem.remedy
 
 
-def test_target_lock_release_reports_an_operational_publish_failure_and_closes_descriptor(
+def test_target_lock_release_reports_a_lock_failure_and_closes_descriptor(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     project, config_path, _runtime = _workspace(tmp_path)
@@ -322,10 +362,11 @@ def test_target_lock_release_reports_an_operational_publish_failure_and_closes_d
     assert closed.value.errno == errno.EBADF
     assert not result.success
     problem = result.problems[0]
-    assert problem.identifier == "workflow-publish-failed"
+    assert problem.identifier == "workflow-lock-failed"
     assert str(target.destination_root) in problem.message
     assert "Interrupted system call" in problem.message
     assert "portable" not in problem.remedy
+    assert "writable" not in problem.remedy
 
 
 def test_unreadable_canonical_root_reports_lock_failure_without_traceback(
@@ -360,6 +401,7 @@ def test_unreadable_canonical_root_reports_lock_failure_without_traceback(
     assert "Permission denied" in problem.message
     assert "Traceback" not in repr(result)
     assert "portable" not in problem.remedy
+    assert "writable" not in problem.remedy
 
 
 def test_flock_acquisition_failure_reports_canonical_lock_failure(
@@ -406,6 +448,7 @@ def test_initial_audit_lock_failure_reports_the_structured_problem(
     assert "No locks available" in problem.message
     assert problem.remedy == LOCK_REMEDY
     assert "portable" not in problem.remedy
+    assert "writable" not in problem.remedy
 
 
 def test_canonical_unlock_failure_reports_preparation_lock_failure(

--- a/tests/test_core/test_config_workflow.py
+++ b/tests/test_core/test_config_workflow.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import errno
 import json
 import stat
 from pathlib import Path, PurePosixPath
@@ -10,6 +11,7 @@ import pytest
 import djinn_in_a_box.core.config_workflow as workflow_module
 from djinn_in_a_box.config.loader import save_config
 from djinn_in_a_box.config.models import AppConfig, ConfigSyncConfig, ConfigSyncSource
+from djinn_in_a_box.core import workflow_publisher
 from djinn_in_a_box.core.config_sync import (
     CANONICAL_REMEDY,
     CanonicalDeliveryViewResult,
@@ -284,6 +286,62 @@ def test_unreadable_canonical_root_reports_lock_failure_without_traceback(
     assert "Permission denied" in problem.message
     assert "Traceback" not in repr(result)
     assert "portable" not in problem.remedy
+
+
+def test_flock_acquisition_failure_reports_canonical_lock_failure(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    project, config_path, _runtime = _workspace(tmp_path)
+    assert prepare_config_workflow(project, config_path=config_path).success
+    audit = audit_config_sync(project, config_path=config_path)
+    target = WorkflowDeliveryTarget("codex", tmp_path / "host-codex", provision=True)
+
+    def fixed_audit(*_args: object, **_kwargs: object) -> ConfigSyncAudit:
+        return audit
+
+    def fail_acquisition(_descriptor: int, _operation: int) -> None:
+        raise OSError(errno.ENOLCK, "No locks available")
+
+    monkeypatch.setattr(workflow_module, "audit_config_sync", fixed_audit)
+    monkeypatch.setattr(workflow_publisher.fcntl, "flock", fail_acquisition)
+    result = prepare_config_workflow(project, (target,), config_path=config_path)
+
+    assert not result.success
+    problem = result.problems[0]
+    assert problem.identifier == "canonical-lock-failed"
+    assert problem.identifier != DriftClass.INVALID_OR_SEMANTIC.value
+    assert "No locks available" in problem.message
+
+
+def test_canonical_unlock_failure_reports_preparation_lock_failure(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    project, config_path, _runtime = _workspace(tmp_path)
+    assert prepare_config_workflow(project, config_path=config_path).success
+    audit = audit_config_sync(project, config_path=config_path)
+    target = WorkflowDeliveryTarget("codex", tmp_path / "host-codex", provision=True)
+    original_flock = workflow_publisher.fcntl.flock
+
+    def fixed_audit(*_args: object, **_kwargs: object) -> ConfigSyncAudit:
+        return audit
+
+    def failed_view(*_args: object, **_kwargs: object) -> CanonicalDeliveryViewResult:
+        return CanonicalDeliveryViewResult(False, audit)
+
+    def fail_unlock(descriptor: int, operation: int) -> None:
+        if operation == workflow_publisher.fcntl.LOCK_UN:
+            raise OSError(errno.EINTR, "Interrupted system call")
+        original_flock(descriptor, operation)
+
+    monkeypatch.setattr(workflow_module, "audit_config_sync", fixed_audit)
+    monkeypatch.setattr(workflow_module, "load_canonical_delivery_view", failed_view)
+    monkeypatch.setattr(workflow_publisher.fcntl, "flock", fail_unlock)
+    result = prepare_config_workflow(project, (target,), config_path=config_path)
+
+    assert not result.success
+    problem = result.problems[0]
+    assert problem.identifier == "canonical-lock-failed"
+    assert "Interrupted system call" in problem.message
 
 
 def test_canonical_config_reload_os_error_is_not_reported_as_publish_failure(

--- a/tests/test_core/test_config_workflow.py
+++ b/tests/test_core/test_config_workflow.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import stat
 from pathlib import Path, PurePosixPath
 from typing import NoReturn
 
@@ -12,6 +13,7 @@ from djinn_in_a_box.config.models import AppConfig, ConfigSyncConfig, ConfigSync
 from djinn_in_a_box.core.config_sync import (
     CANONICAL_REMEDY,
     CanonicalDeliveryViewResult,
+    ConfigSyncAudit,
     DriftClass,
     audit_config_sync,
 )
@@ -211,26 +213,74 @@ def test_missing_target_reports_the_destination_not_workflow_drift(tmp_path: Pat
     assert "portable" not in problem.remedy
 
 
-def test_publish_os_error_reports_the_path_not_workflow_drift(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_non_traversable_target_parent_reports_preparation_failure(tmp_path: Path) -> None:
+    project, config_path, _runtime = _workspace(tmp_path)
+    parent = tmp_path / "blocked-parent"
+    target = WorkflowDeliveryTarget("codex", parent / "existing-target")
+    target.destination_root.mkdir(parents=True)
+    original_mode = stat.S_IMODE(parent.stat().st_mode)
+    parent.chmod(0o000)
+    try:
+        result = prepare_config_workflow(project, (target,), config_path=config_path)
+    finally:
+        parent.chmod(original_mode)
+
+    assert not result.success
+    problem = result.problems[0]
+    assert problem.identifier == "target-provisioning-failed"
+    assert str(target.destination_root) in problem.message
+    assert "Permission denied" in problem.message
+    assert "portable" not in problem.remedy
+
+
+def test_publish_write_error_reports_the_path_not_workflow_drift(tmp_path: Path) -> None:
     project, config_path, _runtime = _workspace(tmp_path)
     target = WorkflowDeliveryTarget("codex", tmp_path / "host-codex", provision=True)
-    failed_path = target.destination_root / RUNTIME_MANIFEST_NAME
-
-    def no_space(*_args: object, **_kwargs: object) -> NoReturn:
-        raise OSError(28, "No space left on device", failed_path)
-
-    monkeypatch.setattr(workflow_module, "publish_workflow_view", no_space)
-
-    result = prepare_config_workflow(project, (target,), config_path=config_path)
+    target.destination_root.mkdir()
+    original_mode = stat.S_IMODE(target.destination_root.stat().st_mode)
+    target.destination_root.chmod(0o555)
+    try:
+        result = prepare_config_workflow(project, (target,), config_path=config_path)
+    finally:
+        target.destination_root.chmod(original_mode)
 
     assert not result.success
     problem = result.problems[0]
     assert problem.identifier == "workflow-publish-failed"
-    assert str(failed_path) in problem.message
-    assert "No space left on device" in problem.message
+    assert str(target.destination_root) in problem.message
+    assert "Permission denied" in problem.message
     assert "portable" not in problem.remedy
+
+
+def test_canonical_config_reload_os_error_is_not_reported_as_publish_failure(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    project, config_path, _runtime = _workspace(tmp_path)
+    assert prepare_config_workflow(project, config_path=config_path).success
+    target = WorkflowDeliveryTarget("codex", tmp_path / "host-codex")
+    target.destination_root.mkdir()
+    original_audit = workflow_module.audit_config_sync
+    original_mode = stat.S_IMODE(config_path.stat().st_mode)
+    config_file = config_path
+
+    def make_config_unreadable_after_audit(
+        project_root: Path, *, config_path: Path | None = None
+    ) -> ConfigSyncAudit:
+        audit = original_audit(project_root, config_path=config_path)
+        config_file.chmod(0o000)
+        return audit
+
+    monkeypatch.setattr(workflow_module, "audit_config_sync", make_config_unreadable_after_audit)
+    try:
+        result = prepare_config_workflow(project, (target,), config_path=config_path)
+    finally:
+        config_path.chmod(original_mode)
+
+    assert not result.success
+    problem = result.problems[0]
+    assert problem.identifier == DriftClass.INVALID_OR_SEMANTIC.value
+    assert "publish" not in problem.message
+    assert str(target.destination_root) not in problem.message
 
 
 def test_compose_claude_retires_legacy_without_publisher_and_codex_uses_publisher(

--- a/tests/test_core/test_session.py
+++ b/tests/test_core/test_session.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import stat
 import subprocess
 import sys
@@ -13,6 +14,10 @@ import pytest
 from djinn_in_a_box.config.models import AgentConfig
 from djinn_in_a_box.core.docker import WorkflowImageCompatibility
 from djinn_in_a_box.core.session import SessionManager, SessionResult, SessionTarget
+from djinn_in_a_box.core.workflow_publisher import (
+    PUBLISHER_LOCK_ERROR_PREFIX,
+    PUBLISHER_WRITE_ERROR_PREFIX,
+)
 
 _SESSION_MODULE = "djinn_in_a_box.core.session"
 _SUBPROCESS_RUN = f"{_SESSION_MODULE}.subprocess.run"
@@ -412,6 +417,41 @@ class TestRefreshOpenCodeWorkflow:
 
         assert "target-drift" in result.stderr
         assert "modified managed workflow item" in result.stderr
+
+    def test_publisher_refresh_prefers_the_later_lock_diagnostic_over_write_diagnostic(
+        self, session_mgr: SessionManager
+    ) -> None:
+        failed = MagicMock(
+            returncode=13,
+            stdout="",
+            stderr=(
+                "workflow publisher: invalid-or-semantic\n"
+                + PUBLISHER_WRITE_ERROR_PREFIX
+                + json.dumps({"destination": "/destination", "error": "No space left on device"})
+                + "\n"
+                + PUBLISHER_LOCK_ERROR_PREFIX
+                + json.dumps({"root": "/canonical", "error": "No locks available"})
+                + "\n"
+            ),
+        )
+
+        with (
+            patch.object(
+                session_mgr,
+                "workflow_image_compatible",
+                return_value=WorkflowImageCompatibility.COMPATIBLE,
+            ),
+            patch(_SUBPROCESS_RUN, return_value=failed),
+        ):
+            result = session_mgr.refresh_opencode_workflow(
+                SessionTarget(container_id="container-id")
+            )
+
+        assert result.stderr == (
+            "OpenCode workflow refresh failed: Canonical workflow lock failed at /canonical: "
+            "No locks available. Remedy: Check that the canonical workflow root is a readable, "
+            "lockable directory and that no other Djinn process is stuck on it, then retry."
+        )
 
     def test_host_target_does_not_execute_refresh(self, session_mgr: SessionManager) -> None:
         with patch(_SUBPROCESS_RUN) as run:

--- a/tests/test_core/test_session.py
+++ b/tests/test_core/test_session.py
@@ -258,6 +258,24 @@ class TestRefreshOpenCodeWorkflow:
         assert "Rebuild/recreate required" not in result.stderr
         run.assert_called_once()
 
+    def test_missing_image_blocks_refresh_with_build_remedy(
+        self, session_mgr: SessionManager
+    ) -> None:
+        with (
+            patch.object(
+                session_mgr,
+                "workflow_image_compatible",
+                return_value=WorkflowImageCompatibility.MISSING,
+            ),
+            patch(_SUBPROCESS_RUN) as run,
+        ):
+            result = session_mgr.refresh_opencode_workflow(
+                SessionTarget(container_id="container-id")
+            )
+
+        assert result.stderr == "Workflow image is not built — run `djinn build`, then retry."
+        run.assert_not_called()
+
     def test_inspect_timeout_is_unknown(self, session_mgr: SessionManager) -> None:
         with patch(
             _SUBPROCESS_RUN, side_effect=subprocess.TimeoutExpired(cmd="docker", timeout=10)
@@ -267,6 +285,20 @@ class TestRefreshOpenCodeWorkflow:
             )
 
         assert compatibility is WorkflowImageCompatibility.UNKNOWN
+
+    def test_missing_container_image_is_distinguished_when_daemon_replies(
+        self, session_mgr: SessionManager
+    ) -> None:
+        container = MagicMock(returncode=0, stdout="sha256:image\n", stderr="")
+        image = MagicMock(returncode=1, stdout="", stderr="")
+        daemon = MagicMock(returncode=0, stdout="", stderr="")
+
+        with patch(_SUBPROCESS_RUN, side_effect=(container, image, daemon)):
+            compatibility = session_mgr.workflow_image_compatible(
+                SessionTarget(container_id="container-id")
+            )
+
+        assert compatibility is WorkflowImageCompatibility.MISSING
 
     @pytest.mark.parametrize(
         ("label", "expected"),

--- a/tests/test_core/test_session.py
+++ b/tests/test_core/test_session.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import stat
 import subprocess
+import sys
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -228,6 +230,70 @@ class TestRefreshOpenCodeWorkflow:
 
         assert code in result.stderr
         assert expected in result.stderr
+
+    def test_publisher_write_error_reports_destination_io(
+        self, session_mgr: SessionManager, tmp_path: Path
+    ) -> None:
+        canonical = tmp_path / "canonical"
+        target = tmp_path / "target"
+        view = tmp_path / "view"
+        publisher = (
+            Path(__file__).resolve().parents[2]
+            / "src/djinn_in_a_box/core/workflow_publisher.py"
+        )
+        canonical.mkdir()
+        target.mkdir()
+        view.mkdir()
+        (canonical / ".djinn-config-sync.json").write_text('{"source":"opencode","items":[]}')
+        sentinel = "PRIVATE-WORKFLOW-BODY-SENTINEL"
+        (view / "AGENTS.md").write_text(sentinel)
+        original_mode = stat.S_IMODE(target.stat().st_mode)
+        target.chmod(0o555)
+        try:
+            failed = subprocess.run(
+                [
+                    sys.executable,
+                    str(publisher),
+                    "--view",
+                    str(view),
+                    "--canonical-root",
+                    str(canonical),
+                    "--target",
+                    str(target),
+                    "--manifest",
+                    str(target / ".djinn-workflow-state.json"),
+                ],
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+        finally:
+            target.chmod(original_mode)
+
+        assert failed.returncode == 13
+        assert str(target) in failed.stderr
+        assert "Permission denied" in failed.stderr
+        assert sentinel not in failed.stderr
+
+        with (
+            patch.object(
+                session_mgr,
+                "workflow_image_compatible",
+                return_value=WorkflowImageCompatibility.COMPATIBLE,
+            ),
+            patch(_SUBPROCESS_RUN, return_value=failed),
+        ):
+            result = session_mgr.refresh_opencode_workflow(
+                SessionTarget(container_id="container-id")
+            )
+
+        assert result.returncode == failed.returncode
+        assert result.stderr == (
+            f"OpenCode workflow refresh failed to publish workflow to {target}: Permission denied. "
+            "Remedy: Check that the workflow destination and its parent directories are writable "
+            "with available space, then retry."
+        )
+        assert sentinel not in result.stderr
 
     def test_running_old_container_blocks_before_exec_even_if_tag_is_new(
         self, session_mgr: SessionManager

--- a/tests/test_core/test_workflow_publisher.py
+++ b/tests/test_core/test_workflow_publisher.py
@@ -449,6 +449,25 @@ def test_compose_retirement_retries_after_verify_before_remove_crash(
     assert not legacy.exists()
 
 
+def test_retirement_carries_directory_fsync_error_as_write_error(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    root = tmp_path / "claude"
+    root.mkdir()
+    (root / workflow_publisher.LEGACY_DELIVERY_MANIFEST_NAME).write_bytes(_legacy_manifest({}))
+
+    def fail_fsync(_root: Path) -> None:
+        raise OSError(errno.ENOSPC, "No space left on device")
+
+    monkeypatch.setattr(workflow_publisher, "_fsync_directory", fail_fsync)
+    result = retire_legacy_delivery_manifest(root)
+
+    assert result.drift_class is DriftClass.INVALID_OR_SEMANTIC
+    assert result.write_error is not None
+    assert result.write_error.errno == errno.ENOSPC
+    assert result.write_error.strerror == "No space left on device"
+
+
 def test_stale_file_and_owned_json_key_are_removed_without_touching_neighbor(
     tmp_path: Path,
 ) -> None:

--- a/tests/test_core/test_workflow_publisher.py
+++ b/tests/test_core/test_workflow_publisher.py
@@ -18,6 +18,7 @@ from djinn_in_a_box.core import workflow_publisher
 from djinn_in_a_box.core.workflow_publisher import (
     CANONICAL_MANIFEST_NAME,
     EXIT_CODES,
+    PUBLISHER_WRITE_ERROR_PREFIX,
     RUNTIME_MANIFEST_NAME,
     CarrierFragment,
     DriftClass,
@@ -897,6 +898,33 @@ def test_standalone_file_only_publish_exit_codes_fragment_refusal_and_missing_ca
     sentinel = "operator edit"
     assert sentinel not in drift.stderr
     assert sentinel not in collision.stderr
+
+
+def test_standalone_write_failure_reports_destination_io_without_workflow_content(
+    tmp_path: Path,
+) -> None:
+    canonical = tmp_path / "canonical"
+    target = tmp_path / "target"
+    view = tmp_path / "view"
+    canonical.mkdir()
+    target.mkdir()
+    view.mkdir()
+    sentinel = "PRIVATE-WORKFLOW-BODY-SENTINEL"
+    _canonical_identity(canonical)
+    _write(view / "AGENTS.md", sentinel.encode())
+    original_mode = stat.S_IMODE(target.stat().st_mode)
+    target.chmod(0o555)
+    try:
+        result = _run_cli(view, canonical, target)
+    finally:
+        target.chmod(original_mode)
+
+    assert result.returncode == EXIT_CODES[DriftClass.INVALID_OR_SEMANTIC]
+    assert result.stderr.splitlines()[0] == "workflow publisher: invalid-or-semantic"
+    diagnostic_line = result.stderr.splitlines()[1]
+    diagnostic = json.loads(diagnostic_line.removeprefix(PUBLISHER_WRITE_ERROR_PREFIX))
+    assert diagnostic == {"destination": str(target), "error": "Permission denied"}
+    assert sentinel not in result.stderr
 
 
 @pytest.mark.parametrize("foreign_path", ("operator-private.txt", "commands/codex-review.md"))

--- a/tests/test_core/test_workflow_publisher.py
+++ b/tests/test_core/test_workflow_publisher.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import errno
 import json
 import multiprocessing
+import os
 import stat
 import subprocess
 import sys
@@ -19,6 +20,7 @@ from djinn_in_a_box.core import workflow_publisher
 from djinn_in_a_box.core.workflow_publisher import (
     CANONICAL_MANIFEST_NAME,
     EXIT_CODES,
+    PUBLISHER_LOCK_ERROR_PREFIX,
     PUBLISHER_WRITE_ERROR_PREFIX,
     RUNTIME_MANIFEST_NAME,
     CarrierFragment,
@@ -819,6 +821,59 @@ def test_canonical_lock_wraps_close_failure(
     assert exc_info.value.__cause__.errno == errno.EIO
 
 
+def test_target_lock_wraps_acquisition_failure(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _canonical, target = _roots(tmp_path)
+
+    def fail_acquisition(_descriptor: int, _operation: int) -> None:
+        raise OSError(errno.ENOLCK, "No locks available")
+
+    monkeypatch.setattr(workflow_publisher.fcntl, "flock", fail_acquisition)
+
+    with pytest.raises(PublishError) as exc_info, workflow_publisher._target_lock(target):
+        pass
+
+    assert exc_info.value.drift_class is DriftClass.INVALID_OR_SEMANTIC
+    assert exc_info.value.lock_error is exc_info.value.__cause__
+    assert isinstance(exc_info.value.__cause__, OSError)
+    assert exc_info.value.__cause__.errno == errno.ENOLCK
+
+
+def test_target_lock_wraps_unlock_failure_and_closes_descriptor(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _canonical, target = _roots(tmp_path)
+    original_open = workflow_publisher._open_directory
+    original_flock = workflow_publisher.fcntl.flock
+    descriptor: int | None = None
+
+    def record_descriptor(path: Path) -> int:
+        nonlocal descriptor
+        descriptor = original_open(path)
+        return descriptor
+
+    def fail_unlock(candidate: int, operation: int) -> None:
+        if candidate == descriptor and operation == workflow_publisher.fcntl.LOCK_UN:
+            raise OSError(errno.EINTR, "Interrupted system call")
+        original_flock(candidate, operation)
+
+    monkeypatch.setattr(workflow_publisher, "_open_directory", record_descriptor)
+    monkeypatch.setattr(workflow_publisher.fcntl, "flock", fail_unlock)
+
+    with pytest.raises(PublishError) as exc_info, workflow_publisher._target_lock(target):
+        pass
+
+    assert descriptor is not None
+    with pytest.raises(OSError) as closed:
+        os.fstat(descriptor)
+    assert closed.value.errno == errno.EBADF
+    assert exc_info.value.drift_class is DriftClass.INVALID_OR_SEMANTIC
+    assert exc_info.value.lock_error is exc_info.value.__cause__
+    assert isinstance(exc_info.value.__cause__, OSError)
+    assert exc_info.value.__cause__.errno == errno.EINTR
+
+
 def test_parallel_canonical_and_runtime_publish_complete_without_deadlock(tmp_path: Path) -> None:
     canonical, runtime = _roots(tmp_path)
     canonical_publisher = multiprocessing.Process(
@@ -917,6 +972,8 @@ def test_standalone_cli_reports_flock_acquisition_failure(
     canonical, target = _roots(tmp_path)
     view = tmp_path / "view"
     view.mkdir()
+    sentinel = "PRIVATE-WORKFLOW-BODY-SENTINEL"
+    _write(view / "AGENTS.md", sentinel.encode())
 
     def fail_acquisition(_descriptor: int, _operation: int) -> None:
         raise OSError(errno.ENOLCK, "No locks available")
@@ -937,7 +994,10 @@ def test_standalone_cli_reports_flock_acquisition_failure(
     captured = capsys.readouterr()
 
     assert code == EXIT_CODES[DriftClass.INVALID_OR_SEMANTIC]
-    assert captured.err.splitlines() == ["workflow publisher: invalid-or-semantic"]
+    assert captured.err.splitlines()[0] == "workflow publisher: invalid-or-semantic"
+    diagnostic = json.loads(captured.err.splitlines()[1].removeprefix(PUBLISHER_LOCK_ERROR_PREFIX))
+    assert diagnostic == {"root": str(canonical), "error": "No locks available"}
+    assert sentinel not in captured.err
     assert "Traceback" not in captured.err
 
 
@@ -948,7 +1008,8 @@ def test_standalone_cli_reports_canonical_unlock_failure(
     view = tmp_path / "view"
     view.mkdir()
     _canonical_identity(canonical)
-    _write(view / "AGENTS.md", b"cli view\n")
+    sentinel = "PRIVATE-WORKFLOW-BODY-SENTINEL"
+    _write(view / "AGENTS.md", sentinel.encode())
     original_open = workflow_publisher._open_directory
     original_flock = workflow_publisher.fcntl.flock
     descriptor: int | None = None
@@ -982,8 +1043,14 @@ def test_standalone_cli_reports_canonical_unlock_failure(
     captured = capsys.readouterr()
 
     assert descriptor is not None
+    with pytest.raises(OSError) as closed:
+        os.fstat(descriptor)
+    assert closed.value.errno == errno.EBADF
     assert code == EXIT_CODES[DriftClass.INVALID_OR_SEMANTIC]
-    assert captured.err.splitlines() == ["workflow publisher: invalid-or-semantic"]
+    assert captured.err.splitlines()[0] == "workflow publisher: invalid-or-semantic"
+    diagnostic = json.loads(captured.err.splitlines()[1].removeprefix(PUBLISHER_LOCK_ERROR_PREFIX))
+    assert diagnostic == {"root": str(canonical), "error": "Interrupted system call"}
+    assert sentinel not in captured.err
     assert "Traceback" not in captured.err
 
 

--- a/tests/test_core/test_workflow_publisher.py
+++ b/tests/test_core/test_workflow_publisher.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 # pyright: reportPrivateUsage=false
+import errno
 import json
 import multiprocessing
 import stat
@@ -23,6 +24,7 @@ from djinn_in_a_box.core.workflow_publisher import (
     CarrierFragment,
     DriftClass,
     PublishedFile,
+    PublishError,
     WorkflowView,
     canonical_lock,
     publish_workflow_view,
@@ -764,6 +766,59 @@ def test_lock_contention_blocks_until_canonical_lock_releases(tmp_path: Path) ->
     assert (target / "AGENTS.md").read_bytes() == b"blocked then published\n"
 
 
+def test_canonical_lock_wraps_unlock_failure(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    canonical, _target = _roots(tmp_path)
+    original_flock = workflow_publisher.fcntl.flock
+
+    def fail_unlock(descriptor: int, operation: int) -> None:
+        if operation == workflow_publisher.fcntl.LOCK_UN:
+            raise OSError(errno.EINTR, "Interrupted system call")
+        original_flock(descriptor, operation)
+
+    monkeypatch.setattr(workflow_publisher.fcntl, "flock", fail_unlock)
+
+    with pytest.raises(PublishError) as exc_info, canonical_lock(canonical, exclusive=False):
+        pass
+
+    assert exc_info.value.drift_class is DriftClass.INVALID_OR_SEMANTIC
+    assert isinstance(exc_info.value.__cause__, OSError)
+    assert exc_info.value.__cause__.errno == errno.EINTR
+
+
+def test_canonical_lock_wraps_close_failure(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    canonical, _target = _roots(tmp_path)
+    original_open = workflow_publisher._open_directory
+    original_close = workflow_publisher.os.close
+    descriptor: int | None = None
+
+    def record_descriptor(path: Path) -> int:
+        nonlocal descriptor
+        descriptor = original_open(path)
+        return descriptor
+
+    def fail_close(candidate: int) -> None:
+        if candidate == descriptor:
+            raise OSError(errno.EIO, "Input/output error")
+        original_close(candidate)
+
+    monkeypatch.setattr(workflow_publisher, "_open_directory", record_descriptor)
+    monkeypatch.setattr(workflow_publisher.os, "close", fail_close)
+    try:
+        with pytest.raises(PublishError) as exc_info, canonical_lock(canonical, exclusive=False):
+            pass
+    finally:
+        assert descriptor is not None
+        original_close(descriptor)
+
+    assert exc_info.value.drift_class is DriftClass.INVALID_OR_SEMANTIC
+    assert isinstance(exc_info.value.__cause__, OSError)
+    assert exc_info.value.__cause__.errno == errno.EIO
+
+
 def test_parallel_canonical_and_runtime_publish_complete_without_deadlock(tmp_path: Path) -> None:
     canonical, runtime = _roots(tmp_path)
     canonical_publisher = multiprocessing.Process(
@@ -854,6 +909,82 @@ def _run_cli(
         capture_output=True,
         text=True,
     )
+
+
+def test_standalone_cli_reports_flock_acquisition_failure(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    canonical, target = _roots(tmp_path)
+    view = tmp_path / "view"
+    view.mkdir()
+
+    def fail_acquisition(_descriptor: int, _operation: int) -> None:
+        raise OSError(errno.ENOLCK, "No locks available")
+
+    monkeypatch.setattr(workflow_publisher.fcntl, "flock", fail_acquisition)
+    code = workflow_publisher.main(
+        (
+            "--view",
+            str(view),
+            "--canonical-root",
+            str(canonical),
+            "--target",
+            str(target),
+            "--manifest",
+            str(target / RUNTIME_MANIFEST_NAME),
+        )
+    )
+    captured = capsys.readouterr()
+
+    assert code == EXIT_CODES[DriftClass.INVALID_OR_SEMANTIC]
+    assert captured.err.splitlines() == ["workflow publisher: invalid-or-semantic"]
+    assert "Traceback" not in captured.err
+
+
+def test_standalone_cli_reports_canonical_unlock_failure(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    canonical, target = _roots(tmp_path)
+    view = tmp_path / "view"
+    view.mkdir()
+    _canonical_identity(canonical)
+    _write(view / "AGENTS.md", b"cli view\n")
+    original_open = workflow_publisher._open_directory
+    original_flock = workflow_publisher.fcntl.flock
+    descriptor: int | None = None
+
+    def record_canonical_descriptor(path: Path) -> int:
+        nonlocal descriptor
+        candidate = original_open(path)
+        if path == canonical:
+            descriptor = candidate
+        return candidate
+
+    def fail_canonical_unlock(candidate: int, operation: int) -> None:
+        if candidate == descriptor and operation == workflow_publisher.fcntl.LOCK_UN:
+            raise OSError(errno.EINTR, "Interrupted system call")
+        original_flock(candidate, operation)
+
+    monkeypatch.setattr(workflow_publisher, "_open_directory", record_canonical_descriptor)
+    monkeypatch.setattr(workflow_publisher.fcntl, "flock", fail_canonical_unlock)
+    code = workflow_publisher.main(
+        (
+            "--view",
+            str(view),
+            "--canonical-root",
+            str(canonical),
+            "--target",
+            str(target),
+            "--manifest",
+            str(target / RUNTIME_MANIFEST_NAME),
+        )
+    )
+    captured = capsys.readouterr()
+
+    assert descriptor is not None
+    assert code == EXIT_CODES[DriftClass.INVALID_OR_SEMANTIC]
+    assert captured.err.splitlines() == ["workflow publisher: invalid-or-semantic"]
+    assert "Traceback" not in captured.err
 
 
 def test_standalone_file_only_publish_exit_codes_fragment_refusal_and_missing_canonical(

--- a/tests/test_docker.py
+++ b/tests/test_docker.py
@@ -96,8 +96,25 @@ class TestWorkflowImageCompatibility:
         assert workflow_image_compatible() is WorkflowImageCompatibility.INCOMPATIBLE
 
     @patch("djinn_in_a_box.core.docker.subprocess.run")
-    def test_inspect_failure_is_unknown(self, run: MagicMock) -> None:
-        run.return_value = MagicMock(returncode=1, stdout="")
+    def test_missing_image_is_distinguished_from_an_unreachable_daemon(
+        self, run: MagicMock
+    ) -> None:
+        run.side_effect = (
+            MagicMock(returncode=1, stdout=""),
+            MagicMock(returncode=0, stdout=""),
+        )
+
+        assert workflow_image_compatible() is WorkflowImageCompatibility.MISSING
+        assert run.call_args_list[1].args[0] == ["docker", "info"]
+
+    @patch("djinn_in_a_box.core.docker.subprocess.run")
+    def test_inspect_failure_is_unknown_when_daemon_is_unreachable(
+        self, run: MagicMock
+    ) -> None:
+        run.side_effect = (
+            MagicMock(returncode=1, stdout=""),
+            MagicMock(returncode=1, stdout=""),
+        )
 
         assert workflow_image_compatible() is WorkflowImageCompatibility.UNKNOWN
 

--- a/tests/test_ws3_doctor_session.py
+++ b/tests/test_ws3_doctor_session.py
@@ -17,7 +17,7 @@ from djinn_in_a_box.commands import session as session_mod
 from djinn_in_a_box.config.models import AppConfig
 from djinn_in_a_box.core.config_workflow import WorkflowPreparationResult
 from djinn_in_a_box.core.exceptions import ConfigNotFoundError, ConfigValidationError
-from djinn_in_a_box.core.session import SessionResult
+from djinn_in_a_box.core.session import SessionResult, SessionTarget
 
 runner = CliRunner()
 
@@ -233,6 +233,7 @@ def test_session_create_absent_workspace_creates_and_proceeds(tmp_path: Path) ->
         patch("djinn_in_a_box.commands.session.SessionManager") as mock_mgr,
     ):
         mock_instance = mock_mgr.return_value
+        mock_instance.resolve_target.return_value = SessionTarget()
         mock_instance.preflight_check.return_value = None
         mock_instance.run_headless.return_value = mock_result
 
@@ -253,6 +254,7 @@ def test_session_without_create_absent_workspace_errors(tmp_path: Path) -> None:
         patch("djinn_in_a_box.commands.session.Path.home", return_value=tmp_path),
         patch("djinn_in_a_box.commands.session.SessionManager") as mock_mgr,
     ):
+        mock_mgr.return_value.resolve_target.return_value = SessionTarget()
         result = runner.invoke(app, ["session", "--project", "missing", "--prompt", "hello"])
 
         assert result.exit_code == 1
@@ -269,6 +271,7 @@ def test_session_create_existing_file_errors_cleanly(tmp_path: Path) -> None:
         patch("djinn_in_a_box.commands.session.Path.home", return_value=tmp_path),
         patch("djinn_in_a_box.commands.session.SessionManager") as mock_mgr,
     ):
+        mock_mgr.return_value.resolve_target.return_value = SessionTarget()
         result = runner.invoke(
             app,
             ["session", "--project", "testproj", "--prompt", "hello", "--create"],
@@ -295,6 +298,7 @@ def test_session_interactive_failure_prints_stderr(tmp_path: Path) -> None:
         patch.object(session_mod.err_console, "print") as mock_err_print,
     ):
         mock_instance = mock_mgr.return_value
+        mock_instance.resolve_target.return_value = SessionTarget()
         mock_instance.preflight_check.return_value = None
         mock_instance.run_interactive.return_value = mock_result
 


### PR DESCRIPTION
Closes #22. Closes #18.

## What was wrong

`prepare_config_workflow` funnelled several unrelated failures through
`_failure("invalid-or-semantic")`, whose canonical remedy is *"Author or edit the
artifact natively in the target tool's view, or make the source form portable."*
Correct for a non-portable workflow artifact; misleading for a permission
problem, a full disk, a symlinked destination or a lock the kernel would not
grant. And nothing tested that the config directory lock actually excludes.

## What changed

**#22 — the lock's exclusivity is now pinned.** `LOCK_EX` → `LOCK_SH`, or
dropping the `flock` call, left the suite green while `config edit` and
`config set config_sync.source` both read-modify-write `config.toml` under that
lock. A spawned probe now attempts `flock` with `LOCK_NB` while the parent holds
it — non-blocking, so no sleep and no timing window in a repo that just spent two
cycles restoring CI trust. Both mutations verified to fail the test.

**#18 — failures name what actually failed.** `_prepare_target` discarded its
`OSError` and returned bare `False` for three different conditions. The one that
bites in practice needs no exception at all: a dotfiles-managed `~/.claude`
symlink produced "make the artifact portable", with neither the path nor the word
symlink in the output. There are now distinct results for symlink,
not-a-directory, provisioning failure and missing target.

`Path.exists()` and `is_symlink()` return `False` on `OSError` in Python 3.14
(verified on 3.14.6), so a destination under a non-traversable parent reported
"missing — create it". `lstat()` now decides, and only `FileNotFoundError` takes
the missing path.

**A missing image is no longer reported as an unreachable daemon.** Both exit 1
from `docker image inspect`, so a bounded `docker info` probe settles it. The
risky half was the new enum member — every consumer tested identity against
`UNKNOWN`, so a new value would have slipped past and possibly been treated as
compatible. All consumers handle it explicitly, and an exhaustive test fails if a
future member is added unhandled.

**One error channel per lock helper.** Five review iterations each found a
different variant of one defect: `canonical_lock` raised `PublishError` from the
directory open but plain `OSError` from `flock`, the unlock and the close, so
every consumer needed two handlers and none had both. `_target_lock` and
`config_directory_lock` had the same shape. All three now raise one type,
chained from the originating `OSError`, and close the descriptor even when the
unlock fails — measured, no leak in any of them.

**The cause survives the trip to the user.** My own enumeration covered where
these errors are *produced*, not where they are *consumed* — three transform
functions rebuilt a generic drift class from a structured cause. `_audit_failure`
ignored `audit.problems`; the compose-Claude retirement route ignored
`write_error` three lines before the publish route checks it;
`_publisher_refresh_error` did not know the lock prefix, so a container-side lock
failure came out as the portability remedy. And lock errors travelled in the
`write_error` field, so a lease failure was announced as a publish failure with a
writability remedy. `PublishResult` now has a separate `lock_error`.

## Behaviour changes worth noting

- `djinn config set config_sync.source` prints success **after** the lock exits.
  It previously printed success and then raised, so a failing unlock produced
  "value updated" followed by a traceback. A release failure after a successful
  write now exits 1 and says exactly that.
- `djinn config status` / `config sync` show a lock diagnosis instead of the
  portability remedy when the canonical lock fails.

## Constraints kept

The five audit drift classes and `EXIT_CODES` are untouched — every new problem
is a preparation/operational problem constructed beside them, never routed
through `_failure()`, which coerces via `DriftClass` and would raise. User-facing
messages carry paths and `strerror` only; the sentinel test asserting no workflow
body reaches `repr(result)` still holds.

## Verification

Loop findings by iteration: **4 → 2 → 1 → 4 → 3 → 1**, each round a different
layer (sources, sibling helpers, consumers), each closed once. Iteration 4
prompted the switch from patching instances to closing the class.

Checked by me rather than taken from a report:

- Both lock mutations fail the new test; an unhandled enum member fails the
  exhaustive test; removing the `write_error` propagation fails the publish test;
  removing the `PublishError` handler lets the exception escape.
- All three lock helpers close their descriptor after a failing unlock, measured
  against `/proc/self/fd`.
- Python 3.14's `exists()`/`is_symlink()` behaviour, reproduced directly.
- Every `fcntl.flock` and `os.open` in `src/` is either inside a single-channel
  helper or deliberately outside one (`_fsync_directory` holds no lease).
- Two tests that pinned the old wrong wording were corrected, not worked around.
  Their names said `publish_failure` while they exercised lock failures — which
  is how the mismatch stayed invisible.

`ruff check` clean · `pyright src` 0 errors · **678 tests pass**.

## Deliberately not in this PR

`ENOLCK` and `EINTR` cannot be provoked reliably on an ordinary filesystem, so
those specific tests monkeypatch `fcntl.flock`. They sit alongside the
real-filesystem exclusion, contention and unreadable-root tests, not in place of
them.
