### PR TITLE
fix(firewall): refuse blocked connections instead of dropping them

### DIFF
--- a/README.md
+++ b/README.md
@@ -420,11 +420,16 @@ in `scripts/init-firewall.sh`: package registries, the four bundled CLIs' API an
 sign-in endpoints, GitHub, and the Docker networks. Every address a domain
 resolves to is permitted.
 
-Two limits are worth knowing before you rely on it. The list is resolved **once**
-at container start, so an address a provider rotates in later is denied until you
-restart. And only IPv4 is covered. If a tool fails in unusual ways under
+A blocked connection is refused immediately rather than dropped, so a tool that
+hits the allowlist fails in about 0.2 seconds with "connection refused" instead
+of hanging until its own timeout. If something fails in unusual ways under
 `--firewall`, that list is the first place to look — add the domain you need at
 the marked spot near the end of the array.
+
+One limit is worth knowing before you rely on it: the list is resolved **once**
+at container start, so an address a provider rotates in later is denied until you
+restart. IPv4 only, which matches the Djinn network — it runs with IPv6
+disabled.
 
 Third-party model providers you configure yourself (OpenRouter, x.ai, and the
 like) are deliberately absent; add the ones you actually use.

--- a/scripts/init-firewall.sh
+++ b/scripts/init-firewall.sh
@@ -182,8 +182,22 @@ for domain in "${ALLOWED_DOMAINS[@]}"; do
     fi
 done
 
-# Default deny
-iptables -A OUTPUT -j DROP
+# Default deny.
+#
+# REJECT, not DROP: a dropped packet gives the client nothing to react to, so a
+# blocked request sits until its own timeout expires. Measured in this image,
+# curl took 12.0 s to fail with "Connection timed out" under DROP and 0.2 s to
+# fail with "Couldn't connect to server" under REJECT. The agent that hangs for
+# twelve seconds tells the user nothing; the immediate refusal at least says a
+# connection was refused rather than lost.
+#
+# Deliberately no --reject-with tcp-reset: that option requires -p tcp, so on
+# this catch-all rule `iptables` fails with "RULE_APPEND failed (Invalid
+# argument)" and appends nothing — leaving the chain with no terminal rule and
+# the policy at ACCEPT. Verified: with tcp-reset the script still printed
+# "Firewall initialized" while every outbound request succeeded. The default
+# icmp-port-unreachable works on a protocol-agnostic rule.
+iptables -A OUTPUT -j REJECT
 
 echo "" >&2
 ui_ok "Firewall initialized. Outbound traffic restricted to whitelist."


### PR DESCRIPTION
Refs #17 — closes the diagnosability half; the point-in-time-resolution limit stays open there.

## The problem

Under `djinn start --firewall`, a blocked request produced no signal. Measured in
this image:

| Terminal rule | Time to fail | What the user sees |
|---|---|---|
| `DROP` (before) | 12.0 s | `curl: (28) Connection timed out` |
| `REJECT` (after) | 0.2 s | `curl: (7) Couldn't connect to server` |

An agent that hangs for twelve seconds and then reports a timeout gives no hint
that a firewall is involved. An immediate refusal at least distinguishes "refused"
from "lost".

## A trap worth recording

`--reject-with tcp-reset` looks like the better choice for TCP and is not usable
here. It requires `-p tcp`, so on this protocol-agnostic catch-all rule
`iptables` fails with `RULE_APPEND failed (Invalid argument)` and appends
**nothing** — leaving the chain with no terminal rule and the policy at `ACCEPT`.

Verified: with `tcp-reset` the script still printed `Firewall initialized` while
every outbound request succeeded, including hosts that are not on the allowlist.
That is a silent total failure of the protection mode, and it would have looked
correct in the startup output. The default `icmp-port-unreachable` works on a
catch-all rule.

## Verification

Run against the real script in a throwaway container with `NET_ADMIN`:

- last rule is `REJECT ... reject-with icmp-port-unreachable`
- `api.anthropic.com` and `generativelanguage.googleapis.com` stay reachable
- an unlisted host is refused in 212 ms with a connection error

`ruff check` clean · 678 tests pass · `bash -n` clean · the 17 firewall output
tests unchanged and passing.

## Documentation

README states the immediate refusal, and the IPv6 caveat is dropped rather than
carried: `djinn-network` runs with IPv6 disabled (`EnableIPv6: false`), so
IPv4-only coverage matches the network instead of being a gap. The
resolved-once-at-container-start limit remains documented and tracked in #17.