### PR TITLE
chore(agents): bump the four CLI agent versions to current

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -80,10 +80,10 @@ ENV PATH="/home/${USERNAME}/.local/bin:/home/${USERNAME}/.local/share/fnm:$PATH"
 RUN eval "$(fnm env)" && fnm install --lts && fnm default lts-latest
 
 # CLI Agent versions - update with: ./scripts/update-agents.sh
-ARG CLAUDE_CODE_VERSION=2.1.114
-ARG GEMINI_CLI_VERSION=0.38.2
-ARG CODEX_VERSION=0.121.0
-ARG OPENCODE_VERSION=1.4.12
+ARG CLAUDE_CODE_VERSION=2.1.220
+ARG GEMINI_CLI_VERSION=0.53.0
+ARG CODEX_VERSION=0.146.0
+ARG OPENCODE_VERSION=1.18.9
 
 # Claude Code via native installer (no npm/Node.js dependency)
 # Installs to ~/.local/bin/claude (already in PATH via .zshrc)


### PR DESCRIPTION
## Why

The rollout of yesterday's hardening chain did not take effect. `djinn build`
builds from the production instance (`com.docker.compose.project.working_dir`
proves it), and that checkout still sits on `d554d8e` — 29 commits behind. The
build could only be a full cache hit, so the running container is still the
image from 2026-07-29 08:46 without `scripts/opencode-credentials.sh`.

Pulling there is blocked: the instance carries the agent-version bump as an
**uncommitted** local edit to `Dockerfile`, and the incoming commits change that
same file. Git refuses the pull rather than discarding the edit — correctly, the
versions are what keeps the image current.

## What

`scripts/update-agents.sh` run against npm today:

| | before | after |
|---|---|---|
| Claude Code | 2.1.114 | 2.1.220 |
| Gemini CLI | 0.38.2 | 0.53.0 |
| Codex | 0.121.0 | 0.146.0 |
| OpenCode | 1.4.12 | 1.18.9 |

The four values are identical to the ones the production instance already ran,
so the rebuilt image keeps its agent versions — this only moves the bump from an
untracked local edit into the checkout.

## Effect

The production instance can discard its local edit and fast-forward, which
unblocks `djinn build` and with it the OpenCode credential migration.

Diff is four `ARG` lines, nothing else. Quality gate local: ruff clean,
`pyright src/` clean, 693 tests pass.