### PR TITLE
feat(opencode): keep credentials in the config root, not the data volume

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -154,6 +154,7 @@ RUN chmod +x ~/.tools/install.sh ~/.tools/installers/*.sh 2>/dev/null || true \
 COPY --chown=dev:dev scripts/entrypoint.sh /home/dev/entrypoint.sh
 COPY --chown=dev:dev src/djinn_in_a_box/core/workflow_publisher.py /home/dev/workflow-publisher.py
 COPY --chown=dev:dev scripts/settings-copy.py /home/dev/settings-copy.py
+COPY --chown=dev:dev scripts/opencode-credentials.sh /home/dev/opencode-credentials.sh
 COPY --chown=dev:dev scripts/output-lib.sh /home/dev/output-lib.sh
 COPY --chown=dev:dev scripts/seed-lib.sh /home/dev/seed-lib.sh
 COPY --chown=dev:dev scripts/mcp-register.sh /home/dev/mcp-register.sh

--- a/IMPLEMENTATION.md
+++ b/IMPLEMENTATION.md
@@ -483,6 +483,8 @@ container start
   +-- claude_settings_merge ~/.claude_seed -> ~/.claude/settings.json
   +-- sync_seed gemini   ~/.gemini_seed   -> ~/.gemini
   +-- settings-copy.py persists personal OpenCode settings only
+  +-- opencode-credentials.sh migrates legacy OpenCode credential files and
+      re-establishes volume-to-config-root symlinks on every start
   +-- workflow-publisher.py publishes ~/.opencode/seed -> ~/.config/opencode
       using the read-only /home/dev/.djinn-canonical root and the runtime state manifest
   +-- source mcp-register.sh and register MCP servers
@@ -536,9 +538,13 @@ exception: plain `codex login` starts a container-local login server that the
 host browser cannot reach, so users must run `codex login --device-auth` (or
 choose the remote/headless option in its TUI). README documents this.
 
-Claude Code, Gemini CLI, Codex, and the GitHub CLI persist the resulting
-credentials in their config-root bind mounts; OpenCode writes `auth.json` into
-the `djinn-opencode-data` named volume.
+Claude Code, Gemini CLI, Codex, GitHub CLI, and OpenCode persist the resulting
+credentials in config-root bind mounts. At each container start, the entrypoint
+reconciles legacy OpenCode `auth.json` and `mcp-auth.json` files from the
+`djinn-opencode-data` volume: it migrates volume-only files, or preserves the
+config-root file and sets aside the volume file on conflict. It then
+re-establishes the volume paths under `~/.local/share/opencode/` as symlinks to
+the config-root files.
 
 Common mounts include:
 

--- a/README.md
+++ b/README.md
@@ -130,17 +130,14 @@ The GitHub CLI is not an agent binary but shares the same model — run
 `gh auth login` in that shell and choose the device-code flow when prompted.
 
 The resulting credentials persist outside the container image, so you only do
-this once per tool. Note where each tool stores them, because the two locations
-back up and move differently:
+this once per tool:
 
 | Tool | Credential location | Backup category |
 | --- | --- | --- |
-| Claude Code, Gemini CLI, Codex, GitHub CLI | your configured config root | `credentials` |
-| OpenCode | the `djinn-opencode-data` named volume (`auth.json`) | `data` |
+| Claude Code, Gemini CLI, Codex, OpenCode, GitHub CLI | your configured config root | `credentials` |
 
 `djinn backup` includes both categories by default. If you back up selectively,
-or copy only your config root to another machine, OpenCode's login does not
-travel with it.
+copy the matching credential category.
 
 ## Configuration
 

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -113,6 +113,10 @@ elif [[ -e "$OPENCODE_LEGACY_SETTINGS" || -L "$OPENCODE_LEGACY_SETTINGS" ]]; the
         --copy-settings "$OPENCODE_PERSISTENT_SETTINGS" "$OPENCODE_RUNTIME_SETTINGS" >&2
 fi
 
+OPENCODE_CREDENTIALS_HELPER="${OPENCODE_CREDENTIALS_HELPER:-/home/dev/opencode-credentials.sh}"
+source "$OPENCODE_CREDENTIALS_HELPER"
+ensure_opencode_credentials
+
 ui_info "[workflow-delivery] opencode:"
 WORKFLOW_PUBLISHER="${WORKFLOW_PUBLISHER:-/home/dev/workflow-publisher.py}"
 CANONICAL_CONFIG_ROOT="${DJINN_CANONICAL_ROOT:-/home/dev/.djinn-canonical}"

--- a/scripts/opencode-credentials.sh
+++ b/scripts/opencode-credentials.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env zsh
+
+# Reconcile OpenCode's volume-backed credential locations with the config-root
+# credential files. The entrypoint sources output-lib.sh before this helper.
+ensure_opencode_credentials() {
+    local credential_name
+    local volume_path
+    local config_path
+
+    mkdir -p "$HOME/.local/share/opencode" "$HOME/.opencode"
+
+    for credential_name in auth.json mcp-auth.json; do
+        volume_path="$HOME/.local/share/opencode/$credential_name"
+        config_path="$HOME/.opencode/$credential_name"
+
+        if [[ -f "$volume_path" && ! -L "$volume_path" ]]; then
+            if [[ -e "$config_path" || -L "$config_path" ]]; then
+                mv -- "$volume_path" "$volume_path.pre-migration"
+                ui_warn "OpenCode credential conflict for $credential_name; set aside $credential_name.pre-migration."
+            else
+                mv -- "$volume_path" "$config_path"
+                ui_info "Migrated OpenCode credential $credential_name to the config root."
+            fi
+        elif [[ ! -e "$config_path" && ! -L "$config_path" ]]; then
+            printf '{}' > "$config_path"
+        fi
+
+        chmod 0600 "$config_path"
+
+        if [[ -L "$volume_path" && "$volume_path" -ef "$config_path" ]]; then
+            continue
+        fi
+
+        [[ -e "$volume_path" || -L "$volume_path" ]] && rm -f "$volume_path"
+        ln -s "$config_path" "$volume_path"
+    done
+}

--- a/scripts/opencode-credentials.sh
+++ b/scripts/opencode-credentials.sh
@@ -23,7 +23,19 @@ ensure_opencode_credentials() {
         fi
 
         if [[ -L "$volume_path" ]]; then
-            if [[ ! -f "$config_path" || ! "$volume_path" -ef "$config_path" ]]; then
+            # A canonical link whose target is gone is the state
+            # `djinn clean volumes --credentials` leaves behind: it empties the
+            # config-root directory while the volume mount keeps its links. That
+            # must stay recoverable — the target is recreated below — so compare
+            # where the link points rather than whether it resolves. `-ef` when
+            # the target exists (robust against equivalent path spellings),
+            # falling back to the link text when it does not.
+            if [[ -f "$config_path" ]]; then
+                if [[ ! "$volume_path" -ef "$config_path" ]]; then
+                    ui_err "OpenCode credential $credential_name at $volume_path must be a regular file or the canonical symlink to $config_path; refusing to change it."
+                    return 1
+                fi
+            elif [[ "$(readlink -- "$volume_path")" != "$config_path" ]]; then
                 ui_err "OpenCode credential $credential_name at $volume_path must be a regular file or the canonical symlink to $config_path; refusing to change it."
                 return 1
             fi

--- a/scripts/opencode-credentials.sh
+++ b/scripts/opencode-credentials.sh
@@ -2,6 +2,18 @@
 
 # Reconcile OpenCode's volume-backed credential locations with the config-root
 # credential files. The entrypoint sources output-lib.sh before this helper.
+
+# Absolute, normalised target of a symlink, without needing it to resolve.
+# `-ef` handles equivalent spellings while the target exists; once
+# `clean volumes --credentials` removes it, the link dangles and only its text
+# remains. Comparing that text raw would reject a relative or `..`-containing
+# canonical link that the same helper accepts while the target is present.
+_opencode_link_target() {
+    local target
+    target="$(readlink -- "$1")"
+    [[ "$target" != /* ]] && target="${1:h}/$target"
+    printf '%s' "${target:a}"
+}
 ensure_opencode_credentials() {
     local credential_name
     local volume_path
@@ -23,19 +35,21 @@ ensure_opencode_credentials() {
         fi
 
         if [[ -L "$volume_path" ]]; then
-            # A canonical link whose target is gone is the state
-            # `djinn clean volumes --credentials` leaves behind: it empties the
-            # config-root directory while the volume mount keeps its links. That
-            # must stay recoverable — the target is recreated below — so compare
-            # where the link points rather than whether it resolves. `-ef` when
-            # the target exists (robust against equivalent path spellings),
-            # falling back to the link text when it does not.
-            if [[ -f "$config_path" ]]; then
-                if [[ ! "$volume_path" -ef "$config_path" ]]; then
-                    ui_err "OpenCode credential $credential_name at $volume_path must be a regular file or the canonical symlink to $config_path; refusing to change it."
-                    return 1
-                fi
-            elif [[ "$(readlink -- "$volume_path")" != "$config_path" ]]; then
+            # One definition of "canonical", used whether or not the target
+            # currently exists. `djinn clean volumes --credentials` empties the
+            # config-root directory while the volume mount keeps its links, so
+            # every link dangles afterwards and must still be recoverable — the
+            # target is recreated below. Deciding by filesystem identity (`-ef`)
+            # cannot survive that, because the inode is gone; deciding by path
+            # can. Using both, one per branch, is what made an alias accepted
+            # before a clean and refused after it.
+            #
+            # Lexical comparison also refuses two arrangements `-ef` would have
+            # accepted — a link through an aliased directory, and a link to a
+            # hard link of the credential. Both are deliberate redirects that
+            # this design does not manage, so refusing them consistently is the
+            # intended behaviour rather than a side effect.
+            if [[ "$(_opencode_link_target "$volume_path")" != "${config_path:a}" ]]; then
                 ui_err "OpenCode credential $credential_name at $volume_path must be a regular file or the canonical symlink to $config_path; refusing to change it."
                 return 1
             fi

--- a/scripts/opencode-credentials.sh
+++ b/scripts/opencode-credentials.sh
@@ -6,6 +6,8 @@ ensure_opencode_credentials() {
     local credential_name
     local volume_path
     local config_path
+    local set_aside_path
+    local set_aside_suffix
 
     mkdir -p "$HOME/.local/share/opencode" "$HOME/.opencode"
 
@@ -13,25 +15,52 @@ ensure_opencode_credentials() {
         volume_path="$HOME/.local/share/opencode/$credential_name"
         config_path="$HOME/.opencode/$credential_name"
 
+        # A deliberate redirect can otherwise cause a silent logout. Refuse it
+        # and return nonzero so the entrypoint's `set -e` stops this start intact.
+        if [[ -L "$config_path" || ( -e "$config_path" && ! -f "$config_path" ) ]]; then
+            ui_err "OpenCode credential $credential_name at $config_path must be a regular file or be absent; refusing to change it."
+            return 1
+        fi
+
+        if [[ -L "$volume_path" ]]; then
+            if [[ ! -f "$config_path" || ! "$volume_path" -ef "$config_path" ]]; then
+                ui_err "OpenCode credential $credential_name at $volume_path must be a regular file or the canonical symlink to $config_path; refusing to change it."
+                return 1
+            fi
+        elif [[ -e "$volume_path" && ! -f "$volume_path" ]]; then
+            ui_err "OpenCode credential $credential_name at $volume_path must be a regular file or the canonical symlink to $config_path; refusing to change it."
+            return 1
+        fi
+
         if [[ -f "$volume_path" && ! -L "$volume_path" ]]; then
-            if [[ -e "$config_path" || -L "$config_path" ]]; then
-                mv -- "$volume_path" "$volume_path.pre-migration"
-                ui_warn "OpenCode credential conflict for $credential_name; set aside $credential_name.pre-migration."
+            if [[ -f "$config_path" ]]; then
+                set_aside_path="$volume_path.pre-migration"
+                set_aside_suffix=1
+                while true; do
+                    while [[ -e "$set_aside_path" || -L "$set_aside_path" ]]; do
+                        set_aside_path="$volume_path.pre-migration.$set_aside_suffix"
+                        (( set_aside_suffix += 1 ))
+                    done
+                    mv -n -- "$volume_path" "$set_aside_path"
+                    [[ ! -e "$volume_path" && ! -L "$volume_path" ]] && break
+                done
+                chmod 0600 "$set_aside_path"
+                ui_warn "OpenCode credential conflict for $credential_name; set aside ${set_aside_path:t}."
             else
                 mv -- "$volume_path" "$config_path"
                 ui_info "Migrated OpenCode credential $credential_name to the config root."
             fi
-        elif [[ ! -e "$config_path" && ! -L "$config_path" ]]; then
+        elif [[ ! -f "$config_path" ]]; then
             printf '{}' > "$config_path"
         fi
 
         chmod 0600 "$config_path"
 
-        if [[ -L "$volume_path" && "$volume_path" -ef "$config_path" ]]; then
+        if [[ -L "$volume_path" ]]; then
             continue
         fi
 
-        [[ -e "$volume_path" || -L "$volume_path" ]] && rm -f "$volume_path"
+        [[ -e "$volume_path" ]] && rm -f "$volume_path"
         ln -s "$config_path" "$volume_path"
     done
 }

--- a/tests/test_opencode_credentials.py
+++ b/tests/test_opencode_credentials.py
@@ -281,3 +281,34 @@ def test_missing_volume_links_are_reestablished_silently(tmp_path: Path) -> None
         volume_path = volume_credential(tmp_path, name)
         assert volume_path.is_symlink()
         assert volume_path.resolve() == config_credential(tmp_path, name)
+
+
+def test_credentials_clean_leaves_a_startable_state(tmp_path: Path) -> None:
+    """`clean volumes --credentials` must not make the next start refuse.
+
+    That command empties the config-root credential directory while the named
+    volume keeps its symlinks, so both links dangle. Refusing there would make
+    the very cleanup #19 enabled leave Djinn unable to start.
+    """
+    first = run_credentials(tmp_path)
+    assert first.returncode == 0, first.stderr
+
+    # Exactly what clear_sync_path does to the config-root credential directory.
+    for name in ("auth.json", "mcp-auth.json"):
+        config_credential(tmp_path, name).unlink()
+        assert volume_credential(tmp_path, name).is_symlink()
+        assert not volume_credential(tmp_path, name).exists()  # dangling
+
+    result = run_credentials(tmp_path)
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout == ""
+    assert result.stderr == ""
+    for name in ("auth.json", "mcp-auth.json"):
+        config_path = config_credential(tmp_path, name)
+        volume_path = volume_credential(tmp_path, name)
+        assert config_path.is_file() and not config_path.is_symlink()
+        assert config_path.read_text(encoding="utf-8") == "{}"
+        assert stat.S_IMODE(config_path.stat().st_mode) == 0o600
+        assert volume_path.is_symlink()
+        assert volume_path.resolve() == config_path

--- a/tests/test_opencode_credentials.py
+++ b/tests/test_opencode_credentials.py
@@ -312,3 +312,97 @@ def test_credentials_clean_leaves_a_startable_state(tmp_path: Path) -> None:
         assert stat.S_IMODE(config_path.stat().st_mode) == 0o600
         assert volume_path.is_symlink()
         assert volume_path.resolve() == config_path
+
+
+def test_relative_canonical_link_survives_a_credentials_clean(tmp_path: Path) -> None:
+    """An equivalent link spelling must recover like the one the helper writes.
+
+    `-ef` accepts a relative or `..`-containing link while the target exists, so
+    such a link is a valid already-done state. Comparing the raw link text after
+    a clean would reject exactly that state and abort the start — the same
+    regression as before, one spelling further out.
+    """
+    for name in ("auth.json", "mcp-auth.json"):
+        config_path = config_credential(tmp_path, name)
+        config_path.parent.mkdir(exist_ok=True)
+        config_path.write_text(f"{name}-secret", encoding="utf-8")
+        config_path.chmod(0o600)
+        volume_path = volume_credential(tmp_path, name)
+        volume_path.parent.mkdir(parents=True, exist_ok=True)
+        volume_path.symlink_to(Path("../../..") / ".opencode" / name)
+
+    assert run_credentials(tmp_path).returncode == 0
+
+    for name in ("auth.json", "mcp-auth.json"):
+        config_credential(tmp_path, name).unlink()
+
+    result = run_credentials(tmp_path)
+
+    assert result.returncode == 0, result.stderr
+    assert result.stderr == ""
+    for name in ("auth.json", "mcp-auth.json"):
+        config_path = config_credential(tmp_path, name)
+        assert config_path.read_text(encoding="utf-8") == "{}"
+        assert stat.S_IMODE(config_path.stat().st_mode) == 0o600
+        assert volume_credential(tmp_path, name).is_symlink()
+
+
+def test_relative_link_to_an_unrelated_file_is_still_refused(tmp_path: Path) -> None:
+    external = tmp_path / "external.json"
+    external.write_text("external-secret", encoding="utf-8")
+    external.chmod(0o640)
+    volume_path = volume_credential(tmp_path, "auth.json")
+    volume_path.parent.mkdir(parents=True, exist_ok=True)
+    volume_path.symlink_to(Path("../../..") / "external.json")
+
+    result = run_credentials(tmp_path)
+
+    assert result.returncode == 1
+    assert "refusing to change it" in result.stderr
+    assert external.read_text(encoding="utf-8") == "external-secret"
+    assert stat.S_IMODE(external.stat().st_mode) == 0o640
+
+
+def test_aliased_directory_link_is_refused_consistently(tmp_path: Path) -> None:
+    """One definition of canonical, before and after a clean.
+
+    `-ef` accepted a link through an aliased directory while the target existed
+    and the text comparison refused it afterwards, so the same arrangement was
+    valid on one start and unstartable on the next. Lexical comparison refuses it
+    in both, which is the intended handling of a deliberate redirect.
+    """
+    config_path = config_credential(tmp_path, "auth.json")
+    config_path.parent.mkdir(exist_ok=True)
+    config_path.write_text("secret", encoding="utf-8")
+    alias_dir = tmp_path / ".opencode-alias"
+    alias_dir.symlink_to(config_path.parent, target_is_directory=True)
+    volume_path = volume_credential(tmp_path, "auth.json")
+    volume_path.parent.mkdir(parents=True, exist_ok=True)
+    volume_path.symlink_to(alias_dir / "auth.json")
+
+    before = run_credentials(tmp_path)
+    config_path.unlink()
+    after = run_credentials(tmp_path)
+
+    assert before.returncode == 1
+    assert after.returncode == 1
+    assert "refusing to change it" in before.stderr
+
+
+def test_hard_link_target_is_refused_consistently(tmp_path: Path) -> None:
+    config_path = config_credential(tmp_path, "auth.json")
+    config_path.parent.mkdir(exist_ok=True)
+    config_path.write_text("secret", encoding="utf-8")
+    hard_link = tmp_path / "hard-link.json"
+    os.link(config_path, hard_link)
+    volume_path = volume_credential(tmp_path, "auth.json")
+    volume_path.parent.mkdir(parents=True, exist_ok=True)
+    volume_path.symlink_to(hard_link)
+
+    before = run_credentials(tmp_path)
+    config_path.unlink()
+    after = run_credentials(tmp_path)
+
+    assert before.returncode == 1
+    assert after.returncode == 1
+    assert hard_link.read_text(encoding="utf-8") == "secret"

--- a/tests/test_opencode_credentials.py
+++ b/tests/test_opencode_credentials.py
@@ -1,0 +1,157 @@
+"""Tests for the OpenCode config-root credential reconciliation helper."""
+
+from __future__ import annotations
+
+import os
+import shutil
+import stat
+import subprocess
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "opencode-credentials.sh"
+OUTPUT_LIB = ROOT / "scripts" / "output-lib.sh"
+
+
+def run_credentials(tmp_path: Path) -> subprocess.CompletedProcess[str]:
+    zsh = shutil.which("zsh")
+    assert zsh is not None
+
+    env = {
+        **os.environ,
+        "HOME": str(tmp_path),
+        "NO_COLOR": "1",
+    }
+    env.pop("DJINN_FORCE_UI_COLOR", None)
+
+    return subprocess.run(
+        [
+            zsh,
+            "-c",
+            (
+                "set -euo pipefail; "
+                f'source "{OUTPUT_LIB}"; '
+                f'source "{SCRIPT}"; '
+                "ensure_opencode_credentials"
+            ),
+        ],
+        check=False,
+        capture_output=True,
+        env=env,
+        text=True,
+    )
+
+
+def config_credential(tmp_path: Path, name: str = "auth.json") -> Path:
+    return tmp_path / ".opencode" / name
+
+
+def volume_credential(tmp_path: Path, name: str = "auth.json") -> Path:
+    return tmp_path / ".local" / "share" / "opencode" / name
+
+
+def assert_restrictive_mode(path: Path) -> None:
+    assert stat.S_IMODE(path.stat().st_mode) == 0o600
+
+
+def test_fresh_credentials_are_created_in_config_root_and_linked(tmp_path: Path) -> None:
+    result = run_credentials(tmp_path)
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout == ""
+    assert result.stderr == ""
+    for name in ("auth.json", "mcp-auth.json"):
+        config_path = config_credential(tmp_path, name)
+        volume_path = volume_credential(tmp_path, name)
+        assert config_path.read_text(encoding="utf-8") == "{}"
+        assert_restrictive_mode(config_path)
+        assert volume_path.is_symlink()
+        assert volume_path.resolve() == config_path
+
+
+def test_existing_volume_credential_migrates_with_restrictive_mode(tmp_path: Path) -> None:
+    volume_path = volume_credential(tmp_path)
+    volume_path.parent.mkdir(parents=True)
+    secret = "migrated-provider-token"
+    volume_path.write_text(secret, encoding="utf-8")
+    volume_path.chmod(0o600)
+
+    result = run_credentials(tmp_path)
+
+    config_path = config_credential(tmp_path)
+    assert result.returncode == 0, result.stderr
+    assert result.stdout == ""
+    assert "Migrated OpenCode credential auth.json" in result.stderr
+    assert secret not in result.stderr
+    assert config_path.read_text(encoding="utf-8") == secret
+    assert_restrictive_mode(config_path)
+    assert volume_path.is_symlink()
+    assert volume_path.resolve() == config_path
+
+
+def test_conflicting_credential_keeps_config_and_sets_aside_volume_file(
+    tmp_path: Path,
+) -> None:
+    config_path = config_credential(tmp_path)
+    config_path.parent.mkdir()
+    config_secret = "config-root-token"
+    config_path.write_text(config_secret, encoding="utf-8")
+    config_path.chmod(0o600)
+
+    volume_path = volume_credential(tmp_path)
+    volume_path.parent.mkdir(parents=True)
+    volume_secret = "volume-token-to-preserve"
+    volume_path.write_text(volume_secret, encoding="utf-8")
+    volume_path.chmod(0o600)
+
+    result = run_credentials(tmp_path)
+
+    set_aside_path = volume_path.with_name("auth.json.pre-migration")
+    assert result.returncode == 0, result.stderr
+    assert result.stdout == ""
+    assert "OpenCode credential conflict for auth.json" in result.stderr
+    assert volume_secret not in result.stderr
+    assert config_secret not in result.stderr
+    assert config_path.read_text(encoding="utf-8") == config_secret
+    assert_restrictive_mode(config_path)
+    assert set_aside_path.exists()
+    assert set_aside_path.read_text(encoding="utf-8") == volume_secret
+    assert volume_path.is_symlink()
+    assert volume_path.resolve() == config_path
+
+
+def test_existing_correct_symlinks_are_idempotent_and_silent(tmp_path: Path) -> None:
+    for name in ("auth.json", "mcp-auth.json"):
+        config_path = config_credential(tmp_path, name)
+        config_path.parent.mkdir(exist_ok=True)
+        config_path.write_text(f"{name}-secret", encoding="utf-8")
+        config_path.chmod(0o600)
+        volume_path = volume_credential(tmp_path, name)
+        volume_path.parent.mkdir(parents=True, exist_ok=True)
+        volume_path.symlink_to(config_path)
+
+    first_result = run_credentials(tmp_path)
+    second_result = run_credentials(tmp_path)
+
+    assert first_result.returncode == 0, first_result.stderr
+    assert second_result.returncode == 0, second_result.stderr
+    assert first_result.stdout == second_result.stdout == ""
+    assert first_result.stderr == second_result.stderr == ""
+
+
+def test_missing_volume_links_are_reestablished_silently(tmp_path: Path) -> None:
+    for name in ("auth.json", "mcp-auth.json"):
+        config_path = config_credential(tmp_path, name)
+        config_path.parent.mkdir(exist_ok=True)
+        config_path.write_text(f"{name}-secret", encoding="utf-8")
+        config_path.chmod(0o600)
+
+    result = run_credentials(tmp_path)
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout == ""
+    assert result.stderr == ""
+    for name in ("auth.json", "mcp-auth.json"):
+        volume_path = volume_credential(tmp_path, name)
+        assert volume_path.is_symlink()
+        assert volume_path.resolve() == config_credential(tmp_path, name)

--- a/tests/test_opencode_credentials.py
+++ b/tests/test_opencode_credentials.py
@@ -8,6 +8,8 @@ import stat
 import subprocess
 from pathlib import Path
 
+import pytest
+
 ROOT = Path(__file__).resolve().parents[1]
 SCRIPT = ROOT / "scripts" / "opencode-credentials.sh"
 OUTPUT_LIB = ROOT / "scripts" / "output-lib.sh"
@@ -81,7 +83,9 @@ def test_existing_volume_credential_migrates_with_restrictive_mode(tmp_path: Pat
     config_path = config_credential(tmp_path)
     assert result.returncode == 0, result.stderr
     assert result.stdout == ""
-    assert "Migrated OpenCode credential auth.json" in result.stderr
+    assert result.stderr == (
+        "  [info] Migrated OpenCode credential auth.json to the config root.\n"
+    )
     assert secret not in result.stderr
     assert config_path.read_text(encoding="utf-8") == secret
     assert_restrictive_mode(config_path)
@@ -109,7 +113,10 @@ def test_conflicting_credential_keeps_config_and_sets_aside_volume_file(
     set_aside_path = volume_path.with_name("auth.json.pre-migration")
     assert result.returncode == 0, result.stderr
     assert result.stdout == ""
-    assert "OpenCode credential conflict for auth.json" in result.stderr
+    assert result.stderr == (
+        "  [warn] OpenCode credential conflict for auth.json; "
+        "set aside auth.json.pre-migration.\n"
+    )
     assert volume_secret not in result.stderr
     assert config_secret not in result.stderr
     assert config_path.read_text(encoding="utf-8") == config_secret
@@ -124,19 +131,138 @@ def test_existing_correct_symlinks_are_idempotent_and_silent(tmp_path: Path) -> 
     for name in ("auth.json", "mcp-auth.json"):
         config_path = config_credential(tmp_path, name)
         config_path.parent.mkdir(exist_ok=True)
-        config_path.write_text(f"{name}-secret", encoding="utf-8")
+        secret = f"{name}-secret"
+        config_path.write_text(secret, encoding="utf-8")
         config_path.chmod(0o600)
         volume_path = volume_credential(tmp_path, name)
         volume_path.parent.mkdir(parents=True, exist_ok=True)
         volume_path.symlink_to(config_path)
 
     first_result = run_credentials(tmp_path)
-    second_result = run_credentials(tmp_path)
 
     assert first_result.returncode == 0, first_result.stderr
+    assert first_result.stdout == ""
+    assert first_result.stderr == ""
+    for name in ("auth.json", "mcp-auth.json"):
+        assert config_credential(tmp_path, name).read_text(encoding="utf-8") == (
+            f"{name}-secret"
+        )
+
+    second_result = run_credentials(tmp_path)
+
     assert second_result.returncode == 0, second_result.stderr
-    assert first_result.stdout == second_result.stdout == ""
-    assert first_result.stderr == second_result.stderr == ""
+    assert second_result.stdout == ""
+    assert second_result.stderr == ""
+    for name in ("auth.json", "mcp-auth.json"):
+        assert config_credential(tmp_path, name).read_text(encoding="utf-8") == (
+            f"{name}-secret"
+        )
+
+
+def test_conflicts_use_a_numbered_set_aside_without_replacing_an_earlier_one(
+    tmp_path: Path,
+) -> None:
+    for name in ("auth.json", "mcp-auth.json"):
+        config_path = config_credential(tmp_path, name)
+        config_path.parent.mkdir(exist_ok=True)
+        config_path.write_text(f"{name}-config", encoding="utf-8")
+        config_path.chmod(0o600)
+
+        volume_path = volume_credential(tmp_path, name)
+        volume_path.parent.mkdir(parents=True, exist_ok=True)
+        volume_path.write_text(f"{name}-restored-volume", encoding="utf-8")
+        volume_path.chmod(0o640)
+        earlier_set_aside = volume_path.with_name(f"{name}.pre-migration")
+        earlier_set_aside.write_text(f"{name}-earlier-set-aside", encoding="utf-8")
+        earlier_set_aside.chmod(0o600)
+
+    result = run_credentials(tmp_path)
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout == ""
+    assert result.stderr == (
+        "  [warn] OpenCode credential conflict for auth.json; "
+        "set aside auth.json.pre-migration.1.\n"
+        "  [warn] OpenCode credential conflict for mcp-auth.json; "
+        "set aside mcp-auth.json.pre-migration.1.\n"
+    )
+    for name in ("auth.json", "mcp-auth.json"):
+        volume_path = volume_credential(tmp_path, name)
+        assert volume_path.is_symlink()
+        assert volume_path.resolve() == config_credential(tmp_path, name)
+        assert (
+            volume_path.with_name(f"{name}.pre-migration").read_text(
+                encoding="utf-8"
+            )
+            == f"{name}-earlier-set-aside"
+        )
+        numbered_set_aside = volume_path.with_name(f"{name}.pre-migration.1")
+        assert numbered_set_aside.read_text(encoding="utf-8") == (
+            f"{name}-restored-volume"
+        )
+        assert_restrictive_mode(numbered_set_aside)
+
+
+@pytest.mark.parametrize("name", ("auth.json", "mcp-auth.json"))
+def test_noncanonical_volume_symlink_is_refused_without_mutation(
+    tmp_path: Path,
+    name: str,
+) -> None:
+    host_managed_path = tmp_path / "host-managed" / name
+    host_managed_path.parent.mkdir()
+    host_managed_path.write_text(f"{name}-host-managed", encoding="utf-8")
+    host_managed_path.chmod(0o640)
+
+    volume_path = volume_credential(tmp_path, name)
+    volume_path.parent.mkdir(parents=True, exist_ok=True)
+    volume_path.symlink_to(host_managed_path)
+
+    result = run_credentials(tmp_path)
+
+    config_path = config_credential(tmp_path, name)
+    assert result.returncode != 0
+    assert result.stdout == ""
+    assert result.stderr == (
+        f"  [err] OpenCode credential {name} at {volume_path} must be a regular "
+        f"file or the canonical symlink to {config_path}; refusing to change it.\n"
+    )
+    assert not config_path.exists()
+    assert not config_path.is_symlink()
+    assert volume_path.is_symlink()
+    assert volume_path.resolve() == host_managed_path
+    assert host_managed_path.read_text(encoding="utf-8") == f"{name}-host-managed"
+    assert stat.S_IMODE(host_managed_path.stat().st_mode) == 0o640
+
+
+@pytest.mark.parametrize("name", ("auth.json", "mcp-auth.json"))
+def test_config_root_symlink_is_refused_without_mutation(
+    tmp_path: Path,
+    name: str,
+) -> None:
+    host_managed_path = tmp_path / "host-managed" / name
+    host_managed_path.parent.mkdir()
+    host_managed_path.write_text(f"{name}-host-managed", encoding="utf-8")
+    host_managed_path.chmod(0o640)
+
+    config_path = config_credential(tmp_path, name)
+    config_path.parent.mkdir(exist_ok=True)
+    config_path.symlink_to(host_managed_path)
+
+    result = run_credentials(tmp_path)
+
+    volume_path = volume_credential(tmp_path, name)
+    assert result.returncode != 0
+    assert result.stdout == ""
+    assert result.stderr == (
+        f"  [err] OpenCode credential {name} at {config_path} must be a regular "
+        "file or be absent; refusing to change it.\n"
+    )
+    assert config_path.is_symlink()
+    assert config_path.resolve() == host_managed_path
+    assert not volume_path.exists()
+    assert not volume_path.is_symlink()
+    assert host_managed_path.read_text(encoding="utf-8") == f"{name}-host-managed"
+    assert stat.S_IMODE(host_managed_path.stat().st_mode) == 0o640
 
 
 def test_missing_volume_links_are_reestablished_silently(tmp_path: Path) -> None:

--- a/tests/test_output_lib.py
+++ b/tests/test_output_lib.py
@@ -345,6 +345,9 @@ def test_entrypoint_security_section_uses_plain_ascii_markers(tmp_path: Path) ->
         "SEED_LIB": str(ROOT / "scripts" / "seed-lib.sh"),
         "MCP_REGISTER": str(ROOT / "scripts" / "mcp-register.sh"),
         "SETTINGS_COPY_HELPER": str(ROOT / "scripts" / "settings-copy.py"),
+        "OPENCODE_CREDENTIALS_HELPER": str(
+            ROOT / "scripts" / "opencode-credentials.sh"
+        ),
         "WORKFLOW_PUBLISHER": str(
             ROOT / "src" / "djinn_in_a_box" / "core" / "workflow_publisher.py"
         ),


### PR DESCRIPTION
Closes #19.

## Why

OpenCode's login lived in the `djinn-opencode-data` volume while the other three
bundled CLIs keep credentials under the config root. So `djinn clean volumes
--credentials` missed OpenCode entirely, its login sat in the `data` backup
category instead of `credentials`, and the README table carried an exception.

## What it does

The entrypoint reconciles `auth.json` and `mcp-auth.json` on every start via
`scripts/opencode-credentials.sh`. The files live in
`${DJINN_CONFIG_ROOT}/opencode/`; the volume paths become symlinks to them.

| State | Behaviour |
|---|---|
| Fresh | create `{}` at 0600, link, silent |
| Migration | move the volume file to the config root, link, one line |
| Conflict | keep the config-root file, set the volume file aside as `<name>.pre-migration[.n]`, one line |
| Already done | leave alone, silent |
| Non-canonical arrangement | refuse, name the path and expected form, change nothing |

**`clean` and `backup` needed no changes.** `clear_sync_path` deletes the
contents of a config-root subdirectory and `backup_sync_path` tars them, so a
file placed there is covered as it stands. That was the main scope question and
the answer removed work rather than adding it.

## Decisions worth knowing

Planned with a grill; `SPEC.md` and `decision-log.md` are in the issue workspace.

**Symlinks, not a file bind-mount.** A mount whose host file is missing makes
Docker create a root-owned directory in its place, and the migration would need a
separate step ordered before the first start. Checked first that a symlink works
at all: a mounted file refuses an atomic rename (`Resource busy`), but OpenCode
writes `auth.json` in place — verified via `opencode auth logout`, contents
rewritten, symlink intact, inode unchanged.

**`XDG_DATA_HOME` was rejected**, not overlooked. It works — OpenCode honours it —
but relocates the whole data directory, putting ~185 MB of database, snapshots
and logs into the directory users mirror between machines.

**Refusal aborts the start.** Consistent with `image-incompatible` and
`host-provisioning-failed`, which already do. A start that succeeds with OpenCode
silently logged out hides its own cause.

## What review caught

Three rounds, each finding a regression in the previous fix rather than in the
original build:

1. **A second conflict destroyed the first set-aside.** `mv` onto a fixed
   `.pre-migration` replaces an existing one, so a restore that reintroduced an
   older volume silently overwrote the credential the conflict path exists to
   preserve. Now the lowest unused numbered suffix, with `mv -n`.
2. **A non-canonical volume symlink logged the user out silently**, and a
   config-root symlink let `chmod` change a file outside Djinn's tree from 0644
   to 0600. Both refused now.
3. **The refusal then broke `clean volumes --credentials`** — it empties the
   config-root directory while the volume keeps its links, so every link dangles
   and the next start aborted. The command this issue enabled made the container
   unstartable.
4. **The fix for that was still inconsistent**: `-ef` decided by inode while the
   target existed, raw text once it was gone, so a relative canonical link was
   valid before a clean and refused after. Both branches now use one lexical
   definition.

## Verification

Every arrangement measured before and after a credentials clean, verdicts
identical in each row:

| Arrangement | before | after |
|---|---|---|
| absolute canonical | accepted | accepted |
| relative canonical | accepted | accepted |
| aliased directory | refused | refused |
| external hard link | refused | refused |

Also verified: the four original states unchanged; external files untouched in
content and mode on every refusal; the post-clean test fails against the previous
condition; no credential content in any output.

`ruff check` clean · `pyright src` 0 errors · **693 tests** · `zsh -n` clean.

## Deliberately stricter than before

A link through an aliased directory and a link to a hard link of the credential
were accepted by `-ef` and are now refused. Both are redirects this design does
not manage; refusing them on every start beats tolerating them until the first
cleanup and blocking then.