### PR TITLE
chore(agents): bump opencode to 1.18.10

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -83,7 +83,7 @@ RUN eval "$(fnm env)" && fnm install --lts && fnm default lts-latest
 ARG CLAUDE_CODE_VERSION=2.1.220
 ARG GEMINI_CLI_VERSION=0.53.0
 ARG CODEX_VERSION=0.146.0
-ARG OPENCODE_VERSION=1.18.9
+ARG OPENCODE_VERSION=1.18.10
 
 # Claude Code via native installer (no npm/Node.js dependency)
 # Installs to ~/.local/bin/claude (already in PATH via .zshrc)


### PR DESCRIPTION
One line. The production instance had already picked this up locally via `scripts/update-agents.sh`; landing it here keeps that checkout able to fast-forward instead of carrying the bump as a permanent local edit that blocks the next pull.

The other three agent versions are unchanged and already current.