### PR TITLE
feat(mounts): several start mounts with a chosen container path

### DIFF
--- a/IMPLEMENTATION.md
+++ b/IMPLEMENTATION.md
@@ -586,6 +586,27 @@ Docker control.
 - `get_shell_mount_args(config)` mounts `.zshrc`, an explicit Oh My Posh theme,
   and the host shell custom directory unless `shell.skip_mounts` is true
 
+The same module owns the repeatable user-mount contract:
+
+- `ContainerMount` stores a resolved host source, container target, and
+  read-only flag.
+- `parse_mount_spec()` accepts `SRC[:DST[:ro|rw]]`, normalizes absolute targets,
+  and rejects relative targets or invalid modes.
+- `resolve_container_mounts()` resolves every source directory, keeps
+  `--here` at `/home/dev/workspace`, and derives target-free mounts below
+  `/home/dev/mount/<basename>`. A duplicate basename first receives one parent
+  component (`parent-basename`), then a numeric suffix (`-2`, `-3`, ...).
+- `validate_container_mounts()` checks the targets actually occupied by this
+  `dev` invocation, including Compose, image-alias, runtime, Direct-socket, and
+  user mounts. Equal targets and user targets that are ancestors of an occupied
+  target raise `MountCollisionError`; child targets remain valid.
+- `MountSpecificationError` reports invalid mount grammar or reserved targets;
+  `MountCollisionError` reports the two involved mounts and the conflict path.
+
+When a mount exists, `compose_run()` uses the first mount target as
+`--workdir`. With no mount it omits `--workdir`, so the Compose service's
+`working_dir: /home/dev/projects` remains effective.
+
 ## Image Build
 
 `Dockerfile` builds from `debian:bookworm-slim`. It installs base packages,
@@ -615,9 +636,14 @@ backed by named volumes.
 
 - `build()`: loads config, runs `preflight(config)`, refreshes build-time
   local-only files via `_sync_build_files()`, then calls `compose_build()`.
-- `start()`: resolves Docker mode, preflights, ensures `djinn-network`, resolves
-  `--here` or `--mount`, prints the banner plus `Environment` and `Container`
-  rules on stderr, then calls `compose_run()` for `dev`.
+- `start()`: resolves Docker mode, preflights, ensures `djinn-network`, parses
+  repeatable `--mount SRC[:DST[:ro|rw]]` values, and resolves each source with
+  `resolve_container_mounts()`. `--here` is placed first at
+  `/home/dev/workspace`; explicit targets are assigned before derived targets,
+  which use `/home/dev/mount/<basename>` with parent and numeric collision
+  fallbacks. The command rejects source errors and mount collisions before
+  calling `compose_run()`, then prints one source-to-target mode line per mount
+  in the `Environment`/`Container` output.
 - `status()`: reports config, containers, known volumes, config-root paths,
   networks, Docker proxy, and MCP Gateway status.
 - `clean_default()`: `djinn clean` stops and removes containers with
@@ -685,9 +711,13 @@ command string from `AgentConfig`. It appends the prompt template, which expands
 otherwise the command uses `AgentConfig.default_model` when configured.
 
 `run()` loads app config and agent config, validates the requested agent, runs
-the shared workflow preparation for Claude/Codex/OpenCode, ensures the Docker
-network, mounts the current directory by default, and calls
-`compose_run(..., interactive=False, env={"AGENT_PROMPT": prompt})`.
+the shared workflow preparation for Claude/Codex/OpenCode, accepts repeatable
+`--mount SRC[:DST[:ro|rw]]` values, and ensures the Docker network. Without an
+explicit mount it keeps the implicit current-directory mount at
+`/home/dev/workspace`; with explicit mounts it uses their resolved targets and
+the first target as the workdir. It then calls
+`compose_run(..., interactive=False, env={"AGENT_PROMPT": prompt})` and reports
+the complete resolved mount collection before execution.
 
 `agents()` lists configured agents, with verbose and JSON modes.
 

--- a/README.md
+++ b/README.md
@@ -393,7 +393,7 @@ value overrides `default_model` for that invocation.
 
 | Command | Container behavior | Workspace behavior | Main use |
 | --- | --- | --- | --- |
-| `djinn start` | Runs the `dev` service interactively with `docker compose run --rm`; removed after exit | `--here` mounts `/home/dev/workspace`; repeatable `--mount` values add directories at chosen or derived targets | Daily interactive shell |
+| `djinn start` | Runs the `dev` service interactively with `docker compose run --rm`; removed after exit | Starts in `/home/dev/projects` without an extra mount; `--here` mounts `/home/dev/workspace`; repeatable `--mount` values add directories at chosen or derived targets | Daily interactive shell |
 | `djinn enter` | Uses `docker exec -it <running-container> zsh` | Enters an already running Djinn container | Open a second shell while `djinn start` is still running |
 | `djinn run AGENT PROMPT` | Runs the `dev` service headlessly with `docker compose run --rm -T`; removed after exit | Without `--mount`, mounts the current directory at `/home/dev/workspace`; otherwise accepts repeatable `--mount` values | One-shot agent prompts |
 | `djinn session` | Uses `docker exec` into a running `djinn` container when available; otherwise host fallback preflight checks the selected agent binary on `PATH`. Claude, Codex, and OpenCode host fallback receives that agent's canonical workflow at its native host root. Running-container OpenCode sessions refresh the live runtime through the shared publisher before invocation. | Uses `~/.djinn/sessions/<project>` on the host and `/home/dev/sessions/<project>` in the container; `--create` creates the host workspace | Reusable session workspaces |
@@ -478,7 +478,8 @@ Bind mounts are host paths that you can inspect and manage directly:
 Each `--mount SRC[:DST[:ro|rw]]` adds a host directory; without `DST`, Djinn derives
 `/home/dev/mount/<basename>`, and `:ro` makes that mount read-only. The working
 directory is `/home/dev/workspace` with `--here`, otherwise the first mount target;
-`djinn start` without mounts passes no `--workdir` (the image default is `/home/dev`).
+`djinn start` without mounts passes no `--workdir`, so the Compose service default
+`working_dir: /home/dev/projects` applies.
 `djinn run` without `--mount` keeps its implicit `--here` behavior.
 
 Named volumes are Docker-managed and host-local:

--- a/README.md
+++ b/README.md
@@ -395,7 +395,7 @@ value overrides `default_model` for that invocation.
 | --- | --- | --- | --- |
 | `djinn start` | Runs the `dev` service interactively with `docker compose run --rm`; removed after exit | Starts in `/home/dev/projects` without an extra mount; `--here` mounts `/home/dev/workspace`; repeatable `--mount` values add directories at chosen or derived targets | Daily interactive shell |
 | `djinn enter` | Uses `docker exec -it <running-container> zsh` | Enters an already running Djinn container | Open a second shell while `djinn start` is still running |
-| `djinn run AGENT PROMPT` | Runs the `dev` service headlessly with `docker compose run --rm -T`; removed after exit | Without `--mount`, mounts the current directory at `/home/dev/workspace`; otherwise accepts repeatable `--mount` values | One-shot agent prompts |
+| `djinn run AGENT PROMPT` | Runs the `dev` service headlessly with `docker compose run --rm -T`; removed after exit | Without `--mount` and without `--here`, mounts the current directory at `/home/dev/workspace`; `--here` keeps that mount when combined with repeatable `--mount` values | One-shot agent prompts |
 | `djinn session` | Uses `docker exec` into a running `djinn` container when available; otherwise host fallback preflight checks the selected agent binary on `PATH`. Claude, Codex, and OpenCode host fallback receives that agent's canonical workflow at its native host root. Running-container OpenCode sessions refresh the live runtime through the shared publisher before invocation. | Uses `~/.djinn/sessions/<project>` on the host and `/home/dev/sessions/<project>` in the container; `--create` creates the host workspace | Reusable session workspaces |
 
 Common `start` options:
@@ -474,13 +474,15 @@ Bind mounts are host paths that you can inspect and manage directly:
 | `./config` | `/home/dev/.djinn-canonical:ro` | Read-only canonical workflow source for the publisher |
 | `./config/mcp-servers.json` | `/home/dev/.config/mcp-servers.json:ro` | Local MCP registry |
 
-`--here` is the only way to mount the current directory at `/home/dev/workspace`.
-Each `--mount SRC[:DST[:ro|rw]]` adds a host directory; without `DST`, Djinn derives
+`--here` mounts the current directory at `/home/dev/workspace` for both `start` and
+`run`; for `run` it can be combined with any number of `--mount` values. Each
+`--mount SRC[:DST[:ro|rw]]` adds a host directory; without `DST`, Djinn derives
 `/home/dev/mount/<basename>`, and `:ro` makes that mount read-only. The working
 directory is `/home/dev/workspace` with `--here`, otherwise the first mount target;
 `djinn start` without mounts passes no `--workdir`, so the Compose service default
 `working_dir: /home/dev/projects` applies.
-`djinn run` without `--mount` keeps its implicit `--here` behavior.
+`djinn run` without `--mount` and without `--here` keeps its implicit `--here`
+behavior.
 
 Named volumes are Docker-managed and host-local:
 

--- a/README.md
+++ b/README.md
@@ -393,9 +393,9 @@ value overrides `default_model` for that invocation.
 
 | Command | Container behavior | Workspace behavior | Main use |
 | --- | --- | --- | --- |
-| `djinn start` | Runs the `dev` service interactively with `docker compose run --rm`; removed after exit | Starts in `/home/dev/projects`; add `--here` or `--mount PATH` to mount `/home/dev/workspace` and work there | Daily interactive shell |
+| `djinn start` | Runs the `dev` service interactively with `docker compose run --rm`; removed after exit | `--here` mounts `/home/dev/workspace`; repeatable `--mount` values add directories at chosen or derived targets | Daily interactive shell |
 | `djinn enter` | Uses `docker exec -it <running-container> zsh` | Enters an already running Djinn container | Open a second shell while `djinn start` is still running |
-| `djinn run AGENT PROMPT` | Runs the `dev` service headlessly with `docker compose run --rm -T`; removed after exit | Mounts the current directory as `/home/dev/workspace` by default; `--mount PATH` overrides it | One-shot agent prompts |
+| `djinn run AGENT PROMPT` | Runs the `dev` service headlessly with `docker compose run --rm -T`; removed after exit | Without `--mount`, mounts the current directory at `/home/dev/workspace`; otherwise accepts repeatable `--mount` values | One-shot agent prompts |
 | `djinn session` | Uses `docker exec` into a running `djinn` container when available; otherwise host fallback preflight checks the selected agent binary on `PATH`. Claude, Codex, and OpenCode host fallback receives that agent's canonical workflow at its native host root. Running-container OpenCode sessions refresh the live runtime through the shared publisher before invocation. | Uses `~/.djinn/sessions/<project>` on the host and `/home/dev/sessions/<project>` in the container; `--create` creates the host workspace | Reusable session workspaces |
 
 Common `start` options:
@@ -406,7 +406,7 @@ Common `start` options:
 | `--docker-direct` | Adds `docker-compose.docker-direct.yml` and mounts `/var/run/docker.sock` directly into the dev container |
 | `--firewall`, `-f` | Sets `ENABLE_FIREWALL=true`; the entrypoint initializes the network firewall |
 | `--here` | Mounts the current directory as `/home/dev/workspace` and uses it as the working directory |
-| `--mount PATH`, `-m PATH` | Mounts `PATH` as `/home/dev/workspace` and uses it as the working directory |
+| `--mount SRC[:DST[:ro\|rw]]`, `-m …` | Repeatable host-directory mount. Without `DST`, it maps to `/home/dev/mount/<basename>`; append `:ro` for read-only. |
 
 `--docker` and `--docker-direct` are mutually exclusive.
 
@@ -474,8 +474,12 @@ Bind mounts are host paths that you can inspect and manage directly:
 | `./config` | `/home/dev/.djinn-canonical:ro` | Read-only canonical workflow source for the publisher |
 | `./config/mcp-servers.json` | `/home/dev/.config/mcp-servers.json:ro` | Local MCP registry |
 
-When `--here`, `--mount`, or `djinn run` is used, an additional host directory is
-mounted at `/home/dev/workspace`.
+`--here` is the only way to mount the current directory at `/home/dev/workspace`.
+Each `--mount SRC[:DST[:ro|rw]]` adds a host directory; without `DST`, Djinn derives
+`/home/dev/mount/<basename>`, and `:ro` makes that mount read-only. The working
+directory is `/home/dev/workspace` with `--here`, otherwise the first mount target;
+`djinn start` without mounts passes no `--workdir` (the image default is `/home/dev`).
+`djinn run` without `--mount` keeps its implicit `--here` behavior.
 
 Named volumes are Docker-managed and host-local:
 

--- a/docs/headless-cheatsheet.md
+++ b/docs/headless-cheatsheet.md
@@ -95,8 +95,10 @@ djinn run opencode "Plan a cleanup for this module" --model default
 # JSON output for scripting
 djinn run claude "List all TODOs" --model sonnet --json | jq '.result'
 
-# Mount a different workspace directory
-djinn run claude "Analyze this project" --model sonnet --mount ~/other-project
+# Mount two directories; the first target is the workdir and the second is read-only
+djinn run claude "Analyze this project" --model sonnet \
+  --mount ~/other-project:/home/dev/project \
+  --mount ~/reference:/home/dev/reference:ro
 
 # Mount the current working directory implicitly
 djinn run claude "Summarize this repository"
@@ -129,13 +131,19 @@ with the agent's return code.
 | `--model <name>`, `-m <name>` | Model override forwarded to the agent. |
 | `--write`, `-w` | Enable the agent's write/edit mode. |
 | `--json`, `-j` | Request JSON output from the agent. |
-| `--mount <path>` | Mount a workspace directory as `/home/dev/workspace`. Defaults to the current directory. |
+| `--mount SRC[:DST[:ro\|rw]]` | Repeatable host-directory mount. Without `DST`, Djinn derives `/home/dev/mount/<basename>`; append `:ro` for read-only. |
 | `--docker`, `-d` | Enable Docker socket access through the proxy. |
 | `--docker-direct` | Enable direct Docker socket access without the proxy. |
 | `--firewall`, `-f` | Enable the outbound firewall inside the container. |
 | `--timeout <sec>`, `-t <sec>` | Timeout for the headless container run. |
 
 `--docker` and `--docker-direct` are mutually exclusive.
+
+`djinn run` without `--mount` keeps its implicit `--here` behavior: the current
+directory is mounted at `/home/dev/workspace` and is the workdir. With mounts,
+the first mount target is the workdir. For `djinn start`, `--here` is the only
+explicit way to use `/home/dev/workspace`; a target-free mount uses
+`/home/dev/mount/<basename>`.
 
 ---
 

--- a/docs/headless-cheatsheet.md
+++ b/docs/headless-cheatsheet.md
@@ -131,6 +131,7 @@ with the agent's return code.
 | `--model <name>`, `-m <name>` | Model override forwarded to the agent. |
 | `--write`, `-w` | Enable the agent's write/edit mode. |
 | `--json`, `-j` | Request JSON output from the agent. |
+| `--here` | Mount the current directory at `/home/dev/workspace`; repeatable with `--mount`. |
 | `--mount SRC[:DST[:ro\|rw]]` | Repeatable host-directory mount. Without `DST`, Djinn derives `/home/dev/mount/<basename>`; append `:ro` for read-only. |
 | `--docker`, `-d` | Enable Docker socket access through the proxy. |
 | `--docker-direct` | Enable direct Docker socket access without the proxy. |
@@ -139,11 +140,11 @@ with the agent's return code.
 
 `--docker` and `--docker-direct` are mutually exclusive.
 
-`djinn run` without `--mount` keeps its implicit `--here` behavior: the current
-directory is mounted at `/home/dev/workspace` and is the workdir. With mounts,
-the first mount target is the workdir. For `djinn start`, `--here` is the only
-explicit way to use `/home/dev/workspace`; a target-free mount uses
-`/home/dev/mount/<basename>`.
+`djinn run` without `--mount` and without `--here` keeps its implicit `--here`
+behavior: the current directory is mounted at `/home/dev/workspace` and is the
+workdir. `--here` can be combined with repeatable mounts; the workspace remains
+the first mount and therefore the workdir. Without `--here`, the first explicit
+mount target is the workdir. A target-free mount uses `/home/dev/mount/<basename>`.
 
 ---
 

--- a/src/djinn_in_a_box/commands/agent.py
+++ b/src/djinn_in_a_box/commands/agent.py
@@ -32,10 +32,12 @@ from djinn_in_a_box.core.console import (
 )
 from djinn_in_a_box.core.decorators import handle_config_errors
 from djinn_in_a_box.core.docker import (
+    ContainerMount,
     DockerMode,
     MountCollisionError,
     MountSpecificationError,
     get_config_root,
+    resolve_container_mounts,
     resolve_docker_mode,
     workflow_image_compatible,
 )
@@ -53,7 +55,7 @@ def _agent_table(title: str) -> Table:
 
 def _show_run_status(
     agent: str,
-    workspace: Path,
+    mounts: tuple[ContainerMount, ...],
     *,
     write: bool,
     json_output: bool,
@@ -68,7 +70,20 @@ def _show_run_status(
     err_console.print()
 
     status_line("Agent", agent)
-    status_line("Workspace", str(workspace))
+    for mount in mounts:
+        mode = "ro" if mount.read_only else "rw"
+        status_line(
+            "Mount",
+            f"{mount.source} -> {mount.target} ({mode})",
+            value_style="path",
+        )
+
+    workspace = next(
+        (mount.source for mount in mounts if mount.target == Path("/home/dev/workspace")),
+        None,
+    )
+    if workspace is not None:
+        status_line("Workspace", str(workspace), value_style="path")
 
     if model:
         status_line("Model", model)
@@ -191,6 +206,12 @@ def run(
         raise typer.Exit(1)
 
     try:
+        resolved_mounts = resolve_container_mounts(tuple(mount or ()), here=not mount)
+    except (MountSpecificationError, FileNotFoundError, NotADirectoryError) as e:
+        error(str(e))
+        raise typer.Exit(1) from None
+
+    try:
         result = run_headless_agent(
             agent,
             prompt,
@@ -200,11 +221,12 @@ def run(
             docker_mode=docker_mode,
             firewall=firewall,
             mounts=tuple(mount or ()),
+            resolved_mounts=resolved_mounts,
             timeout=timeout,
             app_config=checked_config,
-            on_ready=lambda workspace: _show_run_status(
+            on_ready=lambda mounts: _show_run_status(
                 agent,
-                workspace,
+                mounts,
                 write=write,
                 json_output=json_output,
                 model=model,
@@ -220,12 +242,7 @@ def run(
     except AgentNetworkError as e:
         error(str(e))
         raise typer.Exit(1) from None
-    except (
-        MountSpecificationError,
-        MountCollisionError,
-        FileNotFoundError,
-        NotADirectoryError,
-    ) as e:
+    except MountCollisionError as e:
         error(str(e))
         raise typer.Exit(1) from None
 

--- a/src/djinn_in_a_box/commands/agent.py
+++ b/src/djinn_in_a_box/commands/agent.py
@@ -33,6 +33,8 @@ from djinn_in_a_box.core.console import (
 from djinn_in_a_box.core.decorators import handle_config_errors
 from djinn_in_a_box.core.docker import (
     DockerMode,
+    MountCollisionError,
+    MountSpecificationError,
     get_config_root,
     resolve_docker_mode,
     workflow_image_compatible,
@@ -125,14 +127,10 @@ def run(
         typer.Option("--firewall", "-f", help="Enable network firewall"),
     ] = False,
     mount: Annotated[
-        Path | None,
+        list[str] | None,
         typer.Option(
             "--mount",
-            help="Workspace path to mount (default: current directory)",
-            exists=True,
-            file_okay=False,
-            dir_okay=True,
-            resolve_path=True,
+            help="Host directory to mount; repeatable: SRC[:DST[:ro|rw]]",
         ),
     ] = None,
     timeout: Annotated[
@@ -147,8 +145,8 @@ def run(
     to stderr to keep stdout clean for agent output.
 
     By default, the current working directory is mounted as ~/workspace
-    in the container (implicit --here behavior). Use --mount to specify
-    a different directory.
+    in the container (implicit --here behavior). Use repeatable --mount
+    values to mount one or more different directories.
 
     Examples:
 
@@ -201,7 +199,7 @@ def run(
             model=model,
             docker_mode=docker_mode,
             firewall=firewall,
-            mount=mount,
+            mounts=tuple(mount or ()),
             timeout=timeout,
             app_config=checked_config,
             on_ready=lambda workspace: _show_run_status(
@@ -220,6 +218,14 @@ def run(
         console.print(f"Available agents: {', '.join(e.available)}")
         raise typer.Exit(1) from None
     except AgentNetworkError as e:
+        error(str(e))
+        raise typer.Exit(1) from None
+    except (
+        MountSpecificationError,
+        MountCollisionError,
+        FileNotFoundError,
+        NotADirectoryError,
+    ) as e:
         error(str(e))
         raise typer.Exit(1) from None
 

--- a/src/djinn_in_a_box/commands/agent.py
+++ b/src/djinn_in_a_box/commands/agent.py
@@ -141,6 +141,10 @@ def run(
         bool,
         typer.Option("--firewall", "-f", help="Enable network firewall"),
     ] = False,
+    here: Annotated[
+        bool,
+        typer.Option("--here", help="Mount current directory as ~/workspace"),
+    ] = False,
     mount: Annotated[
         list[str] | None,
         typer.Option(
@@ -160,8 +164,8 @@ def run(
     to stderr to keep stdout clean for agent output.
 
     By default, the current working directory is mounted as ~/workspace
-    in the container (implicit --here behavior). Use repeatable --mount
-    values to mount one or more different directories.
+    in the container (implicit --here behavior). Use --here to request that
+    workspace explicitly alongside repeatable --mount values.
 
     Examples:
 
@@ -176,6 +180,10 @@ def run(
 
         # With Docker access and timeout
         djinn run claude "Build the Docker image" --docker --timeout 300
+
+        # Mount the current directory and two additional directories
+        djinn run claude "Compare these projects" --here \
+            --mount ~/other-project --mount ~/reference:/home/dev/reference:ro
     """
     try:
         docker_mode = resolve_docker_mode(docker, docker_direct)
@@ -206,7 +214,9 @@ def run(
         raise typer.Exit(1)
 
     try:
-        resolved_mounts = resolve_container_mounts(tuple(mount or ()), here=not mount)
+        resolved_mounts = resolve_container_mounts(
+            tuple(mount or ()), here=here or not mount
+        )
     except (MountSpecificationError, FileNotFoundError, NotADirectoryError) as e:
         error(str(e))
         raise typer.Exit(1) from None
@@ -220,7 +230,6 @@ def run(
             model=model,
             docker_mode=docker_mode,
             firewall=firewall,
-            mounts=tuple(mount or ()),
             resolved_mounts=resolved_mounts,
             timeout=timeout,
             app_config=checked_config,
@@ -242,7 +251,7 @@ def run(
     except AgentNetworkError as e:
         error(str(e))
         raise typer.Exit(1) from None
-    except MountCollisionError as e:
+    except (MountCollisionError, MountSpecificationError) as e:
         error(str(e))
         raise typer.Exit(1) from None
 

--- a/src/djinn_in_a_box/commands/agent.py
+++ b/src/djinn_in_a_box/commands/agent.py
@@ -35,11 +35,14 @@ from djinn_in_a_box.core.docker import (
     ContainerMount,
     DockerMode,
     MountCollisionError,
-    MountSpecificationError,
     get_config_root,
     resolve_container_mounts,
     resolve_docker_mode,
     workflow_image_compatible,
+)
+from djinn_in_a_box.core.exceptions import (
+    MountSpecificationError,
+    RuntimeMountSpecificationError,
 )
 from djinn_in_a_box.core.paths import get_project_root
 
@@ -182,7 +185,7 @@ def run(
         djinn run claude "Build the Docker image" --docker --timeout 300
 
         # Mount the current directory and two additional directories
-        djinn run claude "Compare these projects" --here \
+        djinn run claude "Compare these projects" --here \\
             --mount ~/other-project --mount ~/reference:/home/dev/reference:ro
     """
     try:
@@ -250,6 +253,9 @@ def run(
         raise typer.Exit(1) from None
     except AgentNetworkError as e:
         error(str(e))
+        raise typer.Exit(1) from None
+    except RuntimeMountSpecificationError as e:
+        error(f"Internal runtime mount construction failed: {e}")
         raise typer.Exit(1) from None
     except (MountCollisionError, MountSpecificationError) as e:
         error(str(e))

--- a/src/djinn_in_a_box/commands/container.py
+++ b/src/djinn_in_a_box/commands/container.py
@@ -34,6 +34,8 @@ from djinn_in_a_box.core.decorators import handle_config_errors
 from djinn_in_a_box.core.docker import (
     DJINN_NETWORK,
     ContainerOptions,
+    MountCollisionError,
+    MountSpecificationError,
     cleanup_docker_proxy,
     clear_sync_path,
     compose_build,
@@ -51,11 +53,12 @@ from djinn_in_a_box.core.docker import (
     get_shell_mount_args,
     is_container_running,
     network_exists,
+    resolve_container_mounts,
     resolve_docker_mode,
     volume_exists,
 )
 from djinn_in_a_box.core.exceptions import ConfigNotFoundError, ConfigValidationError
-from djinn_in_a_box.core.paths import get_project_root, resolve_mount_path
+from djinn_in_a_box.core.paths import get_project_root
 
 
 def _sync_build_files(config: AppConfig | None = None) -> None:
@@ -128,8 +131,12 @@ def start(
         typer.Option("--here", help="Mount current directory as ~/workspace"),
     ] = False,
     mount: Annotated[
-        Path | None,
-        typer.Option("--mount", "-m", help="Mount specified path as ~/workspace"),
+        list[str] | None,
+        typer.Option(
+            "--mount",
+            "-m",
+            help="Host directory to mount; repeatable: SRC[:DST[:ro|rw]]",
+        ),
     ] = None,
 ) -> None:
     """Start interactive development shell.
@@ -174,16 +181,11 @@ def start(
         error(f"Failed to create Docker network '{DJINN_NETWORK}'")
         raise typer.Exit(1)
 
-    # Resolve mount path
-    mount_path: Path | None = None
-    if here:
-        mount_path = Path.cwd()
-    elif mount:
-        try:
-            mount_path = resolve_mount_path(mount)
-        except (FileNotFoundError, NotADirectoryError) as e:
-            error(str(e))
-            raise typer.Exit(1) from None
+    try:
+        mounts = resolve_container_mounts(tuple(mount or ()), here=here)
+    except (MountSpecificationError, FileNotFoundError, NotADirectoryError) as e:
+        error(str(e))
+        raise typer.Exit(1) from None
 
     # Print status output (to stderr, matching Bash format)
     banner()
@@ -203,8 +205,13 @@ def start(
     else:
         status_line("Firewall", "Disabled (use --firewall to enable)", "status.disabled")
 
-    if mount_path:
-        status_line("Workspace", str(mount_path), "status.enabled", value_style="path")
+    for resolved_mount in mounts:
+        mode = "ro" if resolved_mount.read_only else "rw"
+        status_line(
+            "Mount",
+            f"{resolved_mount.source} -> {resolved_mount.target} ({mode})",
+            value_style="path",
+        )
 
     # Shell mount status
     shell_args = get_shell_mount_args(config)
@@ -237,11 +244,14 @@ def start(
     options = ContainerOptions(
         docker_mode=docker_mode,
         firewall_enabled=firewall,
-        mount_path=mount_path,
+        mounts=mounts,
     )
 
     try:
         result = compose_run(config, options, interactive=True)
+    except MountCollisionError as e:
+        error(str(e))
+        raise typer.Exit(1) from None
     finally:
         cleanup_docker_proxy(docker_mode, config)
 

--- a/src/djinn_in_a_box/commands/container.py
+++ b/src/djinn_in_a_box/commands/container.py
@@ -248,7 +248,13 @@ def start(
     )
 
     try:
-        result = compose_run(config, options, interactive=True)
+        result = compose_run(
+            config,
+            options,
+            interactive=True,
+            shell_mount_args=shell_args,
+            audio_mount_args=audio_args,
+        )
     except MountCollisionError as e:
         error(str(e))
         raise typer.Exit(1) from None

--- a/src/djinn_in_a_box/commands/container.py
+++ b/src/djinn_in_a_box/commands/container.py
@@ -35,7 +35,6 @@ from djinn_in_a_box.core.docker import (
     DJINN_NETWORK,
     ContainerOptions,
     MountCollisionError,
-    MountSpecificationError,
     cleanup_docker_proxy,
     clear_sync_path,
     compose_build,
@@ -58,7 +57,12 @@ from djinn_in_a_box.core.docker import (
     resolve_docker_mode,
     volume_exists,
 )
-from djinn_in_a_box.core.exceptions import ConfigNotFoundError, ConfigValidationError
+from djinn_in_a_box.core.exceptions import (
+    ConfigNotFoundError,
+    ConfigValidationError,
+    MountSpecificationError,
+    RuntimeMountSpecificationError,
+)
 from djinn_in_a_box.core.paths import get_project_root
 
 
@@ -261,8 +265,14 @@ def start(
     except (MountCollisionError, MountSpecificationError) as e:
         error(str(e))
         raise typer.Exit(1) from None
+    except RuntimeMountSpecificationError as e:
+        error(f"Internal runtime mount construction failed: {e}")
+        raise typer.Exit(1) from None
     finally:
         cleanup_docker_proxy(docker_mode, config)
+
+    if result.stderr:
+        err_console.print(result.stderr, end="")
 
     raise typer.Exit(result.returncode)
 

--- a/src/djinn_in_a_box/commands/container.py
+++ b/src/djinn_in_a_box/commands/container.py
@@ -47,6 +47,7 @@ from djinn_in_a_box.core.docker import (
     ensure_network,
     get_audio_mount_args,
     get_config_root,
+    get_dbus_mount_args,
     get_existing_sync_paths_by_category,
     get_existing_volumes_by_category,
     get_running_containers,
@@ -224,6 +225,7 @@ def start(
 
     # Audio passthrough status
     audio_args = get_audio_mount_args()
+    dbus_args = get_dbus_mount_args()
     if audio_args:
         status_line("Audio", "PulseAudio forwarding enabled", "status.enabled")
     else:
@@ -254,8 +256,9 @@ def start(
             interactive=True,
             shell_mount_args=shell_args,
             audio_mount_args=audio_args,
+            dbus_mount_args=dbus_args,
         )
-    except MountCollisionError as e:
+    except (MountCollisionError, MountSpecificationError) as e:
         error(str(e))
         raise typer.Exit(1) from None
     finally:

--- a/src/djinn_in_a_box/core/agent_runner.py
+++ b/src/djinn_in_a_box/core/agent_runner.py
@@ -16,6 +16,7 @@ from djinn_in_a_box.core.docker import (
     cleanup_docker_proxy,
     compose_run,
     ensure_network,
+    resolve_container_mounts,
 )
 
 
@@ -69,7 +70,7 @@ def run_headless_agent(
     model: str | None = None,
     docker_mode: DockerMode = DockerMode.NONE,
     firewall: bool = False,
-    mount: Path | None = None,
+    mounts: tuple[str, ...] = (),
     timeout: int | None = None,
     on_ready: Callable[[Path], None] | None = None,
     app_config: AppConfig | None = None,
@@ -82,10 +83,11 @@ def run_headless_agent(
     except KeyError:
         raise UnknownAgentError(agent, tuple(sorted(agent_configs))) from None
 
+    container_mounts = resolve_container_mounts(mounts, here=not mounts)
     if not ensure_network():
         raise AgentNetworkError
 
-    workspace = mount if mount is not None else Path.cwd()
+    workspace = container_mounts[0].source
     if on_ready is not None:
         on_ready(workspace)
 
@@ -98,7 +100,7 @@ def run_headless_agent(
     options = ContainerOptions(
         docker_mode=docker_mode,
         firewall_enabled=firewall,
-        mount_path=workspace,
+        mounts=container_mounts,
     )
 
     try:

--- a/src/djinn_in_a_box/core/agent_runner.py
+++ b/src/djinn_in_a_box/core/agent_runner.py
@@ -4,12 +4,12 @@ from __future__ import annotations
 
 import shlex
 from collections.abc import Callable
-from pathlib import Path
 
 from djinn_in_a_box.config.loader import load_agents, load_config
 from djinn_in_a_box.config.models import AgentConfig, AppConfig
 from djinn_in_a_box.core.docker import (
     DJINN_NETWORK,
+    ContainerMount,
     ContainerOptions,
     DockerMode,
     RunResult,
@@ -71,8 +71,9 @@ def run_headless_agent(
     docker_mode: DockerMode = DockerMode.NONE,
     firewall: bool = False,
     mounts: tuple[str, ...] = (),
+    resolved_mounts: tuple[ContainerMount, ...] | None = None,
     timeout: int | None = None,
-    on_ready: Callable[[Path], None] | None = None,
+    on_ready: Callable[[tuple[ContainerMount, ...]], None] | None = None,
     app_config: AppConfig | None = None,
 ) -> RunResult:
     """Run one configured agent without invoking workflow bootstrap or UI code."""
@@ -83,13 +84,16 @@ def run_headless_agent(
     except KeyError:
         raise UnknownAgentError(agent, tuple(sorted(agent_configs))) from None
 
-    container_mounts = resolve_container_mounts(mounts, here=not mounts)
+    container_mounts = (
+        resolved_mounts
+        if resolved_mounts is not None
+        else resolve_container_mounts(mounts, here=not mounts)
+    )
     if not ensure_network():
         raise AgentNetworkError
 
-    workspace = container_mounts[0].source
     if on_ready is not None:
-        on_ready(workspace)
+        on_ready(container_mounts)
 
     agent_command = build_agent_command(
         agent_config,

--- a/src/djinn_in_a_box/core/agent_runner.py
+++ b/src/djinn_in_a_box/core/agent_runner.py
@@ -16,7 +16,6 @@ from djinn_in_a_box.core.docker import (
     cleanup_docker_proxy,
     compose_run,
     ensure_network,
-    resolve_container_mounts,
 )
 
 
@@ -70,8 +69,7 @@ def run_headless_agent(
     model: str | None = None,
     docker_mode: DockerMode = DockerMode.NONE,
     firewall: bool = False,
-    mounts: tuple[str, ...] = (),
-    resolved_mounts: tuple[ContainerMount, ...] | None = None,
+    resolved_mounts: tuple[ContainerMount, ...],
     timeout: int | None = None,
     on_ready: Callable[[tuple[ContainerMount, ...]], None] | None = None,
     app_config: AppConfig | None = None,
@@ -84,16 +82,11 @@ def run_headless_agent(
     except KeyError:
         raise UnknownAgentError(agent, tuple(sorted(agent_configs))) from None
 
-    container_mounts = (
-        resolved_mounts
-        if resolved_mounts is not None
-        else resolve_container_mounts(mounts, here=not mounts)
-    )
     if not ensure_network():
         raise AgentNetworkError
 
     if on_ready is not None:
-        on_ready(container_mounts)
+        on_ready(resolved_mounts)
 
     agent_command = build_agent_command(
         agent_config,
@@ -104,7 +97,7 @@ def run_headless_agent(
     options = ContainerOptions(
         docker_mode=docker_mode,
         firewall_enabled=firewall,
-        mounts=container_mounts,
+        mounts=resolved_mounts,
     )
 
     try:

--- a/src/djinn_in_a_box/core/docker.py
+++ b/src/djinn_in_a_box/core/docker.py
@@ -34,6 +34,7 @@ _WORKFLOW_PUBLISHER_LABEL = "djinn.workflow.publisher"
 _WORKFLOW_IMAGE_INSPECT_TIMEOUT = 10.0
 _MOUNT_ROOT = Path("/home/dev/mount")
 _WORKSPACE_PATH = Path("/home/dev/workspace")
+_FORBIDDEN_MOUNT_TARGET_ROOTS = (Path("/proc"), Path("/sys"), Path("/dev"))
 _IMAGE_SYMLINK_MOUNT_TARGETS = (
     Path("/home/dev/.config/claude"),
 )
@@ -138,6 +139,12 @@ def parse_mount_spec(specification: str) -> tuple[str, Path | None, bool]:
             target = Path(normalized_target)
             if not target.is_absolute():
                 msg = f"Mount target must be an absolute container path: {target_or_mode!r}"
+                raise MountSpecificationError(msg)
+            if any(
+                target == root or target.is_relative_to(root)
+                for root in _FORBIDDEN_MOUNT_TARGET_ROOTS
+            ):
+                msg = f"Mount target {target} is not allowed under /proc, /sys, or /dev"
                 raise MountSpecificationError(msg)
 
     if len(fields) == 3:
@@ -467,14 +474,16 @@ def _mount_targets_from_args(args: list[str]) -> list[Path]:
         argument = args[index]
         if argument in {"-v", "--volume"}:
             if index + 1 == len(args):
-                raise ValueError(f"Volume flag {argument!r} requires a specification")
+                raise MountSpecificationError(
+                    f"Volume flag {argument!r} requires a specification"
+                )
             specification = args[index + 1]
             index += 2
         elif argument.startswith("--volume="):
             specification = argument.split("=", 1)[1]
             index += 1
         elif argument.startswith("--volume") or argument.startswith("--mount"):
-            raise ValueError(f"Unknown volume flag {argument!r}")
+            raise MountSpecificationError(f"Unknown volume flag {argument!r}")
         else:
             index += 1
             continue

--- a/src/djinn_in_a_box/core/docker.py
+++ b/src/djinn_in_a_box/core/docker.py
@@ -16,7 +16,7 @@ if TYPE_CHECKING:
 
 from djinn_in_a_box.config.defaults import SYNC_PATHS, VOLUME_CATEGORIES
 from djinn_in_a_box.core.console import warning
-from djinn_in_a_box.core.paths import get_project_root
+from djinn_in_a_box.core.paths import get_project_root, resolve_mount_path
 from djinn_in_a_box.core.seeding import workflow_root_is_uninitialized
 
 DJINN_NETWORK: str = "djinn-network"
@@ -31,6 +31,37 @@ _SERVICE_CONTAINER_NAMES: dict[str, str] = {
 _WORKFLOW_IMAGE = "djinn-in-a-box:latest"
 _WORKFLOW_PUBLISHER_LABEL = "djinn.workflow.publisher"
 _WORKFLOW_IMAGE_INSPECT_TIMEOUT = 10.0
+_MOUNT_ROOT = Path("/home/dev/mount")
+_WORKSPACE_PATH = Path("/home/dev/workspace")
+_COMPOSE_DEV_MOUNT_TARGETS = (
+    Path("/home/dev/.claude"),
+    Path("/home/dev/.gemini"),
+    Path("/home/dev/.codex"),
+    Path("/home/dev/.opencode"),
+    Path("/home/dev/.local/share/opencode"),
+    Path("/home/dev/.config/gh"),
+    Path("/home/dev/.config/age"),
+    Path("/home/dev/.cache/uv"),
+    Path("/home/dev/.cache/djinn-tools"),
+    Path("/home/dev/.vscode-server"),
+    Path("/home/dev/workspaces"),
+    Path("/home/dev/.ssh"),
+    Path("/home/dev/.gitconfig"),
+    Path("/home/dev/.claude_seed"),
+    Path("/home/dev/.claude/skills"),
+    Path("/home/dev/.claude/commands"),
+    Path("/home/dev/.claude/agents"),
+    Path("/home/dev/.claude/context"),
+    Path("/home/dev/.claude/scripts"),
+    Path("/home/dev/.claude/CLAUDE.md"),
+    Path("/home/dev/.claude/AGENTS.md"),
+    Path("/home/dev/.gemini_seed"),
+    Path("/home/dev/.opencode/seed"),
+    Path("/home/dev/.djinn-canonical"),
+    Path("/home/dev/.config/mcp-servers.json"),
+    Path("/home/dev/projects"),
+    Path("/home/dev/sessions"),
+)
 
 
 class DockerMode(Enum):
@@ -60,6 +91,122 @@ def resolve_docker_mode(docker: bool, docker_direct: bool) -> DockerMode:
 
 
 @dataclass(frozen=True, slots=True)
+class ContainerMount:
+    """A host directory mounted at a container destination."""
+
+    source: Path
+    target: Path
+    read_only: bool = False
+
+
+class MountSpecificationError(ValueError):
+    """Raised when a ``--mount`` value does not match Djinn's mount grammar."""
+
+
+class MountCollisionError(ValueError):
+    """Raised when a user mount would hide another container mount."""
+
+
+def parse_mount_spec(specification: str) -> tuple[str, Path | None, bool]:
+    """Parse ``SRC[:DST[:ro|rw]]`` into source, optional target, and mode."""
+    fields = specification.split(":")
+    if not 1 <= len(fields) <= 3:
+        msg = f"Invalid mount specification {specification!r}: expected SRC[:DST[:ro|rw]]"
+        raise MountSpecificationError(msg)
+
+    source = fields[0]
+    if not source:
+        msg = "Invalid mount specification: source path must not be empty"
+        raise MountSpecificationError(msg)
+
+    target: Path | None = None
+    read_only = False
+    if len(fields) >= 2:
+        target_or_mode = fields[1]
+        if target_or_mode in {"ro", "rw"}:
+            read_only = target_or_mode == "ro"
+        else:
+            target = Path(os.path.normpath(target_or_mode))
+            if not target.is_absolute():
+                msg = f"Mount target must be an absolute container path: {target_or_mode!r}"
+                raise MountSpecificationError(msg)
+
+    if len(fields) == 3:
+        if target is None:
+            msg = "Mount target must be an absolute container path when a mode is provided"
+            raise MountSpecificationError(msg)
+        mode = fields[2]
+        if mode not in {"ro", "rw"}:
+            msg = f"Invalid mount mode {mode!r}: expected 'ro' or 'rw'"
+            raise MountSpecificationError(msg)
+        read_only = mode == "ro"
+
+    return source, target, read_only
+
+
+def _derived_mount_target(source: Path, assigned_targets: set[Path]) -> Path:
+    """Choose a stable child of ``/home/dev/mount`` for a target-free mount."""
+    basename = source.name
+    candidate_name = basename
+    candidate = _MOUNT_ROOT / candidate_name
+
+    if not basename or candidate in assigned_targets:
+        parent_name = source.parent.name
+        if parent_name:
+            candidate_name = f"{parent_name}-{basename}" if basename else parent_name
+        elif basename:
+            candidate_name = basename
+        else:
+            candidate_name = "root"
+        candidate = _MOUNT_ROOT / candidate_name
+
+    suffix = 2
+    while candidate in assigned_targets:
+        candidate = _MOUNT_ROOT / f"{candidate_name}-{suffix}"
+        suffix += 1
+
+    return candidate
+
+
+def resolve_container_mounts(
+    specifications: tuple[str, ...], *, here: bool = False
+) -> tuple[ContainerMount, ...]:
+    """Resolve sources and assign targets for one start or headless-run invocation."""
+    parsed = [parse_mount_spec(specification) for specification in specifications]
+    if any(target == _WORKSPACE_PATH for _, target, _ in parsed):
+        msg = f"Mount target {_WORKSPACE_PATH} is reserved for --here"
+        raise MountSpecificationError(msg)
+    source_mounts = [
+        (resolve_mount_path(source), target, read_only)
+        for source, target, read_only in parsed
+    ]
+
+    mounts: list[ContainerMount] = []
+    if here:
+        mounts.append(
+            ContainerMount(
+                source=resolve_mount_path(Path.cwd()),
+                target=_WORKSPACE_PATH,
+            )
+        )
+
+    assigned_targets = {target for _, target, _ in source_mounts if target is not None}
+    if here:
+        assigned_targets.add(_WORKSPACE_PATH)
+
+    for source, target, read_only in source_mounts:
+        resolved_target = target
+        if resolved_target is None:
+            resolved_target = _derived_mount_target(source, assigned_targets)
+        assigned_targets.add(resolved_target)
+        mounts.append(
+            ContainerMount(source=source, target=resolved_target, read_only=read_only)
+        )
+
+    return tuple(mounts)
+
+
+@dataclass(frozen=True, slots=True)
 class ContainerOptions:
     """Options for container execution (Docker access, firewall, mounts)."""
 
@@ -69,8 +216,8 @@ class ContainerOptions:
     firewall_enabled: bool = False
     """Enable network firewall (restricts outbound traffic)."""
 
-    mount_path: Path | None = None
-    """Additional workspace mount path (maps to ~/workspace in container)."""
+    mounts: tuple[ContainerMount, ...] = ()
+    """Additional host-directory mounts for this container execution."""
 
 
 @dataclass(frozen=True, slots=True)
@@ -303,6 +450,52 @@ def get_dbus_mount_args() -> list[str]:
     ]
 
 
+def _mount_targets_from_args(args: list[str]) -> list[Path]:
+    """Extract container targets from the ``-v`` arguments built in this module."""
+    targets: list[Path] = []
+    for index, argument in enumerate(args):
+        if argument != "-v" or index + 1 == len(args):
+            continue
+        specification = args[index + 1]
+        parts = specification.rsplit(":", 2)
+        target = parts[-2] if parts[-1] in {"ro", "rw"} else parts[-1]
+        targets.append(Path(target))
+    return targets
+
+
+def _reserved_mount_targets(config: AppConfig, docker_mode: DockerMode) -> list[Path]:
+    """Return targets occupied by this particular ``dev`` container invocation."""
+    targets = [*_COMPOSE_DEV_MOUNT_TARGETS, _MOUNT_ROOT]
+    targets.extend(_mount_targets_from_args(get_shell_mount_args(config)))
+    targets.extend(_mount_targets_from_args(get_audio_mount_args()))
+    targets.extend(_mount_targets_from_args(get_dbus_mount_args()))
+    if docker_mode is DockerMode.DIRECT:
+        targets.append(Path("/var/run/docker.sock"))
+    return targets
+
+
+def validate_container_mounts(
+    mounts: tuple[ContainerMount, ...],
+    config: AppConfig,
+    docker_mode: DockerMode,
+) -> None:
+    """Reject user targets that equal or are ancestors of an occupied target."""
+    occupied: list[tuple[Path, str]] = [
+        (target, f"reserved mount at {target}")
+        for target in _reserved_mount_targets(config, docker_mode)
+    ]
+
+    for mount in mounts:
+        for target, description in occupied:
+            if mount.target == target or target.is_relative_to(mount.target):
+                msg = (
+                    f"Mount {mount.source} -> {mount.target} conflicts with {description} "
+                    f"(conflict path: {target})"
+                )
+                raise MountCollisionError(msg)
+        occupied.append((mount.target, f"mount {mount.source} -> {mount.target}"))
+
+
 def compose_build(config: AppConfig | None = None, *, no_cache: bool = False) -> RunResult:
     project_root = get_project_root()
     args = ["build"]
@@ -356,11 +549,17 @@ def compose_run(
     for key, value in env_vars.items():
         cmd.extend(["-e", f"{key}={value}"])
 
-    # Workspace mount
-    if options.mount_path is not None:
-        mount_str = f"{options.mount_path}:/home/dev/workspace"
+    validate_container_mounts(options.mounts, config, options.docker_mode)
+
+    for mount in options.mounts:
+        mount_str = f"{mount.source}:{mount.target}"
+        if mount.read_only:
+            mount_str += ":ro"
         cmd.extend(["-v", mount_str])
-        cmd.extend(["--workdir", "/home/dev/workspace"])
+
+    if options.mounts:
+        workdir = options.mounts[0].target
+        cmd.extend(["--workdir", str(workdir)])
 
     # Shell mounts (skip_mounts check is inside get_shell_mount_args)
     cmd.extend(get_shell_mount_args(config))

--- a/src/djinn_in_a_box/core/docker.py
+++ b/src/djinn_in_a_box/core/docker.py
@@ -17,6 +17,10 @@ if TYPE_CHECKING:
 
 from djinn_in_a_box.config.defaults import SYNC_PATHS, VOLUME_CATEGORIES
 from djinn_in_a_box.core.console import warning
+from djinn_in_a_box.core.exceptions import (
+    MountSpecificationError,
+    RuntimeMountSpecificationError,
+)
 from djinn_in_a_box.core.paths import get_project_root, resolve_mount_path
 from djinn_in_a_box.core.seeding import workflow_root_is_uninitialized
 
@@ -35,13 +39,11 @@ _WORKFLOW_IMAGE_INSPECT_TIMEOUT = 10.0
 _MOUNT_ROOT = Path("/home/dev/mount")
 _WORKSPACE_PATH = Path("/home/dev/workspace")
 _FORBIDDEN_MOUNT_TARGET_ROOTS = (Path("/proc"), Path("/sys"), Path("/dev"))
-_IMAGE_SYMLINK_MOUNT_TARGETS = (
-    Path("/home/dev/.config/claude"),
-)
-_DIRECT_DOCKER_SOCKET_TARGETS = (
-    Path("/var/run/docker.sock"),
-    Path("/run/docker.sock"),
-)
+_IMAGE_PATH_ALIASES = {
+    Path("/var/run"): Path("/run"),
+    Path("/home/dev/.config/claude"): Path("/home/dev/.claude"),
+}
+_DIRECT_DOCKER_SOCKET_TARGETS = (Path("/run/docker.sock"),)
 _COMPOSE_DEV_MOUNT_TARGETS = (
     Path("/home/dev/.claude"),
     Path("/home/dev/.gemini"),
@@ -71,6 +73,57 @@ _COMPOSE_DEV_MOUNT_TARGETS = (
     Path("/home/dev/projects"),
     Path("/home/dev/sessions"),
 )
+
+
+def _resolve_image_aliases(target: Path) -> Path:
+    for link, real in _IMAGE_PATH_ALIASES.items():
+        if target == link or target.is_relative_to(link):
+            return real / target.relative_to(link)
+    return target
+
+
+def _image_alias_variants(target: Path) -> tuple[Path, ...]:
+    canonical = _resolve_image_aliases(target)
+    variants = [canonical]
+    for link, real in _IMAGE_PATH_ALIASES.items():
+        if canonical == real or canonical.is_relative_to(real):
+            alias = link / canonical.relative_to(real)
+            if alias not in variants:
+                variants.append(alias)
+    return tuple(variants)
+
+
+def _validate_mount_target(target: Path) -> None:
+    if any(
+        target == root or target.is_relative_to(root)
+        for root in _FORBIDDEN_MOUNT_TARGET_ROOTS
+    ):
+        msg = f"Mount target {target} is not allowed under /proc, /sys, or /dev"
+        raise MountSpecificationError(msg)
+
+
+def _normalize_mount_target(target: str | Path) -> Path:
+    target_text = str(target)
+    if "\x00" in target_text:
+        raise MountSpecificationError("Mount target cannot contain a NUL byte")
+
+    normalized = Path(re.sub(r"^/+", "/", os.path.normpath(target_text)))
+    if not normalized.is_absolute():
+        msg = f"Mount target must be an absolute container path: {target_text!r}"
+        raise MountSpecificationError(msg)
+
+    canonical = _resolve_image_aliases(normalized)
+    _validate_mount_target(canonical)
+    return canonical
+
+
+def _normalize_runtime_mount_target(target: str) -> Path:
+    try:
+        return _normalize_mount_target(target)
+    except MountSpecificationError as e:
+        raise RuntimeMountSpecificationError(
+            f"Invalid internal runtime mount target {target!r}: {e}"
+        ) from e
 
 
 class DockerMode(Enum):
@@ -108,10 +161,6 @@ class ContainerMount:
     read_only: bool = False
 
 
-class MountSpecificationError(ValueError):
-    """Raised when a ``--mount`` value does not match Djinn's mount grammar."""
-
-
 class MountCollisionError(ValueError):
     """Raised when a user mount would hide another container mount."""
 
@@ -135,17 +184,7 @@ def parse_mount_spec(specification: str) -> tuple[str, Path | None, bool]:
         if target_or_mode in {"ro", "rw"}:
             read_only = target_or_mode == "ro"
         else:
-            normalized_target = re.sub(r"^/+", "/", os.path.normpath(target_or_mode))
-            target = Path(normalized_target)
-            if not target.is_absolute():
-                msg = f"Mount target must be an absolute container path: {target_or_mode!r}"
-                raise MountSpecificationError(msg)
-            if any(
-                target == root or target.is_relative_to(root)
-                for root in _FORBIDDEN_MOUNT_TARGET_ROOTS
-            ):
-                msg = f"Mount target {target} is not allowed under /proc, /sys, or /dev"
-                raise MountSpecificationError(msg)
+            target = _normalize_mount_target(target_or_mode)
 
     if len(fields) == 3:
         if target is None:
@@ -474,7 +513,7 @@ def _mount_targets_from_args(args: list[str]) -> list[Path]:
         argument = args[index]
         if argument in {"-v", "--volume"}:
             if index + 1 == len(args):
-                raise MountSpecificationError(
+                raise RuntimeMountSpecificationError(
                     f"Volume flag {argument!r} requires a specification"
                 )
             specification = args[index + 1]
@@ -483,15 +522,63 @@ def _mount_targets_from_args(args: list[str]) -> list[Path]:
             specification = argument.split("=", 1)[1]
             index += 1
         elif argument.startswith("--volume") or argument.startswith("--mount"):
-            raise MountSpecificationError(f"Unknown volume flag {argument!r}")
+            raise RuntimeMountSpecificationError(f"Unknown volume flag {argument!r}")
         else:
             index += 1
             continue
 
-        parts = specification.rsplit(":", 2)
-        target = parts[-2] if parts[-1] in {"ro", "rw"} else parts[-1]
-        targets.append(Path(target))
+        _, target, _ = _normalize_runtime_mount_specification(specification)
+        targets.append(target)
     return targets
+
+
+def _normalize_runtime_mount_specification(
+    specification: str,
+) -> tuple[str, Path, str | None]:
+    parts = specification.rsplit(":", 2)
+    if len(parts) not in {2, 3} or not parts[0]:
+        raise RuntimeMountSpecificationError(
+            f"Invalid internal runtime mount specification {specification!r}"
+        )
+    if len(parts) == 3 and parts[2] not in {"ro", "rw"}:
+        raise RuntimeMountSpecificationError(
+            f"Invalid internal runtime mount mode in {specification!r}"
+        )
+    mode = parts[2] if len(parts) == 3 else None
+    return parts[0], _normalize_runtime_mount_target(parts[1]), mode
+
+
+def _canonicalize_runtime_mount_args(args: list[str]) -> list[str]:
+    canonical_args = list(args)
+    index = 0
+    while index < len(canonical_args):
+        argument = canonical_args[index]
+        if argument in {"-v", "--volume"}:
+            if index + 1 == len(canonical_args):
+                raise RuntimeMountSpecificationError(
+                    f"Volume flag {argument!r} requires a specification"
+                )
+            source, target, mode = _normalize_runtime_mount_specification(
+                canonical_args[index + 1]
+            )
+            canonical_args[index + 1] = (
+                f"{source}:{target}" + (f":{mode}" if mode is not None else "")
+            )
+            index += 2
+        elif argument.startswith("--volume="):
+            source, target, mode = _normalize_runtime_mount_specification(
+                argument.split("=", 1)[1]
+            )
+            canonical_args[index] = (
+                f"--volume={source}:{target}"
+                + (f":{mode}" if mode is not None else "")
+            )
+            index += 1
+        elif argument.startswith("--volume") or argument.startswith("--mount"):
+            raise RuntimeMountSpecificationError(f"Unknown volume flag {argument!r}")
+        else:
+            index += 1
+    return canonical_args
 
 
 def _reserved_mount_targets(
@@ -503,19 +590,33 @@ def _reserved_mount_targets(
     dbus_args: list[str] | None = None,
 ) -> list[Path]:
     """Return targets occupied by this particular ``dev`` container invocation."""
-    targets = [*_COMPOSE_DEV_MOUNT_TARGETS, *_IMAGE_SYMLINK_MOUNT_TARGETS, _MOUNT_ROOT]
+    targets = [*_COMPOSE_DEV_MOUNT_TARGETS, _MOUNT_ROOT]
+    if docker_mode is DockerMode.DIRECT:
+        targets.extend(_DIRECT_DOCKER_SOCKET_TARGETS)
     if shell_args is None:
         shell_args = get_shell_mount_args(config)
     if audio_args is None:
         audio_args = get_audio_mount_args()
     if dbus_args is None:
         dbus_args = get_dbus_mount_args()
-    targets.extend(_mount_targets_from_args(shell_args))
-    targets.extend(_mount_targets_from_args(audio_args))
-    targets.extend(_mount_targets_from_args(dbus_args))
-    if docker_mode is DockerMode.DIRECT:
-        targets.extend(_DIRECT_DOCKER_SOCKET_TARGETS)
-    return targets
+    runtime_targets = [
+        *_mount_targets_from_args(shell_args),
+        *_mount_targets_from_args(audio_args),
+        *_mount_targets_from_args(dbus_args),
+    ]
+    accepted_runtime_targets: list[Path] = []
+    for runtime_target in runtime_targets:
+        if any(
+            variant == runtime_target or variant.is_relative_to(runtime_target)
+            for occupied_target in [*targets, *accepted_runtime_targets]
+            for variant in _image_alias_variants(occupied_target)
+        ):
+            raise RuntimeMountSpecificationError(
+                f"Internal runtime mount target {runtime_target} conflicts with "
+                "another container mount"
+            )
+        accepted_runtime_targets.append(runtime_target)
+    return [*targets, *accepted_runtime_targets]
 
 
 def validate_container_mounts(
@@ -528,26 +629,37 @@ def validate_container_mounts(
     dbus_args: list[str] | None = None,
 ) -> None:
     """Reject user targets that equal or are ancestors of an occupied target."""
-    occupied: list[tuple[Path, str]] = [
-        (target, f"reserved mount at {target}")
-        for target in _reserved_mount_targets(
-            config,
-            docker_mode,
-            shell_args=shell_args,
-            audio_args=audio_args,
-            dbus_args=dbus_args,
-        )
-    ]
+    normalized_mounts = tuple(
+        ContainerMount(mount.source, _normalize_mount_target(mount.target), mount.read_only)
+        for mount in mounts
+    )
 
-    for mount in mounts:
-        for target, description in occupied:
-            if mount.target == target or target.is_relative_to(mount.target):
+    reserved_targets = _reserved_mount_targets(
+        config,
+        docker_mode,
+        shell_args=shell_args,
+        audio_args=audio_args,
+        dbus_args=dbus_args,
+    )
+    occupied: list[tuple[Path, str, Path]] = []
+    for target in reserved_targets:
+        occupied.extend(
+            (variant, f"reserved mount at {target}", target)
+            for variant in _image_alias_variants(target)
+        )
+
+    for mount in normalized_mounts:
+        mount_target = mount.target
+        for target, description, display_target in occupied:
+            if mount_target == target or target.is_relative_to(mount_target):
                 msg = (
-                    f"Mount {mount.source} -> {mount.target} conflicts with {description} "
-                    f"(conflict path: {target})"
+                    f"Mount {mount.source} -> {mount_target} conflicts with {description} "
+                    f"(conflict path: {display_target})"
                 )
                 raise MountCollisionError(msg)
-        occupied.append((mount.target, f"mount {mount.source} -> {mount.target}"))
+        occupied.append(
+            (mount_target, f"mount {mount.source} -> {mount_target}", mount_target)
+        )
 
 
 def compose_build(config: AppConfig | None = None, *, no_cache: bool = False) -> RunResult:
@@ -606,11 +718,21 @@ def compose_run(
     for key, value in env_vars.items():
         cmd.extend(["-e", f"{key}={value}"])
 
-    shell_args = get_shell_mount_args(config) if shell_mount_args is None else shell_mount_args
-    audio_args = get_audio_mount_args() if audio_mount_args is None else audio_mount_args
-    dbus_args = get_dbus_mount_args() if dbus_mount_args is None else dbus_mount_args
+    mounts = tuple(
+        ContainerMount(mount.source, _normalize_mount_target(mount.target), mount.read_only)
+        for mount in options.mounts
+    )
+    shell_args = _canonicalize_runtime_mount_args(
+        get_shell_mount_args(config) if shell_mount_args is None else shell_mount_args
+    )
+    audio_args = _canonicalize_runtime_mount_args(
+        get_audio_mount_args() if audio_mount_args is None else audio_mount_args
+    )
+    dbus_args = _canonicalize_runtime_mount_args(
+        get_dbus_mount_args() if dbus_mount_args is None else dbus_mount_args
+    )
     validate_container_mounts(
-        options.mounts,
+        mounts,
         config,
         options.docker_mode,
         shell_args=shell_args,
@@ -618,14 +740,15 @@ def compose_run(
         dbus_args=dbus_args,
     )
 
-    for mount in options.mounts:
-        mount_str = f"{mount.source}:{mount.target}"
+    for mount in mounts:
+        mount_target = _resolve_image_aliases(mount.target)
+        mount_str = f"{mount.source}:{mount_target}"
         if mount.read_only:
             mount_str += ":ro"
         cmd.extend(["-v", mount_str])
 
-    if options.mounts:
-        workdir = options.mounts[0].target
+    if mounts:
+        workdir = mounts[0].target
         cmd.extend(["--workdir", str(workdir)])
 
     # Shell mounts (skip_mounts check is inside get_shell_mount_args)

--- a/src/djinn_in_a_box/core/docker.py
+++ b/src/djinn_in_a_box/core/docker.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+import re
 import shutil
 import subprocess
 import sys
@@ -33,6 +34,13 @@ _WORKFLOW_PUBLISHER_LABEL = "djinn.workflow.publisher"
 _WORKFLOW_IMAGE_INSPECT_TIMEOUT = 10.0
 _MOUNT_ROOT = Path("/home/dev/mount")
 _WORKSPACE_PATH = Path("/home/dev/workspace")
+_IMAGE_SYMLINK_MOUNT_TARGETS = (
+    Path("/home/dev/.config/claude"),
+)
+_DIRECT_DOCKER_SOCKET_TARGETS = (
+    Path("/var/run/docker.sock"),
+    Path("/run/docker.sock"),
+)
 _COMPOSE_DEV_MOUNT_TARGETS = (
     Path("/home/dev/.claude"),
     Path("/home/dev/.gemini"),
@@ -126,7 +134,8 @@ def parse_mount_spec(specification: str) -> tuple[str, Path | None, bool]:
         if target_or_mode in {"ro", "rw"}:
             read_only = target_or_mode == "ro"
         else:
-            target = Path(os.path.normpath(target_or_mode))
+            normalized_target = re.sub(r"^/+", "/", os.path.normpath(target_or_mode))
+            target = Path(normalized_target)
             if not target.is_absolute():
                 msg = f"Mount target must be an absolute container path: {target_or_mode!r}"
                 raise MountSpecificationError(msg)
@@ -451,26 +460,52 @@ def get_dbus_mount_args() -> list[str]:
 
 
 def _mount_targets_from_args(args: list[str]) -> list[Path]:
-    """Extract container targets from the ``-v`` arguments built in this module."""
+    """Extract container targets from volume arguments built in this module."""
     targets: list[Path] = []
-    for index, argument in enumerate(args):
-        if argument != "-v" or index + 1 == len(args):
+    index = 0
+    while index < len(args):
+        argument = args[index]
+        if argument in {"-v", "--volume"}:
+            if index + 1 == len(args):
+                raise ValueError(f"Volume flag {argument!r} requires a specification")
+            specification = args[index + 1]
+            index += 2
+        elif argument.startswith("--volume="):
+            specification = argument.split("=", 1)[1]
+            index += 1
+        elif argument.startswith("--volume") or argument.startswith("--mount"):
+            raise ValueError(f"Unknown volume flag {argument!r}")
+        else:
+            index += 1
             continue
-        specification = args[index + 1]
+
         parts = specification.rsplit(":", 2)
         target = parts[-2] if parts[-1] in {"ro", "rw"} else parts[-1]
         targets.append(Path(target))
     return targets
 
 
-def _reserved_mount_targets(config: AppConfig, docker_mode: DockerMode) -> list[Path]:
+def _reserved_mount_targets(
+    config: AppConfig,
+    docker_mode: DockerMode,
+    *,
+    shell_args: list[str] | None = None,
+    audio_args: list[str] | None = None,
+    dbus_args: list[str] | None = None,
+) -> list[Path]:
     """Return targets occupied by this particular ``dev`` container invocation."""
-    targets = [*_COMPOSE_DEV_MOUNT_TARGETS, _MOUNT_ROOT]
-    targets.extend(_mount_targets_from_args(get_shell_mount_args(config)))
-    targets.extend(_mount_targets_from_args(get_audio_mount_args()))
-    targets.extend(_mount_targets_from_args(get_dbus_mount_args()))
+    targets = [*_COMPOSE_DEV_MOUNT_TARGETS, *_IMAGE_SYMLINK_MOUNT_TARGETS, _MOUNT_ROOT]
+    if shell_args is None:
+        shell_args = get_shell_mount_args(config)
+    if audio_args is None:
+        audio_args = get_audio_mount_args()
+    if dbus_args is None:
+        dbus_args = get_dbus_mount_args()
+    targets.extend(_mount_targets_from_args(shell_args))
+    targets.extend(_mount_targets_from_args(audio_args))
+    targets.extend(_mount_targets_from_args(dbus_args))
     if docker_mode is DockerMode.DIRECT:
-        targets.append(Path("/var/run/docker.sock"))
+        targets.extend(_DIRECT_DOCKER_SOCKET_TARGETS)
     return targets
 
 
@@ -478,11 +513,21 @@ def validate_container_mounts(
     mounts: tuple[ContainerMount, ...],
     config: AppConfig,
     docker_mode: DockerMode,
+    *,
+    shell_args: list[str] | None = None,
+    audio_args: list[str] | None = None,
+    dbus_args: list[str] | None = None,
 ) -> None:
     """Reject user targets that equal or are ancestors of an occupied target."""
     occupied: list[tuple[Path, str]] = [
         (target, f"reserved mount at {target}")
-        for target in _reserved_mount_targets(config, docker_mode)
+        for target in _reserved_mount_targets(
+            config,
+            docker_mode,
+            shell_args=shell_args,
+            audio_args=audio_args,
+            dbus_args=dbus_args,
+        )
     ]
 
     for mount in mounts:
@@ -513,6 +558,9 @@ def compose_run(
     env: dict[str, str] | None = None,
     service: str = "dev",
     timeout: int | None = None,
+    shell_mount_args: list[str] | None = None,
+    audio_mount_args: list[str] | None = None,
+    dbus_mount_args: list[str] | None = None,
 ) -> RunResult:
     """Run a container via docker compose.
 
@@ -549,7 +597,17 @@ def compose_run(
     for key, value in env_vars.items():
         cmd.extend(["-e", f"{key}={value}"])
 
-    validate_container_mounts(options.mounts, config, options.docker_mode)
+    shell_args = get_shell_mount_args(config) if shell_mount_args is None else shell_mount_args
+    audio_args = get_audio_mount_args() if audio_mount_args is None else audio_mount_args
+    dbus_args = get_dbus_mount_args() if dbus_mount_args is None else dbus_mount_args
+    validate_container_mounts(
+        options.mounts,
+        config,
+        options.docker_mode,
+        shell_args=shell_args,
+        audio_args=audio_args,
+        dbus_args=dbus_args,
+    )
 
     for mount in options.mounts:
         mount_str = f"{mount.source}:{mount.target}"
@@ -562,9 +620,9 @@ def compose_run(
         cmd.extend(["--workdir", str(workdir)])
 
     # Shell mounts (skip_mounts check is inside get_shell_mount_args)
-    cmd.extend(get_shell_mount_args(config))
-    cmd.extend(get_audio_mount_args())
-    cmd.extend(get_dbus_mount_args())
+    cmd.extend(shell_args)
+    cmd.extend(audio_args)
+    cmd.extend(dbus_args)
 
     # Service name
     cmd.append(service)

--- a/src/djinn_in_a_box/core/exceptions.py
+++ b/src/djinn_in_a_box/core/exceptions.py
@@ -1,10 +1,9 @@
-"""Exception types for Djinn in a Box configuration errors."""
+"""Exception types shared across Djinn's core layers."""
 
 from pathlib import Path
 
 
 class ConfigNotFoundError(FileNotFoundError):
-
     def __init__(self, path: Path) -> None:
         self.path = path
         super().__init__(
@@ -14,3 +13,11 @@ class ConfigNotFoundError(FileNotFoundError):
 
 class ConfigValidationError(ValueError):
     pass
+
+
+class MountSpecificationError(ValueError):
+    """Raised when a ``--mount`` value cannot be resolved or parsed."""
+
+
+class RuntimeMountSpecificationError(RuntimeError):
+    """Raised when an internal runtime mount builder emits invalid arguments."""

--- a/src/djinn_in_a_box/core/paths.py
+++ b/src/djinn_in_a_box/core/paths.py
@@ -7,6 +7,8 @@ resolving mount paths used in Docker container operations.
 import functools
 from pathlib import Path
 
+from djinn_in_a_box.core.exceptions import MountSpecificationError
+
 CONFIG_DIR: Path = Path.home() / ".config" / "djinn_in_a_box"
 """Configuration directory (~/.config/djinn_in_a_box/)."""
 
@@ -58,7 +60,11 @@ def resolve_mount_path(path: str | Path) -> Path:
     Raises FileNotFoundError or NotADirectoryError on invalid paths.
     """
     path_obj = Path(path) if isinstance(path, str) else path
-    resolved = path_obj.expanduser().resolve()
+    try:
+        resolved = path_obj.expanduser().resolve()
+    except (RuntimeError, ValueError, OSError) as e:
+        msg = f"Mount path cannot be resolved: {path} ({e})"
+        raise MountSpecificationError(msg) from e
 
     # Validate existence
     if not resolved.exists():

--- a/tests/test_commands/test_agent.py
+++ b/tests/test_commands/test_agent.py
@@ -23,6 +23,7 @@ from djinn_in_a_box.core.docker import (
     ContainerMount,
     DockerMode,
     MountCollisionError,
+    MountSpecificationError,
     RunResult,
     WorkflowImageCompatibility,
 )
@@ -200,9 +201,68 @@ class TestRunCommand:
         mock_run = run_mocks["run"]
         mock_run.assert_called_once()
         assert mock_run.call_args.args == ("claude", "test prompt")
-        assert mock_run.call_args.kwargs["mounts"] == ()
+        assert "mounts" not in mock_run.call_args.kwargs
+        assert "resolved_mounts" in mock_run.call_args.kwargs
         assert mock_run.call_args.kwargs["app_config"] is run_mocks["config"]
         assert callable(mock_run.call_args.kwargs["on_ready"])
+
+    def test_run_without_mount_resolves_implicit_here_at_cli_boundary(
+        self,
+        run_mocks: dict[str, Any],
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.chdir(tmp_path)
+        result = CliRunner().invoke(app, ["run", "claude", "test prompt"])
+
+        assert result.exit_code == 0, result.output
+        assert run_mocks["run"].call_args.kwargs["resolved_mounts"] == (
+            ContainerMount(tmp_path, Path("/home/dev/workspace")),
+        )
+
+    def test_run_here_alone_resolves_current_directory(
+        self,
+        run_mocks: dict[str, Any],
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        from djinn_in_a_box.commands.agent import run
+
+        monkeypatch.chdir(tmp_path)
+        with pytest.raises(typer.Exit):
+            run(agent="claude", prompt="test prompt", here=True)
+
+        assert run_mocks["run"].call_args.kwargs["resolved_mounts"] == (
+            ContainerMount(tmp_path, Path("/home/dev/workspace")),
+        )
+
+    def test_run_here_keeps_workspace_first_with_two_additional_mounts(
+        self,
+        run_mocks: dict[str, Any],
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        from djinn_in_a_box.commands.agent import run
+
+        monkeypatch.chdir(tmp_path)
+        first = tmp_path / "first"
+        second = tmp_path / "second"
+        first.mkdir()
+        second.mkdir()
+
+        with pytest.raises(typer.Exit):
+            run(
+                agent="claude",
+                prompt="test prompt",
+                here=True,
+                mount=[str(first), str(second)],
+            )
+
+        assert run_mocks["run"].call_args.kwargs["resolved_mounts"] == (
+            ContainerMount(tmp_path, Path("/home/dev/workspace")),
+            ContainerMount(first, Path("/home/dev/mount/first")),
+            ContainerMount(second, Path("/home/dev/mount/second")),
+        )
 
     def test_run_passes_each_mount_specification_to_the_runner(
         self, run_mocks: dict[str, Any], tmp_path: Path
@@ -221,9 +281,10 @@ class TestRunCommand:
                 mount=[str(first), f"{second}:/container/two:ro"],
             )
 
-        assert run_mocks["run"].call_args.kwargs["mounts"] == (
-            str(first),
-            f"{second}:/container/two:ro",
+        assert "mounts" not in run_mocks["run"].call_args.kwargs
+        assert run_mocks["run"].call_args.kwargs["resolved_mounts"] == (
+            ContainerMount(first, Path("/home/dev/mount/one")),
+            ContainerMount(second, Path("/container/two"), read_only=True),
         )
 
     def test_run_cli_preserves_repeated_mount_options(
@@ -248,7 +309,11 @@ class TestRunCommand:
         )
 
         assert result.exit_code == 0, result.output
-        assert run_mocks["run"].call_args.kwargs["mounts"] == (str(first), str(second))
+        assert "mounts" not in run_mocks["run"].call_args.kwargs
+        assert run_mocks["run"].call_args.kwargs["resolved_mounts"] == (
+            ContainerMount(first, Path("/home/dev/mount/first")),
+            ContainerMount(second, Path("/home/dev/mount/second")),
+        )
 
     def test_run_status_lists_mounts_and_labels_only_an_actual_workspace(
         self, run_mocks: dict[str, Any]
@@ -330,6 +395,21 @@ class TestRunCommand:
 
         assert exc_info.value.exit_code == 1
         error.assert_called_once_with("mount collision detail")
+
+    def test_run_reports_a_mount_specification_error(
+        self, run_mocks: dict[str, Any]
+    ) -> None:
+        from djinn_in_a_box.commands.agent import run
+
+        run_mocks["run"].side_effect = MountSpecificationError("bad volume arguments")
+        with (
+            patch("djinn_in_a_box.commands.agent.error") as error,
+            pytest.raises(typer.Exit) as exc_info,
+        ):
+            run(agent="claude", prompt="test prompt")
+
+        assert exc_info.value.exit_code == 1
+        error.assert_called_once_with("bad volume arguments")
 
     def test_run_keeps_checked_config_when_loader_changes_after_bootstrap(
         self, run_mocks: dict[str, Any]

--- a/tests/test_commands/test_agent.py
+++ b/tests/test_commands/test_agent.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 from collections.abc import Generator
 from pathlib import Path
 from typing import Any
@@ -27,6 +28,7 @@ from djinn_in_a_box.core.docker import (
     RunResult,
     WorkflowImageCompatibility,
 )
+from djinn_in_a_box.core.exceptions import RuntimeMountSpecificationError
 
 
 @pytest.fixture
@@ -219,6 +221,56 @@ class TestRunCommand:
         assert run_mocks["run"].call_args.kwargs["resolved_mounts"] == (
             ContainerMount(tmp_path, Path("/home/dev/workspace")),
         )
+
+    @pytest.mark.parametrize("mount", ["~nosuchuser/x", "\x00"])
+    def test_run_cli_reports_unresolvable_mount_without_traceback(
+        self, run_mocks: dict[str, Any], mount: str
+    ) -> None:
+        result = CliRunner().invoke(
+            app,
+            ["run", "claude", "test prompt", "--mount", mount],
+        )
+
+        assert result.exit_code == 1
+        assert result.exception is None or isinstance(result.exception, SystemExit)
+        assert "Mount path cannot be resolved" in result.output
+        run_mocks["run"].assert_not_called()
+
+    def test_run_cli_reports_unresolvable_mount_target_without_traceback(
+        self, run_mocks: dict[str, Any], tmp_path: Path
+    ) -> None:
+        result = CliRunner().invoke(
+            app,
+            ["run", "claude", "test prompt", "--mount", f"{tmp_path}:/work\x00bad"],
+        )
+
+        assert result.exit_code == 1
+        assert result.exception is None or isinstance(result.exception, SystemExit)
+        assert "Mount target cannot contain a NUL byte" in result.output
+        run_mocks["run"].assert_not_called()
+
+    def test_run_cli_labels_runtime_mount_builder_failures(
+        self, run_mocks: dict[str, Any]
+    ) -> None:
+        run_mocks["run"].side_effect = RuntimeMountSpecificationError("bad builder output")
+
+        result = CliRunner().invoke(app, ["run", "claude", "test prompt"])
+
+        assert result.exit_code == 1
+        assert result.exception is None or isinstance(result.exception, SystemExit)
+        assert "Internal runtime mount construction failed" in result.output
+
+    def test_run_help_preserves_example_line_continuation(self, run_mocks: dict[str, Any]) -> None:
+        result = CliRunner().invoke(app, ["run", "--help"])
+        plain_output = re.sub(r"\x1b\[[0-9;]*m", "", result.output)
+
+        assert result.exit_code == 0
+        lines = plain_output.splitlines()
+        example_index = next(
+            index for index, line in enumerate(lines) if "Compare these projects" in line
+        )
+        assert lines[example_index].rstrip().endswith("--here \\")
+        assert "--mount" in lines[example_index + 1]
 
     def test_run_here_alone_resolves_current_directory(
         self,

--- a/tests/test_commands/test_agent.py
+++ b/tests/test_commands/test_agent.py
@@ -9,7 +9,9 @@ from unittest.mock import patch
 
 import pytest
 import typer
+from typer.testing import CliRunner
 
+from djinn_in_a_box.cli.djinn import app
 from djinn_in_a_box.commands.agent import build_agent_command
 from djinn_in_a_box.config.models import AgentConfig
 from djinn_in_a_box.core.agent_runner import UnknownAgentError
@@ -17,7 +19,13 @@ from djinn_in_a_box.core.config_workflow import (
     WorkflowPreparationProblem,
     WorkflowPreparationResult,
 )
-from djinn_in_a_box.core.docker import DockerMode, RunResult, WorkflowImageCompatibility
+from djinn_in_a_box.core.docker import (
+    ContainerMount,
+    DockerMode,
+    MountCollisionError,
+    RunResult,
+    WorkflowImageCompatibility,
+)
 
 
 @pytest.fixture
@@ -197,29 +205,99 @@ class TestRunCommand:
         assert callable(mock_run.call_args.kwargs["on_ready"])
 
     def test_run_passes_each_mount_specification_to_the_runner(
-        self, run_mocks: dict[str, Any]
+        self, run_mocks: dict[str, Any], tmp_path: Path
     ) -> None:
         from djinn_in_a_box.commands.agent import run
+
+        first = tmp_path / "one"
+        second = tmp_path / "two"
+        first.mkdir()
+        second.mkdir()
 
         with pytest.raises(typer.Exit):
             run(
                 agent="claude",
                 prompt="test prompt",
-                mount=["one", "two:/container/two:ro"],
+                mount=[str(first), f"{second}:/container/two:ro"],
             )
 
         assert run_mocks["run"].call_args.kwargs["mounts"] == (
-            "one",
-            "two:/container/two:ro",
+            str(first),
+            f"{second}:/container/two:ro",
         )
+
+    def test_run_cli_preserves_repeated_mount_options(
+        self, run_mocks: dict[str, Any], tmp_path: Path
+    ) -> None:
+        first = tmp_path / "first"
+        second = tmp_path / "second"
+        first.mkdir()
+        second.mkdir()
+
+        result = CliRunner().invoke(
+            app,
+            [
+                "run",
+                "claude",
+                "test prompt",
+                "--mount",
+                str(first),
+                "--mount",
+                str(second),
+            ],
+        )
+
+        assert result.exit_code == 0, result.output
+        assert run_mocks["run"].call_args.kwargs["mounts"] == (str(first), str(second))
+
+    def test_run_status_lists_mounts_and_labels_only_an_actual_workspace(
+        self, run_mocks: dict[str, Any]
+    ) -> None:
+        from djinn_in_a_box.commands.agent import run
+
+        with pytest.raises(typer.Exit):
+            run(agent="claude", prompt="test prompt")
+        on_ready = run_mocks["run"].call_args.kwargs["on_ready"]
+        assert callable(on_ready)
+
+        extra_mounts = (
+            ContainerMount(Path("/host/readonly"), Path("/home/dev/mount/readonly"), True),
+            ContainerMount(Path("/host/reference"), Path("/home/dev/mount/reference")),
+        )
+        with patch("djinn_in_a_box.commands.agent.status_line") as status_line:
+            on_ready(extra_mounts)
+
+        mount_lines = [
+            call.args for call in status_line.call_args_list if call.args[0] == "Mount"
+        ]
+        workspace_lines = [
+            call.args for call in status_line.call_args_list if call.args[0] == "Workspace"
+        ]
+        assert mount_lines == [
+            ("Mount", "/host/readonly -> /home/dev/mount/readonly (ro)"),
+            ("Mount", "/host/reference -> /home/dev/mount/reference (rw)"),
+        ]
+        assert workspace_lines == []
+
+        workspace_mount = ContainerMount(Path("/host/workspace"), Path("/home/dev/workspace"))
+        with patch("djinn_in_a_box.commands.agent.status_line") as status_line:
+            on_ready((workspace_mount, extra_mounts[1]))
+
+        workspace_lines = [
+            call.args for call in status_line.call_args_list if call.args[0] == "Workspace"
+        ]
+        assert workspace_lines == [("Workspace", "/host/workspace")]
 
     def test_run_reports_a_mount_validation_error(
         self, run_mocks: dict[str, Any]
     ) -> None:
         from djinn_in_a_box.commands.agent import run
 
-        run_mocks["run"].side_effect = FileNotFoundError("Mount path does not exist: /missing")
         with (
+            patch(
+                "djinn_in_a_box.commands.agent.resolve_container_mounts",
+                side_effect=FileNotFoundError("Mount path does not exist: /missing"),
+            ),
             patch("djinn_in_a_box.commands.agent.error") as error,
             pytest.raises(typer.Exit) as exc_info,
         ):
@@ -227,6 +305,31 @@ class TestRunCommand:
 
         assert exc_info.value.exit_code == 1
         error.assert_called_once_with("Mount path does not exist: /missing")
+
+    def test_run_does_not_translate_runner_file_not_found(
+        self, run_mocks: dict[str, Any]
+    ) -> None:
+        from djinn_in_a_box.commands.agent import run
+
+        run_mocks["run"].side_effect = FileNotFoundError("runner cwd disappeared")
+
+        with pytest.raises(FileNotFoundError, match="runner cwd disappeared"):
+            run(agent="claude", prompt="test prompt")
+
+    def test_run_reports_a_mount_collision_error(
+        self, run_mocks: dict[str, Any]
+    ) -> None:
+        from djinn_in_a_box.commands.agent import run
+
+        run_mocks["run"].side_effect = MountCollisionError("mount collision detail")
+        with (
+            patch("djinn_in_a_box.commands.agent.error") as error,
+            pytest.raises(typer.Exit) as exc_info,
+        ):
+            run(agent="claude", prompt="test prompt")
+
+        assert exc_info.value.exit_code == 1
+        error.assert_called_once_with("mount collision detail")
 
     def test_run_keeps_checked_config_when_loader_changes_after_bootstrap(
         self, run_mocks: dict[str, Any]

--- a/tests/test_commands/test_agent.py
+++ b/tests/test_commands/test_agent.py
@@ -192,8 +192,41 @@ class TestRunCommand:
         mock_run = run_mocks["run"]
         mock_run.assert_called_once()
         assert mock_run.call_args.args == ("claude", "test prompt")
+        assert mock_run.call_args.kwargs["mounts"] == ()
         assert mock_run.call_args.kwargs["app_config"] is run_mocks["config"]
         assert callable(mock_run.call_args.kwargs["on_ready"])
+
+    def test_run_passes_each_mount_specification_to_the_runner(
+        self, run_mocks: dict[str, Any]
+    ) -> None:
+        from djinn_in_a_box.commands.agent import run
+
+        with pytest.raises(typer.Exit):
+            run(
+                agent="claude",
+                prompt="test prompt",
+                mount=["one", "two:/container/two:ro"],
+            )
+
+        assert run_mocks["run"].call_args.kwargs["mounts"] == (
+            "one",
+            "two:/container/two:ro",
+        )
+
+    def test_run_reports_a_mount_validation_error(
+        self, run_mocks: dict[str, Any]
+    ) -> None:
+        from djinn_in_a_box.commands.agent import run
+
+        run_mocks["run"].side_effect = FileNotFoundError("Mount path does not exist: /missing")
+        with (
+            patch("djinn_in_a_box.commands.agent.error") as error,
+            pytest.raises(typer.Exit) as exc_info,
+        ):
+            run(agent="claude", prompt="test prompt", mount=["/missing"])
+
+        assert exc_info.value.exit_code == 1
+        error.assert_called_once_with("Mount path does not exist: /missing")
 
     def test_run_keeps_checked_config_when_loader_changes_after_bootstrap(
         self, run_mocks: dict[str, Any]

--- a/tests/test_commands/test_container.py
+++ b/tests/test_commands/test_container.py
@@ -24,6 +24,7 @@ from djinn_in_a_box.core.docker import (
     ContainerMount,
     DockerMode,
     MountCollisionError,
+    MountSpecificationError,
     RunResult,
 )
 from djinn_in_a_box.core.exceptions import ConfigNotFoundError, ConfigValidationError
@@ -96,6 +97,7 @@ class TestStartCommand:
             patch("djinn_in_a_box.commands.container.cleanup_docker_proxy") as mock_cleanup,
             patch("djinn_in_a_box.commands.container.get_shell_mount_args", return_value=[]),
             patch("djinn_in_a_box.commands.container.get_audio_mount_args", return_value=[]),
+            patch("djinn_in_a_box.commands.container.get_dbus_mount_args", return_value=[]),
             patch("djinn_in_a_box.commands.container.banner") as mock_banner,
             patch(
                 "djinn_in_a_box.commands.container.prepare_config_workflow",
@@ -170,6 +172,34 @@ class TestStartCommand:
             container.start(firewall=True)
         options = start_mocks["run"].call_args[0][1]
         assert options.firewall_enabled is True
+
+    def test_start_passes_each_precomputed_runtime_mount_list(
+        self, start_mocks: dict[str, Any]
+    ) -> None:
+        shell_args = ["-v", "/host/.zshrc:/home/dev/.zshrc.local:ro"]
+        audio_args = ["-v", "/host/pulse:/run/user/1000/pulse/native"]
+        dbus_args = ["-v", "/host/bus:/run/user/1000/bus:ro"]
+        with (
+            patch(
+                "djinn_in_a_box.commands.container.get_shell_mount_args",
+                return_value=shell_args,
+            ),
+            patch(
+                "djinn_in_a_box.commands.container.get_audio_mount_args",
+                return_value=audio_args,
+            ),
+            patch(
+                "djinn_in_a_box.commands.container.get_dbus_mount_args",
+                return_value=dbus_args,
+            ),
+            pytest.raises(typer.Exit),
+        ):
+            container.start()
+
+        kwargs = start_mocks["run"].call_args.kwargs
+        assert kwargs["shell_mount_args"] is shell_args
+        assert kwargs["audio_mount_args"] is audio_args
+        assert kwargs["dbus_mount_args"] is dbus_args
 
     def test_start_with_here_flag(
         self, start_mocks: dict[str, Any], tmp_path: Path, monkeypatch: pytest.MonkeyPatch
@@ -263,6 +293,17 @@ class TestStartCommand:
         assert exc_info.value.exit_code == 1
         assert "mount collision detail" in start_mocks["err_output"].getvalue()
         start_mocks["cleanup"].assert_called_once_with(DockerMode.NONE, start_mocks["config"])
+
+    def test_start_reports_a_mount_specification_error_from_the_core(
+        self, start_mocks: dict[str, Any]
+    ) -> None:
+        start_mocks["run"].side_effect = MountSpecificationError("bad volume arguments")
+
+        with pytest.raises(typer.Exit) as exc_info:
+            container.start()
+
+        assert exc_info.value.exit_code == 1
+        assert "bad volume arguments" in start_mocks["err_output"].getvalue()
 
     def test_start_uses_the_common_mount_path_validation(
         self, start_mocks: dict[str, Any], tmp_path: Path

--- a/tests/test_commands/test_container.py
+++ b/tests/test_commands/test_container.py
@@ -10,7 +10,9 @@ from unittest.mock import MagicMock, patch
 import pytest
 import typer
 from rich.console import Console
+from typer.testing import CliRunner
 
+from djinn_in_a_box.cli.djinn import app
 from djinn_in_a_box.commands import container
 from djinn_in_a_box.config.loader import load_config, save_config
 from djinn_in_a_box.config.models import AppConfig
@@ -180,6 +182,22 @@ class TestStartCommand:
             ContainerMount(tmp_path, Path("/home/dev/workspace")),
         )
 
+    def test_start_keeps_here_mount_first_with_additional_mount(
+        self, start_mocks: dict[str, Any], tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.chdir(tmp_path)
+        additional = tmp_path / "additional"
+        additional.mkdir()
+
+        with pytest.raises(typer.Exit):
+            container.start(here=True, mount=[str(additional)])
+
+        options = start_mocks["run"].call_args[0][1]
+        assert options.mounts == (
+            ContainerMount(tmp_path, Path("/home/dev/workspace")),
+            ContainerMount(additional, Path("/home/dev/mount/additional")),
+        )
+
     def test_start_collects_repeatable_mounts(
         self, start_mocks: dict[str, Any], tmp_path: Path
     ) -> None:
@@ -194,6 +212,23 @@ class TestStartCommand:
             ContainerMount(first, Path("/home/dev/mount/first")),
             ContainerMount(second, Path("/opt/second"), read_only=True),
         )
+
+    def test_start_cli_preserves_repeated_mount_options(
+        self, start_mocks: dict[str, Any], tmp_path: Path
+    ) -> None:
+        first = tmp_path / "first"
+        second = tmp_path / "second"
+        first.mkdir()
+        second.mkdir()
+
+        result = CliRunner().invoke(
+            app,
+            ["start", "--mount", str(first), "--mount", str(second)],
+        )
+
+        assert result.exit_code == 0, result.output
+        options = start_mocks["run"].call_args[0][1]
+        assert [mount.source for mount in options.mounts] == [first, second]
 
     def test_start_lists_each_resolved_mount(
         self, start_mocks: dict[str, Any], tmp_path: Path

--- a/tests/test_commands/test_container.py
+++ b/tests/test_commands/test_container.py
@@ -18,7 +18,12 @@ from djinn_in_a_box.core.config_workflow import (
     WorkflowPreparationProblem,
     WorkflowPreparationResult,
 )
-from djinn_in_a_box.core.docker import DockerMode, RunResult
+from djinn_in_a_box.core.docker import (
+    ContainerMount,
+    DockerMode,
+    MountCollisionError,
+    RunResult,
+)
 from djinn_in_a_box.core.exceptions import ConfigNotFoundError, ConfigValidationError
 from djinn_in_a_box.core.theme import DJINN_THEME
 
@@ -171,16 +176,73 @@ class TestStartCommand:
         with pytest.raises(typer.Exit):
             container.start(here=True)
         options = start_mocks["run"].call_args[0][1]
-        assert options.mount_path == tmp_path
+        assert options.mounts == (
+            ContainerMount(tmp_path, Path("/home/dev/workspace")),
+        )
 
-    def test_start_with_mount_path(self, start_mocks: dict[str, Any], tmp_path: Path) -> None:
+    def test_start_collects_repeatable_mounts(
+        self, start_mocks: dict[str, Any], tmp_path: Path
+    ) -> None:
+        first = tmp_path / "first"
+        second = tmp_path / "second"
+        first.mkdir()
+        second.mkdir()
+        with pytest.raises(typer.Exit):
+            container.start(mount=[str(first), f"{second}:/opt/second:ro"])
+        options = start_mocks["run"].call_args[0][1]
+        assert options.mounts == (
+            ContainerMount(first, Path("/home/dev/mount/first")),
+            ContainerMount(second, Path("/opt/second"), read_only=True),
+        )
+
+    def test_start_lists_each_resolved_mount(
+        self, start_mocks: dict[str, Any], tmp_path: Path
+    ) -> None:
+        first = tmp_path / "first"
+        second = tmp_path / "second"
+        first.mkdir()
+        second.mkdir()
+
         with (
-            patch("djinn_in_a_box.commands.container.resolve_mount_path", return_value=tmp_path),
+            patch("djinn_in_a_box.commands.container.status_line") as status_line,
             pytest.raises(typer.Exit),
         ):
-            container.start(mount=tmp_path)
-        options = start_mocks["run"].call_args[0][1]
-        assert options.mount_path == tmp_path
+            container.start(mount=[str(first), f"{second}:/opt/second:ro"])
+
+        mount_lines = [
+            call.args for call in status_line.call_args_list if call.args[0] == "Mount"
+        ]
+        assert mount_lines == [
+            ("Mount", f"{first} -> /home/dev/mount/first (rw)"),
+            ("Mount", f"{second} -> /opt/second (ro)"),
+        ]
+
+    def test_start_reports_a_mount_collision_from_the_core(
+        self, start_mocks: dict[str, Any]
+    ) -> None:
+        start_mocks["run"].side_effect = MountCollisionError("mount collision detail")
+
+        with pytest.raises(typer.Exit) as exc_info:
+            container.start()
+
+        assert exc_info.value.exit_code == 1
+        assert "mount collision detail" in start_mocks["err_output"].getvalue()
+        start_mocks["cleanup"].assert_called_once_with(DockerMode.NONE, start_mocks["config"])
+
+    def test_start_uses_the_common_mount_path_validation(
+        self, start_mocks: dict[str, Any], tmp_path: Path
+    ) -> None:
+        missing = tmp_path / "missing"
+
+        with (
+            patch("djinn_in_a_box.commands.container.error") as error,
+            pytest.raises(typer.Exit) as exc_info,
+        ):
+            container.start(mount=[str(missing)])
+
+        assert exc_info.value.exit_code == 1
+        error.assert_called_once_with(f"Mount path does not exist: {missing}")
+        start_mocks["run"].assert_not_called()
 
     def test_start_exits_on_config_not_found(self, tmp_path: Path) -> None:
         from djinn_in_a_box.core.exceptions import ConfigNotFoundError

--- a/tests/test_commands/test_container.py
+++ b/tests/test_commands/test_container.py
@@ -27,7 +27,11 @@ from djinn_in_a_box.core.docker import (
     MountSpecificationError,
     RunResult,
 )
-from djinn_in_a_box.core.exceptions import ConfigNotFoundError, ConfigValidationError
+from djinn_in_a_box.core.exceptions import (
+    ConfigNotFoundError,
+    ConfigValidationError,
+    RuntimeMountSpecificationError,
+)
 from djinn_in_a_box.core.theme import DJINN_THEME
 
 
@@ -305,6 +309,28 @@ class TestStartCommand:
         assert exc_info.value.exit_code == 1
         assert "bad volume arguments" in start_mocks["err_output"].getvalue()
 
+    def test_start_reports_a_runtime_mount_builder_failure(
+        self, start_mocks: dict[str, Any]
+    ) -> None:
+        start_mocks["run"].side_effect = RuntimeMountSpecificationError("bad builder output")
+
+        with pytest.raises(typer.Exit) as exc_info:
+            container.start()
+
+        assert exc_info.value.exit_code == 1
+        assert "Internal runtime mount construction failed" in start_mocks["err_output"].getvalue()
+
+    def test_start_prints_compose_stderr(
+        self, start_mocks: dict[str, Any], capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        start_mocks["run"].return_value = RunResult(returncode=127, stderr="docker missing\n")
+
+        with pytest.raises(typer.Exit) as exc_info:
+            container.start()
+
+        assert exc_info.value.exit_code == 127
+        assert "docker missing" in capsys.readouterr().err
+
     def test_start_uses_the_common_mount_path_validation(
         self, start_mocks: dict[str, Any], tmp_path: Path
     ) -> None:
@@ -318,6 +344,30 @@ class TestStartCommand:
 
         assert exc_info.value.exit_code == 1
         error.assert_called_once_with(f"Mount path does not exist: {missing}")
+        start_mocks["run"].assert_not_called()
+
+    @pytest.mark.parametrize("mount", ["~nosuchuser/x", "\x00"])
+    def test_start_cli_reports_unresolvable_mount_without_traceback(
+        self, start_mocks: dict[str, Any], mount: str
+    ) -> None:
+        result = CliRunner().invoke(app, ["start", "--mount", mount])
+
+        assert result.exit_code == 1
+        assert result.exception is None or isinstance(result.exception, SystemExit)
+        assert "Mount path cannot be resolved" in start_mocks["err_output"].getvalue()
+        start_mocks["run"].assert_not_called()
+
+    def test_start_cli_reports_unresolvable_mount_target_without_traceback(
+        self, start_mocks: dict[str, Any], tmp_path: Path
+    ) -> None:
+        result = CliRunner().invoke(
+            app,
+            ["start", "--mount", f"{tmp_path}:/work\x00bad"],
+        )
+
+        assert result.exit_code == 1
+        assert result.exception is None or isinstance(result.exception, SystemExit)
+        assert "Mount target cannot contain a NUL byte" in start_mocks["err_output"].getvalue()
         start_mocks["run"].assert_not_called()
 
     def test_start_exits_on_config_not_found(self, tmp_path: Path) -> None:

--- a/tests/test_core/test_agent_runner.py
+++ b/tests/test_core/test_agent_runner.py
@@ -66,7 +66,7 @@ def test_run_headless_agent_builds_and_executes_typed_request(
     tmp_path: Path,
     runner_mocks: dict[str, Any],
 ) -> None:
-    ready: list[Path] = []
+    ready: list[tuple[ContainerMount, ...]] = []
 
     result = run_headless_agent(
         "codex",
@@ -80,7 +80,9 @@ def test_run_headless_agent_builds_and_executes_typed_request(
     )
 
     assert result is runner_mocks["result"]
-    assert ready == [tmp_path]
+    assert ready == [
+        (ContainerMount(tmp_path, Path(f"/home/dev/mount/{tmp_path.name}")),)
+    ]
     compose = runner_mocks["compose"]
     compose.assert_called_once()
     assert compose.call_args.args[0] is runner_mocks["app_config"]
@@ -112,6 +114,30 @@ def test_run_headless_agent_uses_current_directory_by_default(
     assert options.mounts == (
         ContainerMount(tmp_path, Path("/home/dev/workspace")),
     )
+
+
+def test_run_headless_agent_on_ready_receives_all_resolved_mounts(
+    tmp_path: Path,
+    runner_mocks: dict[str, Any],
+) -> None:
+    first = tmp_path / "first"
+    second = tmp_path / "second"
+    first.mkdir()
+    second.mkdir()
+    ready: list[tuple[ContainerMount, ...]] = []
+
+    run_headless_agent(
+        "codex",
+        "inspect",
+        mounts=(str(first), str(second)),
+        on_ready=ready.append,
+    )
+
+    expected = (
+        ContainerMount(first, Path("/home/dev/mount/first")),
+        ContainerMount(second, Path("/home/dev/mount/second")),
+    )
+    assert ready == [expected]
 
 
 def test_run_headless_agent_validates_mount_before_network(

--- a/tests/test_core/test_agent_runner.py
+++ b/tests/test_core/test_agent_runner.py
@@ -13,7 +13,7 @@ from djinn_in_a_box.core.agent_runner import (
     UnknownAgentError,
     run_headless_agent,
 )
-from djinn_in_a_box.core.docker import DockerMode, RunResult
+from djinn_in_a_box.core.docker import ContainerMount, DockerMode, RunResult
 
 
 @pytest.fixture
@@ -74,7 +74,7 @@ def test_run_headless_agent_builds_and_executes_typed_request(
         json_output=True,
         docker_mode=DockerMode.PROXY,
         firewall=True,
-        mount=tmp_path,
+        mounts=(str(tmp_path),),
         timeout=120,
         on_ready=ready.append,
     )
@@ -87,7 +87,9 @@ def test_run_headless_agent_builds_and_executes_typed_request(
     options = compose.call_args.args[1]
     assert options.docker_mode is DockerMode.PROXY
     assert options.firewall_enabled is True
-    assert options.mount_path == tmp_path
+    assert options.mounts == (
+        ContainerMount(tmp_path, Path(f"/home/dev/mount/{tmp_path.name}")),
+    )
     assert "--model configured-model" in compose.call_args.kwargs["command"]
     assert "--sandbox read-only" in compose.call_args.kwargs["command"]
     assert "--json" in compose.call_args.kwargs["command"]
@@ -107,7 +109,29 @@ def test_run_headless_agent_uses_current_directory_by_default(
     run_headless_agent("codex", "inspect")
 
     options = runner_mocks["compose"].call_args.args[1]
-    assert options.mount_path == tmp_path
+    assert options.mounts == (
+        ContainerMount(tmp_path, Path("/home/dev/workspace")),
+    )
+
+
+def test_run_headless_agent_validates_mount_before_network(
+    app_config: AppConfig,
+    agent_config: AgentConfig,
+    tmp_path: Path,
+) -> None:
+    missing = tmp_path / "missing"
+    with (
+        patch("djinn_in_a_box.core.agent_runner.load_config", return_value=app_config),
+        patch(
+            "djinn_in_a_box.core.agent_runner.load_agents",
+            return_value={"codex": agent_config},
+        ),
+        patch("djinn_in_a_box.core.agent_runner.ensure_network") as network,
+        pytest.raises(FileNotFoundError, match=f"Mount path does not exist: {missing}"),
+    ):
+        run_headless_agent("codex", "inspect", mounts=(str(missing),))
+
+    network.assert_not_called()
 
 
 def test_checked_config_snapshot_is_used_without_reload(

--- a/tests/test_core/test_agent_runner.py
+++ b/tests/test_core/test_agent_runner.py
@@ -74,7 +74,9 @@ def test_run_headless_agent_builds_and_executes_typed_request(
         json_output=True,
         docker_mode=DockerMode.PROXY,
         firewall=True,
-        mounts=(str(tmp_path),),
+        resolved_mounts=(
+            ContainerMount(tmp_path, Path(f"/home/dev/mount/{tmp_path.name}")),
+        ),
         timeout=120,
         on_ready=ready.append,
     )
@@ -101,19 +103,26 @@ def test_run_headless_agent_builds_and_executes_typed_request(
     runner_mocks["cleanup"].assert_called_once_with(DockerMode.PROXY, runner_mocks["app_config"])
 
 
-def test_run_headless_agent_uses_current_directory_by_default(
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
+def test_run_headless_agent_requires_resolved_mounts(
     runner_mocks: dict[str, Any],
 ) -> None:
-    monkeypatch.chdir(tmp_path)
+    with pytest.raises(TypeError, match="resolved_mounts"):
+        run_headless_agent("codex", "inspect")  # type: ignore[call-arg]
 
-    run_headless_agent("codex", "inspect")
+
+def test_run_headless_agent_uses_supplied_mount_collection_unchanged(
+    tmp_path: Path,
+    runner_mocks: dict[str, Any],
+) -> None:
+    # The CLI-level implicit --here contract is guarded by
+    # test_run_without_mount_resolves_implicit_here_at_cli_boundary. This
+    # lower-level test guards that the runner uses the resolved collection as-is.
+    resolved = (ContainerMount(tmp_path, Path("/home/dev/workspace")),)
+
+    run_headless_agent("codex", "inspect", resolved_mounts=resolved)
 
     options = runner_mocks["compose"].call_args.args[1]
-    assert options.mounts == (
-        ContainerMount(tmp_path, Path("/home/dev/workspace")),
-    )
+    assert options.mounts is resolved
 
 
 def test_run_headless_agent_on_ready_receives_all_resolved_mounts(
@@ -129,7 +138,10 @@ def test_run_headless_agent_on_ready_receives_all_resolved_mounts(
     run_headless_agent(
         "codex",
         "inspect",
-        mounts=(str(first), str(second)),
+        resolved_mounts=(
+            ContainerMount(first, Path("/home/dev/mount/first")),
+            ContainerMount(second, Path("/home/dev/mount/second")),
+        ),
         on_ready=ready.append,
     )
 
@@ -138,26 +150,6 @@ def test_run_headless_agent_on_ready_receives_all_resolved_mounts(
         ContainerMount(second, Path("/home/dev/mount/second")),
     )
     assert ready == [expected]
-
-
-def test_run_headless_agent_validates_mount_before_network(
-    app_config: AppConfig,
-    agent_config: AgentConfig,
-    tmp_path: Path,
-) -> None:
-    missing = tmp_path / "missing"
-    with (
-        patch("djinn_in_a_box.core.agent_runner.load_config", return_value=app_config),
-        patch(
-            "djinn_in_a_box.core.agent_runner.load_agents",
-            return_value={"codex": agent_config},
-        ),
-        patch("djinn_in_a_box.core.agent_runner.ensure_network") as network,
-        pytest.raises(FileNotFoundError, match=f"Mount path does not exist: {missing}"),
-    ):
-        run_headless_agent("codex", "inspect", mounts=(str(missing),))
-
-    network.assert_not_called()
 
 
 def test_checked_config_snapshot_is_used_without_reload(
@@ -169,7 +161,12 @@ def test_checked_config_snapshot_is_used_without_reload(
     runner_mocks["load_config"].reset_mock()
     runner_mocks["load_config"].return_value = changed
 
-    run_headless_agent("codex", "inspect", app_config=checked)
+    run_headless_agent(
+        "codex",
+        "inspect",
+        resolved_mounts=(),
+        app_config=checked,
+    )
 
     runner_mocks["load_config"].assert_not_called()
     assert runner_mocks["compose"].call_args.args[0] is checked
@@ -188,7 +185,7 @@ def test_run_headless_agent_rejects_unknown_agent_before_network(
         patch("djinn_in_a_box.core.agent_runner.ensure_network") as network,
         pytest.raises(UnknownAgentError) as exc_info,
     ):
-        run_headless_agent("missing", "inspect")
+        run_headless_agent("missing", "inspect", resolved_mounts=())
 
     assert exc_info.value.available == ("codex",)
     network.assert_not_called()
@@ -209,7 +206,7 @@ def test_run_headless_agent_reports_network_failure_without_container(
         patch("djinn_in_a_box.core.agent_runner.cleanup_docker_proxy") as cleanup,
         pytest.raises(AgentNetworkError),
     ):
-        run_headless_agent("codex", "inspect")
+        run_headless_agent("codex", "inspect", resolved_mounts=())
 
     compose.assert_not_called()
     cleanup.assert_not_called()
@@ -221,6 +218,11 @@ def test_run_headless_agent_cleans_proxy_after_execution_error(
     runner_mocks["compose"].side_effect = RuntimeError("compose failed")
 
     with pytest.raises(RuntimeError, match="compose failed"):
-        run_headless_agent("codex", "inspect", docker_mode=DockerMode.PROXY)
+        run_headless_agent(
+            "codex",
+            "inspect",
+            docker_mode=DockerMode.PROXY,
+            resolved_mounts=(),
+        )
 
     runner_mocks["cleanup"].assert_called_once_with(DockerMode.PROXY, runner_mocks["app_config"])

--- a/tests/test_docker.py
+++ b/tests/test_docker.py
@@ -2,6 +2,7 @@
 
 import os
 import re
+import socket
 import subprocess
 from collections.abc import Generator
 from pathlib import Path
@@ -48,6 +49,10 @@ from djinn_in_a_box.core.docker import (
 )
 
 
+def _empty_mount_args(_config: AppConfig | None = None) -> list[str]:
+    return []
+
+
 class TestParseMountSpec:
     """Tests for the public ``SRC[:DST[:ro|rw]]`` mount grammar."""
 
@@ -82,6 +87,16 @@ class TestParseMountSpec:
     def test_rejects_unknown_mode(self) -> None:
         with pytest.raises(MountSpecificationError, match="expected 'ro' or 'rw'"):
             parse_mount_spec("/host/src:/container/dst:read-only")
+
+    def test_collapses_leading_slashes_in_absolute_target(self) -> None:
+        _, target, _ = parse_mount_spec("/host/src://home/dev/.claude")
+
+        assert target == Path("/home/dev/.claude")
+
+    def test_normalizes_parent_segments_in_absolute_target(self) -> None:
+        _, target, _ = parse_mount_spec("/host/src:/home/dev/mount/../.claude")
+
+        assert target == Path("/home/dev/.claude")
 
 
 class TestResolveContainerMounts:
@@ -122,6 +137,19 @@ class TestResolveContainerMounts:
             Path("/home/dev/mount/src"),
         ]
 
+    def test_numbers_the_third_duplicate_basename(self, tmp_path: Path) -> None:
+        sources = [tmp_path / parent / "x" / "src" for parent in ("a", "b", "c")]
+        for source in sources:
+            source.mkdir(parents=True)
+
+        mounts = resolve_container_mounts(tuple(str(source) for source in sources))
+
+        assert [mount.target for mount in mounts] == [
+            Path("/home/dev/mount/src"),
+            Path("/home/dev/mount/x-src"),
+            Path("/home/dev/mount/x-src-2"),
+        ]
+
     def test_rejects_workspace_as_an_explicit_target(self, tmp_path: Path) -> None:
         with pytest.raises(MountSpecificationError, match="reserved for --here"):
             resolve_container_mounts((f"{tmp_path}:/home/dev/workspace",))
@@ -132,9 +160,18 @@ class TestMountTargetCollisions:
 
     @staticmethod
     def _without_runtime_mounts(monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.setattr(docker_mod, "get_shell_mount_args", lambda _config: [])
-        monkeypatch.setattr(docker_mod, "get_audio_mount_args", lambda: [])
-        monkeypatch.setattr(docker_mod, "get_dbus_mount_args", lambda: [])
+        monkeypatch.setattr(docker_mod, "get_shell_mount_args", _empty_mount_args)
+        monkeypatch.setattr(docker_mod, "get_audio_mount_args", _empty_mount_args)
+        monkeypatch.setattr(docker_mod, "get_dbus_mount_args", _empty_mount_args)
+
+    def test_mount_targets_from_args_accepts_long_volume_flag(self) -> None:
+        assert docker_mod._mount_targets_from_args(
+            ["--volume", "/host/source:/container/target:ro"]
+        ) == [Path("/container/target")]
+
+    def test_mount_targets_from_args_rejects_unknown_volume_flag(self) -> None:
+        with pytest.raises(ValueError, match="Unknown volume flag"):
+            docker_mod._mount_targets_from_args(["--volumes-from", "other-container"])
 
     def test_rejects_exact_compose_target(
         self, mock_app_config: AppConfig, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
@@ -197,10 +234,10 @@ class TestMountTargetCollisions:
         monkeypatch.setattr(
             docker_mod,
             "get_shell_mount_args",
-            lambda _config: ["-v", "/host/.zshrc:/home/dev/.zshrc.local:ro"],
+            MagicMock(return_value=["-v", "/host/.zshrc:/home/dev/.zshrc.local:ro"]),
         )
-        monkeypatch.setattr(docker_mod, "get_audio_mount_args", lambda: [])
-        monkeypatch.setattr(docker_mod, "get_dbus_mount_args", lambda: [])
+        monkeypatch.setattr(docker_mod, "get_audio_mount_args", _empty_mount_args)
+        monkeypatch.setattr(docker_mod, "get_dbus_mount_args", _empty_mount_args)
 
         with pytest.raises(MountCollisionError, match=r"conflict path: /home/dev/\.zshrc\.local"):
             validate_container_mounts(
@@ -208,6 +245,77 @@ class TestMountTargetCollisions:
                 mock_app_config,
                 DockerMode.NONE,
             )
+
+    def test_rejects_image_claude_symlink_target(
+        self, mock_app_config: AppConfig, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        self._without_runtime_mounts(monkeypatch)
+
+        with pytest.raises(
+            MountCollisionError, match=r"conflict path: /home/dev/\.config/claude"
+        ):
+            validate_container_mounts(
+                (ContainerMount(tmp_path, Path("/home/dev/.config/claude")),),
+                mock_app_config,
+                DockerMode.NONE,
+            )
+
+    def test_rejects_active_audio_socket_target(
+        self, mock_app_config: AppConfig, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        pulse_dir = tmp_path / "pulse"
+        pulse_dir.mkdir()
+        pulse_socket = pulse_dir / "native"
+        server = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        server.bind(str(pulse_socket))
+        monkeypatch.setenv("XDG_RUNTIME_DIR", str(tmp_path))
+        monkeypatch.setattr(docker_mod, "get_shell_mount_args", MagicMock(return_value=[]))
+
+        try:
+            with pytest.raises(
+                MountCollisionError,
+                match=r"conflict path: /run/user/1000/pulse/native",
+            ):
+                validate_container_mounts(
+                    (ContainerMount(tmp_path, Path("/run/user/1000/pulse/native")),),
+                    mock_app_config,
+                    DockerMode.NONE,
+                )
+        finally:
+            server.close()
+
+    def test_rejects_active_dbus_socket_target(
+        self, mock_app_config: AppConfig, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        bus_socket = tmp_path / "bus"
+        server = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        server.bind(str(bus_socket))
+        monkeypatch.setenv("XDG_RUNTIME_DIR", str(tmp_path))
+        monkeypatch.setattr(docker_mod, "get_shell_mount_args", MagicMock(return_value=[]))
+
+        try:
+            with pytest.raises(
+                MountCollisionError, match=r"conflict path: /run/user/1000/bus"
+            ):
+                validate_container_mounts(
+                    (ContainerMount(tmp_path, Path("/run/user/1000/bus")),),
+                    mock_app_config,
+                    DockerMode.NONE,
+                )
+        finally:
+            server.close()
+
+    def test_allows_audio_target_when_audio_socket_is_absent(
+        self, mock_app_config: AppConfig, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        monkeypatch.setenv("XDG_RUNTIME_DIR", str(tmp_path))
+        monkeypatch.setattr(docker_mod, "get_shell_mount_args", MagicMock(return_value=[]))
+
+        validate_container_mounts(
+            (ContainerMount(tmp_path, Path("/run/user/1000/pulse/native")),),
+            mock_app_config,
+            DockerMode.NONE,
+        )
 
     def test_rejects_docker_socket_in_direct_mode(
         self, mock_app_config: AppConfig, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
@@ -217,6 +325,18 @@ class TestMountTargetCollisions:
         with pytest.raises(MountCollisionError, match=r"conflict path: /var/run/docker\.sock"):
             validate_container_mounts(
                 (ContainerMount(tmp_path, Path("/var/run/docker.sock")),),
+                mock_app_config,
+                DockerMode.DIRECT,
+            )
+
+    def test_rejects_docker_socket_symlink_alias_in_direct_mode(
+        self, mock_app_config: AppConfig, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        self._without_runtime_mounts(monkeypatch)
+
+        with pytest.raises(MountCollisionError, match=r"conflict path: /run/docker\.sock"):
+            validate_container_mounts(
+                (ContainerMount(tmp_path, Path("/run/docker.sock")),),
                 mock_app_config,
                 DockerMode.DIRECT,
             )
@@ -235,6 +355,31 @@ class TestMountTargetCollisions:
 
         assert "    volumes: *common-volumes" in compose_lines[dev_start:networks_start]
         assert tuple(targets) == docker_mod._COMPOSE_DEV_MOUNT_TARGETS
+
+    def test_dockerfile_aliases_of_reserved_paths_are_reserved(
+        self, mock_app_config: AppConfig
+    ) -> None:
+        dockerfile = (Path(__file__).parents[1] / "Dockerfile").read_text()
+        reserved = set(docker_mod._reserved_mount_targets(mock_app_config, DockerMode.NONE))
+        home = Path("/home/dev")
+
+        for line in dockerfile.splitlines():
+            match = re.search(r"\bln\s+-(?:s|sfn)\s+(\S+)\s+(\S+)", line)
+            if match is None:
+                continue
+
+            source_token, alias_token = match.groups()
+            source = (
+                home / source_token[2:]
+                if source_token.startswith("~/")
+                else Path(source_token)
+            )
+            alias = home / alias_token[2:] if alias_token.startswith("~/") else Path(alias_token)
+            if source in reserved and alias.is_relative_to(home):
+                assert alias in reserved, (
+                    f"Dockerfile alias {alias} points to reserved source {source} "
+                    "but is not itself reserved"
+                )
 
     def test_dev_service_keeps_its_compose_working_dir(self) -> None:
         """Without a mount no ``--workdir`` is passed, so this line decides where
@@ -686,9 +831,9 @@ class TestComposeRun:
 
     @staticmethod
     def _without_runtime_mounts(monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.setattr(docker_mod, "get_shell_mount_args", lambda _config: [])
-        monkeypatch.setattr(docker_mod, "get_audio_mount_args", lambda: [])
-        monkeypatch.setattr(docker_mod, "get_dbus_mount_args", lambda: [])
+        monkeypatch.setattr(docker_mod, "get_shell_mount_args", _empty_mount_args)
+        monkeypatch.setattr(docker_mod, "get_audio_mount_args", _empty_mount_args)
+        monkeypatch.setattr(docker_mod, "get_dbus_mount_args", _empty_mount_args)
 
     @patch("djinn_in_a_box.core.docker.get_project_root")
     @patch("djinn_in_a_box.core.docker.subprocess.run")
@@ -719,6 +864,28 @@ class TestComposeRun:
         second_mount = cmd.index("-v", cmd.index("-v") + 1)
         assert cmd[second_mount : second_mount + 2] == ["-v", "/host/readwrite:/work/two"]
         assert cmd[cmd.index("--workdir") + 1] == "/work/one"
+
+    @patch("djinn_in_a_box.core.docker.get_project_root")
+    @patch("djinn_in_a_box.core.docker.subprocess.run")
+    def test_reuses_dynamic_mount_args_for_validation_and_command(
+        self,
+        mock_run: MagicMock,
+        mock_root: MagicMock,
+        mock_app_config: AppConfig,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        mock_root.return_value = Path("/project")
+        mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+        shell_args = ["-v", "/host/.zshrc:/home/dev/.zshrc.local:ro"]
+        shell = MagicMock(return_value=shell_args)
+        monkeypatch.setattr(docker_mod, "get_shell_mount_args", shell)
+        monkeypatch.setattr(docker_mod, "get_audio_mount_args", MagicMock(return_value=[]))
+        monkeypatch.setattr(docker_mod, "get_dbus_mount_args", MagicMock(return_value=[]))
+
+        compose_run(mock_app_config, ContainerOptions(), command="echo", interactive=False)
+
+        shell.assert_called_once_with(mock_app_config)
+        assert shell_args[1] in mock_run.call_args.args[0]
 
     @patch("djinn_in_a_box.core.docker.get_project_root")
     @patch("djinn_in_a_box.core.docker.subprocess.run")
@@ -754,6 +921,32 @@ class TestComposeRun:
 
         with pytest.raises(MountCollisionError):
             compose_run(mock_app_config, options, command="echo", interactive=False)
+
+        mock_run.assert_not_called()
+
+    @patch("djinn_in_a_box.core.docker.get_project_root")
+    @patch("djinn_in_a_box.core.docker.subprocess.run")
+    def test_rejects_normalized_alias_of_compose_target_before_starting_compose(
+        self,
+        mock_run: MagicMock,
+        mock_root: MagicMock,
+        mock_app_config: AppConfig,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+    ) -> None:
+        self._without_runtime_mounts(monkeypatch)
+        mock_root.return_value = Path("/project")
+        source = tmp_path / "source"
+        source.mkdir()
+        mounts = resolve_container_mounts((f"{source}:/home/dev/mount/../.claude",))
+
+        with pytest.raises(MountCollisionError, match=r"conflict path: /home/dev/\.claude"):
+            compose_run(
+                mock_app_config,
+                ContainerOptions(mounts=mounts),
+                command="echo",
+                interactive=False,
+            )
 
         mock_run.assert_not_called()
 

--- a/tests/test_docker.py
+++ b/tests/test_docker.py
@@ -19,6 +19,7 @@ from djinn_in_a_box.core.docker import (
     DockerMode,
     MountCollisionError,
     MountSpecificationError,
+    RuntimeMountSpecificationError,
     WorkflowImageCompatibility,
     backup_sync_path,
     backup_volume,
@@ -53,26 +54,28 @@ def _empty_mount_args(_config: AppConfig | None = None) -> list[str]:
     return []
 
 
-def _parse_dockerfile_symlink_line(line: str) -> tuple[str, str] | None:
-    """Return source and alias tokens from one ``ln`` symlink command."""
-    match = re.search(r"\bln\s+(--?[^\s]+)\s+(.+)", line)
-    if match is None:
-        return None
+def _parse_dockerfile_symlink_line(line: str) -> list[tuple[str, str]]:
+    """Return source and alias tokens from every ``ln`` symlink command on one line."""
+    parsed: list[tuple[str, str]] = []
+    for match in re.finditer(r"\bln\b([^;&|\n]*)", line):
+        tokens = match.group(1).split()
+        flags: list[str] = []
+        while tokens and tokens[0].startswith("-") and tokens[0] != "\\":
+            flags.append(tokens.pop(0))
 
-    flags, operands = match.groups()
-    is_symlink = (
-        flags in {"--symbolic", "--symbolic-force"}
-        or (flags.startswith("-") and not flags.startswith("--") and "s" in flags[1:])
-    )
-    if not is_symlink:
-        return None
+        is_symlink = any(
+            flag == "--symbolic"
+            or flag.startswith("--symbolic-")
+            or (flag.startswith("-") and not flag.startswith("--") and "s" in flag[1:])
+            for flag in flags
+        )
+        if not is_symlink:
+            continue
 
-    path_tokens = [
-        token for token in operands.split() if not token.startswith("-") and token != "\\"
-    ]
-    if len(path_tokens) < 2:
-        return None
-    return path_tokens[0], path_tokens[1]
+        path_tokens = [token for token in tokens if token != "\\"]
+        if len(path_tokens) >= 2:
+            parsed.append((path_tokens[0], path_tokens[1]))
+    return parsed
 
 
 def _assert_dockerfile_aliases_are_reserved(
@@ -83,29 +86,33 @@ def _assert_dockerfile_aliases_are_reserved(
     home = Path("/home/dev")
 
     for line in dockerfile.splitlines():
-        parsed = _parse_dockerfile_symlink_line(line)
-        if parsed is None:
-            continue
-
-        source_token, alias_token = parsed
-        source = (
-            home / source_token[2:]
-            if source_token.startswith("~/")
-            else Path(source_token)
-        )
-        alias = home / alias_token[2:] if alias_token.startswith("~/") else Path(alias_token)
-        matched += 1
-        source_contains_reserved_target = any(
-            source == target or target.is_relative_to(source) for target in reserved
-        )
-        if source_contains_reserved_target and alias.is_relative_to(home):
-            assert alias in reserved, (
-                f"Dockerfile alias {alias} points to reserved source/ancestor {source} "
-                "but is not itself reserved"
+        for source_token, alias_token in _parse_dockerfile_symlink_line(line):
+            source = (
+                home / source_token[2:] if source_token.startswith("~/") else Path(source_token)
             )
+            alias = home / alias_token[2:] if alias_token.startswith("~/") else Path(alias_token)
+            canonical_alias = docker_mod._resolve_image_aliases(alias)
+            matched += 1
+            source_contains_reserved_target = any(
+                source == target or target.is_relative_to(source) for target in reserved
+            )
+            if source_contains_reserved_target:
+                assert any(
+                    canonical_alias == target or canonical_alias.is_relative_to(target)
+                    for target in reserved
+                ), (
+                    f"Dockerfile alias {alias} points to reserved source/ancestor {source} "
+                    "but is not itself reserved"
+                )
 
     assert matched, "Dockerfile alias drift guard matched no symlink lines"
     return matched
+
+
+def _assert_compose_anchor_uses_short_form(lines: list[str]) -> None:
+    assert not any(
+        re.match(r"\s*(?:-\s+)?type\s*:", line) for line in lines
+    )
 
 
 class TestParseMountSpec:
@@ -139,6 +146,10 @@ class TestParseMountSpec:
         with pytest.raises(MountSpecificationError, match="absolute container path"):
             parse_mount_spec("/host/src:relative/path")
 
+    def test_rejects_nul_in_target(self) -> None:
+        with pytest.raises(MountSpecificationError, match="NUL"):
+            parse_mount_spec("/host/src:/container/\x00dst")
+
     def test_rejects_unknown_mode(self) -> None:
         with pytest.raises(MountSpecificationError, match="expected 'ro' or 'rw'"):
             parse_mount_spec("/host/src:/container/dst:read-only")
@@ -152,6 +163,23 @@ class TestParseMountSpec:
         _, target, _ = parse_mount_spec("/host/src:/home/dev/mount/../.claude")
 
         assert target == Path("/home/dev/.claude")
+
+    @pytest.mark.parametrize(
+        ("target", "expected"),
+        [
+            ("/home/dev/.config/claude/skills", Path("/home/dev/.claude/skills")),
+            (
+                "/var/run/user/1000/pulse/native",
+                Path("/run/user/1000/pulse/native"),
+            ),
+            ("/var/run/user/1000/bus", Path("/run/user/1000/bus")),
+            ("/var/run", Path("/run")),
+        ],
+    )
+    def test_resolves_image_alias_subtrees(self, target: str, expected: Path) -> None:
+        _, resolved, _ = parse_mount_spec(f"/host/src:{target}")
+
+        assert resolved == expected
 
 
 class TestResolveContainerMounts:
@@ -230,12 +258,85 @@ class TestMountTargetCollisions:
         ) == [Path("/container/target")]
 
     def test_mount_targets_from_args_rejects_unknown_volume_flag(self) -> None:
-        with pytest.raises(MountSpecificationError, match="Unknown volume flag"):
+        with pytest.raises(RuntimeMountSpecificationError, match="Unknown volume flag"):
             docker_mod._mount_targets_from_args(["--volumes-from", "other-container"])
 
     def test_mount_targets_from_args_rejects_missing_volume_specification(self) -> None:
-        with pytest.raises(MountSpecificationError, match="requires a specification"):
+        with pytest.raises(RuntimeMountSpecificationError, match="requires a specification"):
             docker_mod._mount_targets_from_args(["-v"])
+
+    @pytest.mark.parametrize(
+        "specification",
+        ["/target", "/host:relative", "/host:/proc/../dev", "/host:/target:bad"],
+    )
+    def test_mount_targets_from_args_rejects_invalid_internal_specification(
+        self, specification: str
+    ) -> None:
+        with pytest.raises(RuntimeMountSpecificationError):
+            docker_mod._mount_targets_from_args(["-v", specification])
+
+    def test_validator_normalizes_direct_container_mount_target(
+        self, mock_app_config: AppConfig, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        self._without_runtime_mounts(monkeypatch)
+
+        with pytest.raises(MountCollisionError, match=r"conflict path: /home/dev/\.claude"):
+            validate_container_mounts(
+                (ContainerMount(tmp_path, Path("/home/dev/tmp/../.claude")),),
+                mock_app_config,
+                DockerMode.NONE,
+            )
+
+    def test_validator_rejects_runtime_mount_over_compose_target(
+        self, mock_app_config: AppConfig, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        self._without_runtime_mounts(monkeypatch)
+
+        with pytest.raises(RuntimeMountSpecificationError, match="conflicts"):
+            validate_container_mounts(
+                (),
+                mock_app_config,
+                DockerMode.NONE,
+                shell_args=["-v", "/host:/home/dev/.claude"],
+                audio_args=[],
+                dbus_args=[],
+            )
+
+    @pytest.mark.parametrize("specification", ["/host:relative", "/host:/proc/../dev"])
+    def test_validator_rejects_invalid_runtime_mount_target(
+        self,
+        specification: str,
+        mock_app_config: AppConfig,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        self._without_runtime_mounts(monkeypatch)
+
+        with pytest.raises(RuntimeMountSpecificationError):
+            validate_container_mounts(
+                (),
+                mock_app_config,
+                DockerMode.NONE,
+                shell_args=["-v", specification],
+                audio_args=[],
+                dbus_args=[],
+            )
+
+    @pytest.mark.parametrize("target", ["/proc", "/sys/kernel", "/dev"])
+    def test_validator_rejects_kernel_target_from_internal_mount(
+        self,
+        target: str,
+        mock_app_config: AppConfig,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+    ) -> None:
+        self._without_runtime_mounts(monkeypatch)
+
+        with pytest.raises(MountSpecificationError, match="not allowed"):
+            validate_container_mounts(
+                (ContainerMount(tmp_path, Path(target)),),
+                mock_app_config,
+                DockerMode.NONE,
+            )
 
     def test_rejects_exact_compose_target(
         self, mock_app_config: AppConfig, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
@@ -316,7 +417,7 @@ class TestMountTargetCollisions:
         self._without_runtime_mounts(monkeypatch)
 
         with pytest.raises(
-            MountCollisionError, match=r"conflict path: /home/dev/\.config/claude"
+            MountCollisionError, match=r"conflict path: /home/dev/\.claude"
         ):
             validate_container_mounts(
                 (ContainerMount(tmp_path, Path("/home/dev/.config/claude")),),
@@ -324,7 +425,91 @@ class TestMountTargetCollisions:
                 DockerMode.NONE,
             )
 
-    def test_rejects_active_audio_socket_target(
+    def test_rejects_image_claude_alias_subtree(
+        self, mock_app_config: AppConfig, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        self._without_runtime_mounts(monkeypatch)
+        mounts = resolve_container_mounts((f"{tmp_path}:/home/dev/.config/claude/skills",))
+
+        with pytest.raises(
+            MountCollisionError, match=r"conflict path: /home/dev/\.claude/skills"
+        ):
+            validate_container_mounts(mounts, mock_app_config, DockerMode.NONE)
+
+    def test_allows_unoccupied_child_of_image_claude_alias(
+        self, mock_app_config: AppConfig, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        self._without_runtime_mounts(monkeypatch)
+        mounts = resolve_container_mounts((f"{tmp_path}:/home/dev/.config/claude/plugins",))
+
+        assert mounts[0].target == Path("/home/dev/.claude/plugins")
+        validate_container_mounts(mounts, mock_app_config, DockerMode.NONE)
+
+    @pytest.mark.parametrize(
+        "target",
+        [
+            "/run/user/1000/pulse/native",
+            "/var/run/user/1000/pulse/native",
+        ],
+    )
+    def test_rejects_active_audio_socket_target_and_alias(
+        self,
+        mock_app_config: AppConfig,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+        target: str,
+    ) -> None:
+        pulse_dir = tmp_path / "pulse"
+        pulse_dir.mkdir()
+        pulse_socket = pulse_dir / "native"
+        server = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        server.bind(str(pulse_socket))
+        monkeypatch.setenv("XDG_RUNTIME_DIR", str(tmp_path))
+        monkeypatch.setattr(docker_mod, "get_shell_mount_args", MagicMock(return_value=[]))
+
+        try:
+            with pytest.raises(
+                MountCollisionError,
+                match=r"conflict path: /run/user/1000/pulse/native",
+            ):
+                validate_container_mounts(
+                    resolve_container_mounts((f"{tmp_path}:{target}",)),
+                    mock_app_config,
+                    DockerMode.NONE,
+                )
+        finally:
+            server.close()
+
+    @pytest.mark.parametrize(
+        "target",
+        ["/run/user/1000/bus", "/var/run/user/1000/bus"],
+    )
+    def test_rejects_active_dbus_socket_target_and_alias(
+        self,
+        mock_app_config: AppConfig,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+        target: str,
+    ) -> None:
+        bus_socket = tmp_path / "bus"
+        server = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        server.bind(str(bus_socket))
+        monkeypatch.setenv("XDG_RUNTIME_DIR", str(tmp_path))
+        monkeypatch.setattr(docker_mod, "get_shell_mount_args", MagicMock(return_value=[]))
+
+        try:
+            with pytest.raises(
+                MountCollisionError, match=r"conflict path: /run/user/1000/bus"
+            ):
+                validate_container_mounts(
+                    resolve_container_mounts((f"{tmp_path}:{target}",)),
+                    mock_app_config,
+                    DockerMode.NONE,
+                )
+        finally:
+            server.close()
+
+    def test_rejects_parent_of_active_audio_socket_through_var_run_alias(
         self, mock_app_config: AppConfig, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
     ) -> None:
         pulse_dir = tmp_path / "pulse"
@@ -341,28 +526,7 @@ class TestMountTargetCollisions:
                 match=r"conflict path: /run/user/1000/pulse/native",
             ):
                 validate_container_mounts(
-                    (ContainerMount(tmp_path, Path("/run/user/1000/pulse/native")),),
-                    mock_app_config,
-                    DockerMode.NONE,
-                )
-        finally:
-            server.close()
-
-    def test_rejects_active_dbus_socket_target(
-        self, mock_app_config: AppConfig, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
-    ) -> None:
-        bus_socket = tmp_path / "bus"
-        server = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
-        server.bind(str(bus_socket))
-        monkeypatch.setenv("XDG_RUNTIME_DIR", str(tmp_path))
-        monkeypatch.setattr(docker_mod, "get_shell_mount_args", MagicMock(return_value=[]))
-
-        try:
-            with pytest.raises(
-                MountCollisionError, match=r"conflict path: /run/user/1000/bus"
-            ):
-                validate_container_mounts(
-                    (ContainerMount(tmp_path, Path("/run/user/1000/bus")),),
+                    resolve_container_mounts((f"{tmp_path}:/var/run",)),
                     mock_app_config,
                     DockerMode.NONE,
                 )
@@ -411,7 +575,7 @@ class TestMountTargetCollisions:
     ) -> None:
         self._without_runtime_mounts(monkeypatch)
 
-        with pytest.raises(MountCollisionError, match=r"conflict path: /var/run/docker\.sock"):
+        with pytest.raises(MountCollisionError, match=r"conflict path: /run/docker\.sock"):
             validate_container_mounts(
                 (ContainerMount(tmp_path, Path("/var/run/docker.sock")),),
                 mock_app_config,
@@ -430,6 +594,24 @@ class TestMountTargetCollisions:
                 DockerMode.DIRECT,
             )
 
+    def test_rejects_ancestor_of_direct_socket_alias(
+        self,
+        mock_app_config: AppConfig,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+    ) -> None:
+        self._without_runtime_mounts(monkeypatch)
+
+        with pytest.raises(MountCollisionError, match=r"conflict path: /run/docker\.sock"):
+            validate_container_mounts(
+                (ContainerMount(tmp_path, Path("/var")),),
+                mock_app_config,
+                DockerMode.DIRECT,
+                shell_args=[],
+                audio_args=[],
+                dbus_args=[],
+            )
+
     def test_static_targets_match_the_dev_compose_volume_anchor(self) -> None:
         compose_lines = (Path(__file__).parents[1] / "docker-compose.yml").read_text().splitlines()
         anchor_start = compose_lines.index("x-common-volumes: &common-volumes")
@@ -442,16 +624,36 @@ class TestMountTargetCollisions:
             if match:
                 targets.append(Path(match.group(1)))
 
+        anchor_lines = compose_lines[anchor_start + 1 : anchor_end]
+        _assert_compose_anchor_uses_short_form(anchor_lines)
         assert "    volumes: *common-volumes" in compose_lines[dev_start:networks_start]
         assert tuple(targets) == docker_mod._COMPOSE_DEV_MOUNT_TARGETS
+
+    def test_compose_anchor_watcher_rejects_reordered_long_form(self) -> None:
+        with pytest.raises(AssertionError):
+            _assert_compose_anchor_uses_short_form(
+                ["    - source: /tmp", "      type: bind", "      target: /mnt"]
+            )
 
     @pytest.mark.parametrize("flags", ["-s", "-sfn", "-snf", "-sf", "-sfT", "--symbolic"])
     def test_dockerfile_symlink_parser_accepts_all_symlink_flag_forms(
         self, flags: str
     ) -> None:
+        assert _parse_dockerfile_symlink_line(f"RUN ln {flags} ~/.claude ~/.config/claude") == [
+            ("~/.claude", "~/.config/claude")
+        ]
+
+    def test_dockerfile_symlink_parser_checks_every_ln_on_a_line(self) -> None:
         assert _parse_dockerfile_symlink_line(
-            f"RUN ln {flags} ~/.claude ~/.config/claude"
-        ) == ("~/.claude", "~/.config/claude")
+            "RUN ln --force --symbolic ~/.claude ~/.config/claude "
+            "&& ln --relative -s /home/dev/.gemini /home/dev/.gemini"
+        ) == [
+            ("~/.claude", "~/.config/claude"),
+            ("/home/dev/.gemini", "/home/dev/.gemini"),
+        ]
+        assert _parse_dockerfile_symlink_line(
+            "RUN ln -s ~/.gemini /tmp/g || ln -s ~/.claude /srv/claude"
+        ) == [("~/.gemini", "/tmp/g"), ("~/.claude", "/srv/claude")]
 
     def test_dockerfile_aliases_of_reserved_paths_are_reserved(
         self, mock_app_config: AppConfig
@@ -471,6 +673,30 @@ class TestMountTargetCollisions:
                 "RUN ln -sfn ~/.config ~/cfg\n",
                 reserved,
             )
+
+    def test_dockerfile_alias_guard_checks_aliases_outside_home(
+        self, mock_app_config: AppConfig
+    ) -> None:
+        reserved = set(docker_mod._reserved_mount_targets(mock_app_config, DockerMode.NONE))
+
+        with pytest.raises(AssertionError, match="alias /srv/claude"):
+            _assert_dockerfile_aliases_are_reserved(
+                "RUN ln -sfn ~/.claude /srv/claude\n",
+                reserved,
+            )
+
+    def test_dockerfile_alias_guard_uses_prefix_reservations(
+        self, mock_app_config: AppConfig
+    ) -> None:
+        reserved = set(docker_mod._reserved_mount_targets(mock_app_config, DockerMode.NONE))
+
+        assert (
+            _assert_dockerfile_aliases_are_reserved(
+                "RUN ln -sfn ~/.claude ~/.config/claude/plugins\n",
+                reserved,
+            )
+            == 1
+        )
 
     def test_dockerfile_alias_guard_rejects_empty_match(self, mock_app_config: AppConfig) -> None:
         reserved = set(docker_mod._reserved_mount_targets(mock_app_config, DockerMode.NONE))
@@ -964,6 +1190,54 @@ class TestComposeRun:
 
     @patch("djinn_in_a_box.core.docker.get_project_root")
     @patch("djinn_in_a_box.core.docker.subprocess.run")
+    def test_emits_canonical_alias_target(
+        self,
+        mock_run: MagicMock,
+        mock_root: MagicMock,
+        mock_app_config: AppConfig,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+    ) -> None:
+        self._without_runtime_mounts(monkeypatch)
+        mock_root.return_value = Path("/project")
+        mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+        options = ContainerOptions(
+            mounts=(
+                ContainerMount(tmp_path, Path("/home/dev/.config/claude/plugins")),
+            )
+        )
+
+        compose_run(mock_app_config, options, command="echo", interactive=False)
+
+        cmd = mock_run.call_args.args[0]
+        assert f"{tmp_path}:/home/dev/.claude/plugins" in cmd
+        assert cmd[cmd.index("--workdir") + 1] == "/home/dev/.claude/plugins"
+
+    @patch("djinn_in_a_box.core.docker.get_project_root")
+    @patch("djinn_in_a_box.core.docker.subprocess.run")
+    def test_emits_normalized_direct_mount_target(
+        self,
+        mock_run: MagicMock,
+        mock_root: MagicMock,
+        mock_app_config: AppConfig,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+    ) -> None:
+        self._without_runtime_mounts(monkeypatch)
+        mock_root.return_value = Path("/project")
+        mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+        options = ContainerOptions(
+            mounts=(ContainerMount(tmp_path, Path("/home/dev/tmp/../work")),)
+        )
+
+        compose_run(mock_app_config, options, command="echo", interactive=False)
+
+        cmd = mock_run.call_args.args[0]
+        assert f"{tmp_path}:/home/dev/work" in cmd
+        assert cmd[cmd.index("--workdir") + 1] == "/home/dev/work"
+
+    @patch("djinn_in_a_box.core.docker.get_project_root")
+    @patch("djinn_in_a_box.core.docker.subprocess.run")
     def test_reuses_dynamic_mount_args_for_validation_and_command(
         self,
         mock_run: MagicMock,
@@ -987,6 +1261,32 @@ class TestComposeRun:
         audio.assert_called_once_with()
         dbus.assert_called_once_with()
         assert shell_args[1] in mock_run.call_args.args[0]
+
+    @patch("djinn_in_a_box.core.docker.get_project_root")
+    @patch("djinn_in_a_box.core.docker.subprocess.run")
+    def test_emits_canonical_runtime_mount_targets(
+        self,
+        mock_run: MagicMock,
+        mock_root: MagicMock,
+        mock_app_config: AppConfig,
+    ) -> None:
+        mock_root.return_value = Path("/project")
+        mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+        shell_args = ["-v", "/host:/home/dev/tmp/../runtime:ro"]
+
+        compose_run(
+            mock_app_config,
+            ContainerOptions(),
+            command="echo",
+            interactive=False,
+            shell_mount_args=shell_args,
+            audio_mount_args=[],
+            dbus_mount_args=[],
+        )
+
+        cmd = mock_run.call_args.args[0]
+        assert "/host:/home/dev/runtime:ro" in cmd
+        assert "/host:/home/dev/tmp/../runtime:ro" not in cmd
 
     @patch("djinn_in_a_box.core.docker.get_project_root")
     @patch("djinn_in_a_box.core.docker.subprocess.run")

--- a/tests/test_docker.py
+++ b/tests/test_docker.py
@@ -53,6 +53,61 @@ def _empty_mount_args(_config: AppConfig | None = None) -> list[str]:
     return []
 
 
+def _parse_dockerfile_symlink_line(line: str) -> tuple[str, str] | None:
+    """Return source and alias tokens from one ``ln`` symlink command."""
+    match = re.search(r"\bln\s+(--?[^\s]+)\s+(.+)", line)
+    if match is None:
+        return None
+
+    flags, operands = match.groups()
+    is_symlink = (
+        flags in {"--symbolic", "--symbolic-force"}
+        or (flags.startswith("-") and not flags.startswith("--") and "s" in flags[1:])
+    )
+    if not is_symlink:
+        return None
+
+    path_tokens = [
+        token for token in operands.split() if not token.startswith("-") and token != "\\"
+    ]
+    if len(path_tokens) < 2:
+        return None
+    return path_tokens[0], path_tokens[1]
+
+
+def _assert_dockerfile_aliases_are_reserved(
+    dockerfile: str, reserved: set[Path]
+) -> int:
+    """Check every Dockerfile symlink alias against exact/ancestor reservations."""
+    matched = 0
+    home = Path("/home/dev")
+
+    for line in dockerfile.splitlines():
+        parsed = _parse_dockerfile_symlink_line(line)
+        if parsed is None:
+            continue
+
+        source_token, alias_token = parsed
+        source = (
+            home / source_token[2:]
+            if source_token.startswith("~/")
+            else Path(source_token)
+        )
+        alias = home / alias_token[2:] if alias_token.startswith("~/") else Path(alias_token)
+        matched += 1
+        source_contains_reserved_target = any(
+            source == target or target.is_relative_to(source) for target in reserved
+        )
+        if source_contains_reserved_target and alias.is_relative_to(home):
+            assert alias in reserved, (
+                f"Dockerfile alias {alias} points to reserved source/ancestor {source} "
+                "but is not itself reserved"
+            )
+
+    assert matched, "Dockerfile alias drift guard matched no symlink lines"
+    return matched
+
+
 class TestParseMountSpec:
     """Tests for the public ``SRC[:DST[:ro|rw]]`` mount grammar."""
 
@@ -154,6 +209,11 @@ class TestResolveContainerMounts:
         with pytest.raises(MountSpecificationError, match="reserved for --here"):
             resolve_container_mounts((f"{tmp_path}:/home/dev/workspace",))
 
+    @pytest.mark.parametrize("target", ["/proc", "/proc/1", "/sys", "/sys/kernel", "/dev"])
+    def test_rejects_kernel_mount_targets(self, target: str) -> None:
+        with pytest.raises(MountSpecificationError, match="not allowed"):
+            parse_mount_spec(f"/host/source:{target}")
+
 
 class TestMountTargetCollisions:
     """User mount targets may not hide a mount of this ``dev`` invocation."""
@@ -170,8 +230,12 @@ class TestMountTargetCollisions:
         ) == [Path("/container/target")]
 
     def test_mount_targets_from_args_rejects_unknown_volume_flag(self) -> None:
-        with pytest.raises(ValueError, match="Unknown volume flag"):
+        with pytest.raises(MountSpecificationError, match="Unknown volume flag"):
             docker_mod._mount_targets_from_args(["--volumes-from", "other-container"])
+
+    def test_mount_targets_from_args_rejects_missing_volume_specification(self) -> None:
+        with pytest.raises(MountSpecificationError, match="requires a specification"):
+            docker_mod._mount_targets_from_args(["-v"])
 
     def test_rejects_exact_compose_target(
         self, mock_app_config: AppConfig, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
@@ -317,6 +381,31 @@ class TestMountTargetCollisions:
             DockerMode.NONE,
         )
 
+    @pytest.mark.parametrize(
+        ("docker_mode", "target"),
+        [
+            (DockerMode.NONE, Path("/var/run/docker.sock")),
+            (DockerMode.NONE, Path("/run/docker.sock")),
+            (DockerMode.PROXY, Path("/var/run/docker.sock")),
+            (DockerMode.PROXY, Path("/run/docker.sock")),
+        ],
+    )
+    def test_allows_docker_socket_target_without_direct_socket(
+        self,
+        docker_mode: DockerMode,
+        target: Path,
+        mock_app_config: AppConfig,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+    ) -> None:
+        self._without_runtime_mounts(monkeypatch)
+
+        validate_container_mounts(
+            (ContainerMount(tmp_path, target),),
+            mock_app_config,
+            docker_mode,
+        )
+
     def test_rejects_docker_socket_in_direct_mode(
         self, mock_app_config: AppConfig, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
     ) -> None:
@@ -356,30 +445,38 @@ class TestMountTargetCollisions:
         assert "    volumes: *common-volumes" in compose_lines[dev_start:networks_start]
         assert tuple(targets) == docker_mod._COMPOSE_DEV_MOUNT_TARGETS
 
+    @pytest.mark.parametrize("flags", ["-s", "-sfn", "-snf", "-sf", "-sfT", "--symbolic"])
+    def test_dockerfile_symlink_parser_accepts_all_symlink_flag_forms(
+        self, flags: str
+    ) -> None:
+        assert _parse_dockerfile_symlink_line(
+            f"RUN ln {flags} ~/.claude ~/.config/claude"
+        ) == ("~/.claude", "~/.config/claude")
+
     def test_dockerfile_aliases_of_reserved_paths_are_reserved(
         self, mock_app_config: AppConfig
     ) -> None:
         dockerfile = (Path(__file__).parents[1] / "Dockerfile").read_text()
         reserved = set(docker_mod._reserved_mount_targets(mock_app_config, DockerMode.NONE))
-        home = Path("/home/dev")
 
-        for line in dockerfile.splitlines():
-            match = re.search(r"\bln\s+-(?:s|sfn)\s+(\S+)\s+(\S+)", line)
-            if match is None:
-                continue
+        assert _assert_dockerfile_aliases_are_reserved(dockerfile, reserved) == 1
 
-            source_token, alias_token = match.groups()
-            source = (
-                home / source_token[2:]
-                if source_token.startswith("~/")
-                else Path(source_token)
+    def test_dockerfile_alias_guard_rejects_alias_of_reserved_descendant(
+        self, mock_app_config: AppConfig
+    ) -> None:
+        reserved = set(docker_mod._reserved_mount_targets(mock_app_config, DockerMode.NONE))
+
+        with pytest.raises(AssertionError, match="source/ancestor"):
+            _assert_dockerfile_aliases_are_reserved(
+                "RUN ln -sfn ~/.config ~/cfg\n",
+                reserved,
             )
-            alias = home / alias_token[2:] if alias_token.startswith("~/") else Path(alias_token)
-            if source in reserved and alias.is_relative_to(home):
-                assert alias in reserved, (
-                    f"Dockerfile alias {alias} points to reserved source {source} "
-                    "but is not itself reserved"
-                )
+
+    def test_dockerfile_alias_guard_rejects_empty_match(self, mock_app_config: AppConfig) -> None:
+        reserved = set(docker_mod._reserved_mount_targets(mock_app_config, DockerMode.NONE))
+
+        with pytest.raises(AssertionError, match="matched no symlink lines"):
+            _assert_dockerfile_aliases_are_reserved("# no links\n", reserved)
 
     def test_dev_service_keeps_its_compose_working_dir(self) -> None:
         """Without a mount no ``--workdir`` is passed, so this line decides where
@@ -878,13 +975,17 @@ class TestComposeRun:
         mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
         shell_args = ["-v", "/host/.zshrc:/home/dev/.zshrc.local:ro"]
         shell = MagicMock(return_value=shell_args)
+        audio = MagicMock(return_value=[])
+        dbus = MagicMock(return_value=[])
         monkeypatch.setattr(docker_mod, "get_shell_mount_args", shell)
-        monkeypatch.setattr(docker_mod, "get_audio_mount_args", MagicMock(return_value=[]))
-        monkeypatch.setattr(docker_mod, "get_dbus_mount_args", MagicMock(return_value=[]))
+        monkeypatch.setattr(docker_mod, "get_audio_mount_args", audio)
+        monkeypatch.setattr(docker_mod, "get_dbus_mount_args", dbus)
 
         compose_run(mock_app_config, ContainerOptions(), command="echo", interactive=False)
 
         shell.assert_called_once_with(mock_app_config)
+        audio.assert_called_once_with()
+        dbus.assert_called_once_with()
         assert shell_args[1] in mock_run.call_args.args[0]
 
     @patch("djinn_in_a_box.core.docker.get_project_root")

--- a/tests/test_docker.py
+++ b/tests/test_docker.py
@@ -1,6 +1,7 @@
 """Tests for djinn_in_a_box.core.docker module."""
 
 import os
+import re
 import subprocess
 from collections.abc import Generator
 from pathlib import Path
@@ -8,11 +9,15 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+import djinn_in_a_box.core.docker as docker_mod
 from djinn_in_a_box.config.loader import load_config, save_config
 from djinn_in_a_box.config.models import AppConfig, ShellConfig
 from djinn_in_a_box.core.docker import (
+    ContainerMount,
     ContainerOptions,
     DockerMode,
+    MountCollisionError,
+    MountSpecificationError,
     WorkflowImageCompatibility,
     backup_sync_path,
     backup_volume,
@@ -34,10 +39,214 @@ from djinn_in_a_box.core.docker import (
     get_shell_mount_args,
     is_container_running,
     is_sync_archive,
+    parse_mount_spec,
+    resolve_container_mounts,
     restore_sync_path,
     restore_volume,
+    validate_container_mounts,
     workflow_image_compatible,
 )
+
+
+class TestParseMountSpec:
+    """Tests for the public ``SRC[:DST[:ro|rw]]`` mount grammar."""
+
+    @pytest.mark.parametrize(
+        ("specification", "expected"),
+        [
+            ("/host/src", ("/host/src", None, False)),
+            ("/host/src:/container/dst", ("/host/src", Path("/container/dst"), False)),
+            ("/host/src:/container/dst:ro", ("/host/src", Path("/container/dst"), True)),
+            ("/host/src:/container/dst:rw", ("/host/src", Path("/container/dst"), False)),
+            ("/host/src:ro", ("/host/src", None, True)),
+            ("/host/src:rw", ("/host/src", None, False)),
+        ],
+    )
+    def test_parses_each_supported_field_count(
+        self, specification: str, expected: tuple[str, Path | None, bool]
+    ) -> None:
+        assert parse_mount_spec(specification) == expected
+
+    @pytest.mark.parametrize(
+        "specification",
+        ["", "/host/src:/container/dst:ro:extra"],
+    )
+    def test_rejects_invalid_field_counts(self, specification: str) -> None:
+        with pytest.raises(MountSpecificationError, match="mount specification"):
+            parse_mount_spec(specification)
+
+    def test_rejects_relative_target(self) -> None:
+        with pytest.raises(MountSpecificationError, match="absolute container path"):
+            parse_mount_spec("/host/src:relative/path")
+
+    def test_rejects_unknown_mode(self) -> None:
+        with pytest.raises(MountSpecificationError, match="expected 'ro' or 'rw'"):
+            parse_mount_spec("/host/src:/container/dst:read-only")
+
+
+class TestResolveContainerMounts:
+    """Tests for source resolution and deterministic automatic targets."""
+
+    def test_derives_a_nonempty_target_for_root_source(self) -> None:
+        mounts = resolve_container_mounts(("/",))
+
+        assert mounts == (
+            ContainerMount(source=Path("/"), target=Path("/home/dev/mount/root")),
+        )
+
+    def test_distinguishes_duplicate_basenames_with_one_parent(self, tmp_path: Path) -> None:
+        first = tmp_path / "one" / "src"
+        second = tmp_path / "two" / "src"
+        first.mkdir(parents=True)
+        second.mkdir(parents=True)
+
+        mounts = resolve_container_mounts((str(first), str(second)))
+
+        assert [mount.target for mount in mounts] == [
+            Path("/home/dev/mount/src"),
+            Path("/home/dev/mount/two-src"),
+        ]
+
+    def test_explicit_target_is_reserved_before_derived_target(self, tmp_path: Path) -> None:
+        automatic = tmp_path / "customer" / "src"
+        explicit = tmp_path / "other"
+        automatic.mkdir(parents=True)
+        explicit.mkdir()
+
+        mounts = resolve_container_mounts(
+            (str(automatic), f"{explicit}:/home/dev/mount/src")
+        )
+
+        assert [mount.target for mount in mounts] == [
+            Path("/home/dev/mount/customer-src"),
+            Path("/home/dev/mount/src"),
+        ]
+
+    def test_rejects_workspace_as_an_explicit_target(self, tmp_path: Path) -> None:
+        with pytest.raises(MountSpecificationError, match="reserved for --here"):
+            resolve_container_mounts((f"{tmp_path}:/home/dev/workspace",))
+
+
+class TestMountTargetCollisions:
+    """User mount targets may not hide a mount of this ``dev`` invocation."""
+
+    @staticmethod
+    def _without_runtime_mounts(monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(docker_mod, "get_shell_mount_args", lambda _config: [])
+        monkeypatch.setattr(docker_mod, "get_audio_mount_args", lambda: [])
+        monkeypatch.setattr(docker_mod, "get_dbus_mount_args", lambda: [])
+
+    def test_rejects_exact_compose_target(
+        self, mock_app_config: AppConfig, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        self._without_runtime_mounts(monkeypatch)
+        mount = ContainerMount(tmp_path, Path("/home/dev/.claude"))
+
+        with pytest.raises(MountCollisionError) as exc_info:
+            validate_container_mounts((mount,), mock_app_config, DockerMode.NONE)
+
+        assert str(tmp_path) in str(exc_info.value)
+        assert "/home/dev/.claude" in str(exc_info.value)
+        assert "conflict path: /home/dev/.claude" in str(exc_info.value)
+
+    def test_rejects_parent_of_compose_target(
+        self, mock_app_config: AppConfig, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        self._without_runtime_mounts(monkeypatch)
+        mount = ContainerMount(tmp_path, Path("/home/dev"))
+
+        with pytest.raises(MountCollisionError, match=r"conflict path: /home/dev/\.claude"):
+            validate_container_mounts((mount,), mock_app_config, DockerMode.NONE)
+
+    def test_allows_child_of_compose_target(
+        self, mock_app_config: AppConfig, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        self._without_runtime_mounts(monkeypatch)
+        mount = ContainerMount(tmp_path, Path("/home/dev/projects/scratch"))
+
+        validate_container_mounts((mount,), mock_app_config, DockerMode.NONE)
+
+    def test_rejects_reserved_automatic_mount_root(
+        self, mock_app_config: AppConfig, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        self._without_runtime_mounts(monkeypatch)
+        mount = ContainerMount(tmp_path, Path("/home/dev/mount"))
+
+        with pytest.raises(MountCollisionError, match=r"conflict path: /home/dev/mount"):
+            validate_container_mounts((mount,), mock_app_config, DockerMode.NONE)
+
+    def test_rejects_duplicate_user_target(
+        self, mock_app_config: AppConfig, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        self._without_runtime_mounts(monkeypatch)
+        first = ContainerMount(tmp_path / "first", Path("/container/shared"))
+        second = ContainerMount(tmp_path / "second", Path("/container/shared"))
+        first.source.mkdir()
+        second.source.mkdir()
+
+        with pytest.raises(MountCollisionError) as exc_info:
+            validate_container_mounts((first, second), mock_app_config, DockerMode.NONE)
+
+        assert str(first.source) in str(exc_info.value)
+        assert str(second.source) in str(exc_info.value)
+        assert "conflict path: /container/shared" in str(exc_info.value)
+
+    def test_rejects_active_shell_mount_target(
+        self, mock_app_config: AppConfig, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        monkeypatch.setattr(
+            docker_mod,
+            "get_shell_mount_args",
+            lambda _config: ["-v", "/host/.zshrc:/home/dev/.zshrc.local:ro"],
+        )
+        monkeypatch.setattr(docker_mod, "get_audio_mount_args", lambda: [])
+        monkeypatch.setattr(docker_mod, "get_dbus_mount_args", lambda: [])
+
+        with pytest.raises(MountCollisionError, match=r"conflict path: /home/dev/\.zshrc\.local"):
+            validate_container_mounts(
+                (ContainerMount(tmp_path, Path("/home/dev/.zshrc.local")),),
+                mock_app_config,
+                DockerMode.NONE,
+            )
+
+    def test_rejects_docker_socket_in_direct_mode(
+        self, mock_app_config: AppConfig, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        self._without_runtime_mounts(monkeypatch)
+
+        with pytest.raises(MountCollisionError, match=r"conflict path: /var/run/docker\.sock"):
+            validate_container_mounts(
+                (ContainerMount(tmp_path, Path("/var/run/docker.sock")),),
+                mock_app_config,
+                DockerMode.DIRECT,
+            )
+
+    def test_static_targets_match_the_dev_compose_volume_anchor(self) -> None:
+        compose_lines = (Path(__file__).parents[1] / "docker-compose.yml").read_text().splitlines()
+        anchor_start = compose_lines.index("x-common-volumes: &common-volumes")
+        anchor_end = compose_lines.index("x-common-environment: &common-environment")
+        dev_start = compose_lines.index("  dev:")
+        networks_start = compose_lines.index("networks:")
+        targets: list[Path] = []
+        for line in compose_lines[anchor_start + 1 : anchor_end]:
+            match = re.fullmatch(r"\s*-\s+.*:(/[^:\s]+)(?::(?:ro|rw))?", line)
+            if match:
+                targets.append(Path(match.group(1)))
+
+        assert "    volumes: *common-volumes" in compose_lines[dev_start:networks_start]
+        assert tuple(targets) == docker_mod._COMPOSE_DEV_MOUNT_TARGETS
+
+    def test_dev_service_keeps_its_compose_working_dir(self) -> None:
+        """Without a mount no ``--workdir`` is passed, so this line decides where
+        a plain ``djinn start`` lands. Deleting it would silently move every
+        mount-less start from /home/dev/projects to the image default /home/dev.
+        """
+        compose_lines = (Path(__file__).parents[1] / "docker-compose.yml").read_text().splitlines()
+        dev_start = compose_lines.index("  dev:")
+        networks_start = compose_lines.index("networks:")
+        dev_block = "\n".join(compose_lines[dev_start:networks_start])
+
+        assert "working_dir: /home/dev/projects" in dev_block
 
 
 class TestEnsureNetwork:
@@ -474,6 +683,79 @@ class TestComposeBuild:
 
 class TestComposeRun:
     """Tests for compose_run function."""
+
+    @staticmethod
+    def _without_runtime_mounts(monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(docker_mod, "get_shell_mount_args", lambda _config: [])
+        monkeypatch.setattr(docker_mod, "get_audio_mount_args", lambda: [])
+        monkeypatch.setattr(docker_mod, "get_dbus_mount_args", lambda: [])
+
+    @patch("djinn_in_a_box.core.docker.get_project_root")
+    @patch("djinn_in_a_box.core.docker.subprocess.run")
+    def test_serializes_all_mounts_and_uses_the_first_target_as_workdir(
+        self,
+        mock_run: MagicMock,
+        mock_root: MagicMock,
+        mock_app_config: AppConfig,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        self._without_runtime_mounts(monkeypatch)
+        mock_root.return_value = Path("/project")
+        mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+        options = ContainerOptions(
+            mounts=(
+                ContainerMount(Path("/host/readonly"), Path("/work/one"), read_only=True),
+                ContainerMount(Path("/host/readwrite"), Path("/work/two")),
+            )
+        )
+
+        compose_run(mock_app_config, options, command="echo", interactive=False)
+
+        cmd = mock_run.call_args.args[0]
+        assert cmd[cmd.index("-v") : cmd.index("-v") + 2] == [
+            "-v",
+            "/host/readonly:/work/one:ro",
+        ]
+        second_mount = cmd.index("-v", cmd.index("-v") + 1)
+        assert cmd[second_mount : second_mount + 2] == ["-v", "/host/readwrite:/work/two"]
+        assert cmd[cmd.index("--workdir") + 1] == "/work/one"
+
+    @patch("djinn_in_a_box.core.docker.get_project_root")
+    @patch("djinn_in_a_box.core.docker.subprocess.run")
+    def test_omits_workdir_without_mounts(
+        self,
+        mock_run: MagicMock,
+        mock_root: MagicMock,
+        mock_app_config: AppConfig,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        self._without_runtime_mounts(monkeypatch)
+        mock_root.return_value = Path("/project")
+        mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+
+        compose_run(mock_app_config, ContainerOptions(), command="echo", interactive=False)
+
+        assert "--workdir" not in mock_run.call_args.args[0]
+
+    @patch("djinn_in_a_box.core.docker.get_project_root")
+    @patch("djinn_in_a_box.core.docker.subprocess.run")
+    def test_rejects_mount_collisions_before_starting_compose(
+        self,
+        mock_run: MagicMock,
+        mock_root: MagicMock,
+        mock_app_config: AppConfig,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        self._without_runtime_mounts(monkeypatch)
+        mock_root.return_value = Path("/project")
+        options = ContainerOptions(
+            mounts=(ContainerMount(Path("/host/source"), Path("/home/dev/.claude")),)
+        )
+
+        with pytest.raises(MountCollisionError):
+            compose_run(mock_app_config, options, command="echo", interactive=False)
+
+        mock_run.assert_not_called()
 
     @patch("djinn_in_a_box.core.docker.get_project_root")
     @patch("djinn_in_a_box.core.docker.subprocess.run")

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 import pytest
 
+from djinn_in_a_box.core.exceptions import MountSpecificationError
 from djinn_in_a_box.core.paths import resolve_mount_path
 
 
@@ -43,3 +44,17 @@ class TestResolveMountPath:
 
         with pytest.raises(NotADirectoryError, match="not a directory"):
             resolve_mount_path(test_file)
+
+    @pytest.mark.parametrize("path", ["~nosuchuser/x", "\x00"])
+    def test_wraps_unresolvable_paths(self, path: str) -> None:
+        with pytest.raises(MountSpecificationError, match="Mount path cannot be resolved"):
+            resolve_mount_path(path)
+
+    def test_wraps_oserror_from_resolution(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        def fail_resolution(*_args: object, **_kwargs: object) -> Path:
+            raise OSError("resolution failed")
+
+        monkeypatch.setattr(Path, "resolve", fail_resolution)
+
+        with pytest.raises(MountSpecificationError, match="resolution failed"):
+            resolve_mount_path("/tmp")


### PR DESCRIPTION
Closes #15.

## What

`--mount` becomes repeatable on `djinn start` and `djinn run`, in the form
`SRC[:DST[:ro|rw]]`:

```bash
djinn start --here \
            --mount ~/data:/home/dev/data \
            --mount ~/reference:ro \
            --mount ~/archive
```

`/home/dev/workspace` now belongs to `--here` alone — which `djinn run` gained as
a real flag, so "current directory plus a second one" is reachable headless too.
A mount without a target lands under `/home/dev/mount/<basename>`, independent of
how many mounts the invocation carries, so adding a second one never moves an
existing one. Colliding basenames get a parent component, then a number.

Targets that would hide something are refused before the container starts, naming
both mounts and the conflicting path. Targets *inside* an occupied one stay
allowed — Compose already nests seven of its own that way.

## Deliberate break

`--mount SRC` used to land in `/home/dev/workspace`; it now lands in
`/home/dev/mount/<name>`. This keeps `workspace` to a single meaning. Issue #15
records it.

## How it was reviewed

Three convergence iterations, five perspectives each, every finding dispositioned.
25 findings in round one, 13 in round two, 10 in round three; all of round one's
and round two's confirmed closed by re-running their reproductions.

The most productive perspective was mutation testing. It found eight rules the
build had no test for — worst of all, nothing bound `--mount` to being repeatable:
changing its annotation from `list[str]` to `str` left all 725 tests green while
`--mount /a --mount /b` would have mounted the host root.

One defect class took all three rounds. Five spellings reached a reserved target
without the check noticing — `//home/dev` (POSIX keeps exactly two leading
slashes, Docker does not), the image symlink `/home/dev/.config/claude`, its whole
subtree, `/var/run` → `/run`, and every runtime socket beneath it. Each round
added another path to a list. The third round fixed the cause instead: an alias is
a directory symlink, so targets are rewritten through an alias map before any
check. The docker-socket special case disappeared with it.

Verification was measured, not taken on report: every claimed fix was
re-attacked, and every new test mutated to confirm it fails when its rule is
removed.

## Deliberately left open

Five residuals are documented rather than fixed — chiefly that symlinks *inside*
mounted content can still point at a reserved target, since runc resolves them in
the rootfs. Measured: 0 of 22,074 symlinks in the real CODE_DIR are affected, and
a fix would have to reconstruct host paths for every target while staying
incomplete for named volumes.

## Numbers

693 → 811 tests. ruff clean, `pyright src/` clean, `pyright tests/` unchanged at
7 pre-existing errors in files this branch does not touch.