### PR TITLE
feat(backup): encrypt archives with a passphrase

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Install shell-test dependencies
-        run: sudo apt-get update && sudo apt-get install -y zsh jq
+        run: sudo apt-get update && sudo apt-get install -y zsh jq age
 
       - name: Set up Python
         uses: actions/setup-python@v6

--- a/IMPLEMENTATION.md
+++ b/IMPLEMENTATION.md
@@ -777,13 +777,19 @@ Category definitions come from `config/defaults.py`:
 - `SYNC_PATHS["repo-dotfiles"]`: `repo-dotfiles`
 
 `backup()` refuses to run while Djinn containers are active. It stages one
-archive per selected named volume or config-root subdirectory, then writes a
-single dated `djinn-backup-YYYY-MM-DD.tar.gz` under `~/.djinn/backups/` and
-removes older backups.
+archive per selected named volume or config-root subdirectory, then encrypts the
+outer tar with `age --passphrase` into a `0600` temporary file in
+`~/.djinn/backups/` and atomically publishes
+`djinn-backup-YYYY-MM-DD.tar.gz.age`. The backup directory is actively set to
+`0700`; the default flow keeps only the newest archive across encrypted and
+legacy cleartext formats. `--no-encrypt` is the explicit cleartext opt-out and
+uses the same atomic publication path.
 
-`restore()` also refuses to run while containers are active, extracts the newest
-backup archive, restores config-root path archives by filename prefix, and
-restores named volumes by validated volume name.
+`restore()` also refuses to run while containers are active. It identifies an
+age archive from its `age-encryption.org/v1` header, decrypts it into a separate
+restore-staging subdirectory, then extracts the outer tar. Legacy cleartext gzip
+archives remain supported. It restores config-root path archives by filename
+prefix and named volumes by validated volume name.
 
 Cache volumes are intentionally excluded from default backups because they are
 large and rebuildable.

--- a/IMPLEMENTATION.md
+++ b/IMPLEMENTATION.md
@@ -878,7 +878,9 @@ djinn backup
   +-- collect selected named volumes
   +-- collect existing config-root paths
   +-- stage per-item tar.gz files
-  +-- write ~/.djinn/backups/djinn-backup-YYYY-MM-DD.tar.gz
+  +-- encrypt and validate the outer tar in a same-directory temp file
+  +-- atomically publish ~/.djinn/backups/djinn-backup-YYYY-MM-DD.tar.gz.age
+  +-- rotate older encrypted and legacy cleartext archives
 ```
 
 Session:

--- a/README.md
+++ b/README.md
@@ -514,9 +514,12 @@ model before you store a high-value key such as an `age` identity.
   acts without approval, so a prompt injection reaching that agent can read the
   key. Run `djinn start --firewall` when an agent processes untrusted content, so
   a leaked secret cannot be sent outbound.
-- **Backups are unencrypted.** `djinn backup` writes a plain `tar.gz` under
-  `~/.djinn/backups/` that contains the credential directories. Protect that
-  directory as carefully as the credentials themselves.
+- **Backups are encrypted by default.** `djinn backup` writes an age-encrypted
+  `tar.gz.age` archive under `~/.djinn/backups/`. `age` prompts for the
+  passphrase directly at your terminal; Djinn never receives or stores it.
+  A forgotten passphrase makes that archive unrecoverable. Use `--no-encrypt`
+  only when you explicitly need a cleartext archive, and protect it as
+  carefully as the credentials themselves.
 
 Read [DOCKER-SOCKET-SECURITY.md](DOCKER-SOCKET-SECURITY.md) before enabling
 Docker socket access, which widens this surface further.
@@ -576,10 +579,14 @@ By default, this backs up:
 The archive is written to:
 
 ```text
-~/.djinn/backups/djinn-backup-YYYY-MM-DD.tar.gz
+~/.djinn/backups/djinn-backup-YYYY-MM-DD.tar.gz.age
 ```
 
-Only the newest `djinn-backup-*.tar.gz` archive is kept in that directory.
+`age` prompts twice for a passphrase at your terminal. Keep it safe: Djinn
+cannot recover a forgotten passphrase. Only the newest
+`djinn-backup-*.tar.gz` or `djinn-backup-*.tar.gz.age` archive is kept in that
+directory. Existing cleartext archives remain restorable and are removed after
+a successful new backup.
 
 Restore the newest backup:
 
@@ -588,12 +595,20 @@ djinn restore
 ```
 
 Restore asks for confirmation and overwrites the restored volume and config-root
-directory contents.
+directory contents. For encrypted backups, `age` prompts for the passphrase at
+the terminal before anything is restored.
 
 To back up specific categories:
 
 ```sh
 djinn backup --categories credentials --categories data
+```
+
+To deliberately create a cleartext archive (for example, for a controlled
+one-time migration), use:
+
+```sh
+djinn backup --no-encrypt
 ```
 
 For cross-machine usage, see

--- a/docs/sync-across-machines.md
+++ b/docs/sync-across-machines.md
@@ -74,6 +74,14 @@ By default, `djinn backup` archives existing credential/config-root paths
 volumes (`djinn-opencode-data`, `djinn-vscode-workspaces`). Cache volumes are
 not included by default because they are rebuildable.
 
+Backups are age-encrypted with a passphrase by default and use the filename
+`djinn-backup-YYYY-MM-DD.tar.gz.age`. `age` asks for that passphrase directly at
+the terminal during backup and restore; Djinn does not store it. Move the
+archive by your chosen secure transport and retain the passphrase separately: a
+forgotten passphrase cannot be recovered. Existing cleartext `.tar.gz` backups
+remain restorable. `djinn backup --no-encrypt` is an explicit cleartext opt-out
+for controlled use only.
+
 Stop Djinn containers before backup or restore; the command enforces this.
 
 ## What Not To Sync

--- a/src/djinn_in_a_box/commands/backup.py
+++ b/src/djinn_in_a_box/commands/backup.py
@@ -115,6 +115,13 @@ def _has_age_header(archive_path: Path) -> bool:
         return archive.read(len(_AGE_HEADER)) == _AGE_HEADER
 
 
+def _is_plausible_age_archive(archive_path: Path) -> bool:
+    try:
+        return archive_path.stat().st_size > 0 and _has_age_header(archive_path)
+    except OSError:
+        return False
+
+
 def _has_controlling_terminal() -> bool:
     try:
         with open("/dev/tty", encoding="utf-8"):
@@ -124,9 +131,12 @@ def _has_controlling_terminal() -> bool:
     return True
 
 
-def _require_age() -> None:
+def _require_age(*, restore: bool = False) -> None:
     if shutil.which("age") is None:
-        error("age is required for encrypted backups. Install age or use --no-encrypt.")
+        if restore:
+            error("age is required to restore an encrypted backup. Install age, then retry.")
+        else:
+            error("age is required for encrypted backups. Install age or use --no-encrypt.")
         raise typer.Exit(1)
 
 
@@ -235,7 +245,7 @@ def backup(
                     _age_encrypt_argv(staged_archive, temp_path),
                     check=False,
                 )
-                if result.returncode != 0:
+                if result.returncode != 0 or not _is_plausible_age_archive(temp_path):
                     error("Backup encryption failed; the previous backup is unchanged.")
                     raise typer.Exit(1)
 
@@ -271,6 +281,8 @@ def restore() -> None:
     _guard_no_containers_running()
     config = load_config()
 
+    BACKUPS_DIR.mkdir(parents=True, exist_ok=True)
+    BACKUPS_DIR.chmod(0o700)
     backups = _list_backups()
 
     if not backups:
@@ -286,7 +298,10 @@ def restore() -> None:
         raise typer.Exit(1) from exc
 
     if backup_file.suffix == ".age" and not encrypted:
-        error(f"Backup archive {backup_file.name} ends in .age but lacks an age encryption header.")
+        error(
+            f"Backup archive {backup_file.name} ends in .age but lacks an age encryption header. "
+            "Use an intact age-encrypted archive, then retry."
+        )
         raise typer.Exit(1)
 
     blank()
@@ -303,9 +318,12 @@ def restore() -> None:
     try:
         archive_to_extract = backup_file
         if encrypted:
-            _require_age()
+            _require_age(restore=True)
             if not _has_controlling_terminal():
-                error("A controlling terminal is required for the age passphrase prompt.")
+                error(
+                    "A controlling terminal is required for the age passphrase prompt. "
+                    "Use an interactive terminal to enter the passphrase, then retry."
+                )
                 raise typer.Exit(1)
             decrypt_dir = staging_dir / "decrypted"
             decrypt_dir.mkdir(mode=0o700)
@@ -322,7 +340,10 @@ def restore() -> None:
             with tarfile.open(archive_to_extract, "r:gz") as tar:
                 tar.extractall(path=staging_dir, filter="data")
         except (tarfile.TarError, EOFError, gzip.BadGzipFile, OSError) as exc:
-            error(f"Backup is neither a valid age archive nor a readable gzip tar: {exc}")
+            error(
+                f"Backup is neither a valid age archive nor a readable gzip tar: {exc}. "
+                "Use an intact backup archive, then retry."
+            )
             raise typer.Exit(1) from exc
 
         inner_archives = sorted(staging_dir.glob("*.tar.gz"))

--- a/src/djinn_in_a_box/commands/backup.py
+++ b/src/djinn_in_a_box/commands/backup.py
@@ -2,10 +2,14 @@
 
 from __future__ import annotations
 
+import gzip
+import os
 import re
 import shutil
+import subprocess
 import tarfile
 import tempfile
+from collections.abc import Callable
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Annotated
@@ -33,6 +37,8 @@ from djinn_in_a_box.core.paths import BACKUPS_DIR
 # "cache" excluded: uv-cache/tools-cache/vscode-server are large and rebuildable
 DEFAULT_CATEGORIES: list[str] = ["credentials", "repo-dotfiles", "data"]
 _VOLUME_NAME_RE = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9_.-]+$")
+_AGE_HEADER = b"age-encryption.org/v1"
+_BACKUP_GLOBS = ("djinn-backup-*.tar.gz", "djinn-backup-*.tar.gz.age")
 
 
 def _guard_no_containers_running() -> None:
@@ -63,6 +69,67 @@ def _collect_items(
     return volumes, sync_paths
 
 
+def _publish_archive(archive_path: Path, write_temp: Callable[[Path], None]) -> None:
+    """Write an archive into BACKUPS_DIR and atomically publish it."""
+    temp_path: Path | None = None
+    try:
+        fd, temp_name = tempfile.mkstemp(prefix=".djinn-backup-", dir=BACKUPS_DIR)
+        temp_path = Path(temp_name)
+        os.close(fd)
+        write_temp(temp_path)
+        os.replace(temp_path, archive_path)
+    finally:
+        if temp_path is not None:
+            try:
+                temp_path.unlink(missing_ok=True)
+            except OSError as exc:
+                warning(f"Failed to clean up temporary backup file: {exc}")
+
+
+def _age_encrypt_argv(archive_source: Path, temp_path: Path) -> list[str]:
+    """Build the age invocation without ever handling a passphrase."""
+    return ["age", "--passphrase", "-o", str(temp_path), str(archive_source)]
+
+
+def _age_decrypt_argv(archive_source: Path, output_path: Path) -> list[str]:
+    """Build the age decryption invocation without handling a passphrase."""
+    return ["age", "--decrypt", "-o", str(output_path), str(archive_source)]
+
+
+def _list_backups() -> list[Path]:
+    if not BACKUPS_DIR.exists():
+        return []
+    return sorted(archive for pattern in _BACKUP_GLOBS for archive in BACKUPS_DIR.glob(pattern))
+
+
+def _remove_stale_temp_archives() -> None:
+    for temp_archive in BACKUPS_DIR.glob(".djinn-backup-*"):
+        try:
+            temp_archive.unlink()
+        except OSError as exc:
+            warning(f"Failed to remove stale temporary backup {temp_archive.name}: {exc}")
+
+
+def _has_age_header(archive_path: Path) -> bool:
+    with archive_path.open("rb") as archive:
+        return archive.read(len(_AGE_HEADER)) == _AGE_HEADER
+
+
+def _has_controlling_terminal() -> bool:
+    try:
+        with open("/dev/tty", encoding="utf-8"):
+            pass
+    except OSError:
+        return False
+    return True
+
+
+def _require_age() -> None:
+    if shutil.which("age") is None:
+        error("age is required for encrypted backups. Install age or use --no-encrypt.")
+        raise typer.Exit(1)
+
+
 @handle_config_errors
 def backup(
     categories: Annotated[
@@ -73,12 +140,19 @@ def backup(
             help="Categories to backup (default: credentials, repo-dotfiles, data)",
         ),
     ] = None,
+    no_encrypt: Annotated[
+        bool,
+        typer.Option(
+            "--no-encrypt",
+            help="Create an unencrypted backup archive.",
+        ),
+    ] = False,
 ) -> None:
     """Back up Docker volumes and sync paths to a single archive.
 
     Creates a compressed archive covering both named volumes (cache/data categories)
     and sync paths (credentials/repo-dotfiles under ${DJINN_CONFIG_ROOT}).
-    The archive is stored in ~/.djinn/backups/ and replaces any previous backup.
+    The archive is encrypted with an age passphrase and replaces any previous backup.
     """
     _guard_no_containers_running()
 
@@ -122,19 +196,63 @@ def backup(
             raise typer.Exit(1)
 
         BACKUPS_DIR.mkdir(parents=True, exist_ok=True)
+        BACKUPS_DIR.chmod(0o700)
+        _remove_stale_temp_archives()
         date_str = datetime.now(tz=UTC).strftime("%Y-%m-%d")
         archive_path = BACKUPS_DIR / f"djinn-backup-{date_str}.tar.gz"
+        staged_archive = staging_dir / archive_path.name
 
-        with tarfile.open(archive_path, "w:gz") as tar:
+        with tarfile.open(staged_archive, "w:gz") as tar:
             for archive_file in staging_dir.iterdir():
-                tar.add(str(archive_file), arcname=archive_file.name)
+                if archive_file != staged_archive:
+                    tar.add(str(archive_file), arcname=archive_file.name)
 
-        for old in BACKUPS_DIR.glob("djinn-backup-*.tar.gz"):
-            if old != archive_path:
-                old.unlink()
+        if no_encrypt:
+            warning("Unencrypted backup can contain credentials.")
+
+            def copy_to_temp(temp_path: Path) -> None:
+                shutil.copyfile(staged_archive, temp_path)
+
+            _publish_archive(
+                archive_path,
+                copy_to_temp,
+            )
+        else:
+            _require_age()
+            if not _has_controlling_terminal():
+                error(
+                    "A controlling terminal is required for the age passphrase prompt. "
+                    "Use an interactive terminal or --no-encrypt."
+                )
+                raise typer.Exit(1)
+            warning(
+                "age will prompt for a passphrase; empty input generates a passphrase shown once. "
+                "After success, an older unencrypted backup is removed."
+            )
+
+            def encrypt_to_temp(temp_path: Path) -> None:
+                result = subprocess.run(
+                    _age_encrypt_argv(staged_archive, temp_path),
+                    check=False,
+                )
+                if result.returncode != 0:
+                    error("Backup encryption failed; the previous backup is unchanged.")
+                    raise typer.Exit(1)
+
+            archive_path = Path(f"{archive_path}.age")
+            _publish_archive(archive_path, encrypt_to_temp)
 
         blank()
         success(f"Backup saved: {archive_path}")
+
+        for old in _list_backups():
+            if old != archive_path:
+                try:
+                    old.unlink()
+                    if old.suffix != ".age":
+                        info(f"Removed unencrypted backup: {old.name}")
+                except OSError as exc:
+                    warning(f"Failed to remove old backup {old.name}: {exc}")
 
     finally:
         try:
@@ -153,13 +271,23 @@ def restore() -> None:
     _guard_no_containers_running()
     config = load_config()
 
-    backups = sorted(BACKUPS_DIR.glob("djinn-backup-*.tar.gz")) if BACKUPS_DIR.exists() else []
+    backups = _list_backups()
 
     if not backups:
         error(f"No backup found in {BACKUPS_DIR}")
         raise typer.Exit(1)
 
     backup_file = backups[-1]
+
+    try:
+        encrypted = _has_age_header(backup_file)
+    except OSError as exc:
+        error(f"Backup archive cannot be read: {exc}")
+        raise typer.Exit(1) from exc
+
+    if backup_file.suffix == ".age" and not encrypted:
+        error(f"Backup archive {backup_file.name} ends in .age but lacks an age encryption header.")
+        raise typer.Exit(1)
 
     blank()
     info(f"Restoring from: {backup_file.name}")
@@ -170,10 +298,32 @@ def restore() -> None:
     )
 
     staging_dir = Path(tempfile.mkdtemp(prefix="djinn-restore-"))
+    decrypt_dir: Path | None = None
 
     try:
-        with tarfile.open(backup_file, "r:gz") as tar:
-            tar.extractall(path=staging_dir, filter="data")
+        archive_to_extract = backup_file
+        if encrypted:
+            _require_age()
+            if not _has_controlling_terminal():
+                error("A controlling terminal is required for the age passphrase prompt.")
+                raise typer.Exit(1)
+            decrypt_dir = staging_dir / "decrypted"
+            decrypt_dir.mkdir(mode=0o700)
+            archive_to_extract = decrypt_dir / "backup.tar.gz"
+            result = subprocess.run(
+                _age_decrypt_argv(backup_file, archive_to_extract),
+                check=False,
+            )
+            if result.returncode != 0:
+                error("Backup decryption failed; check the passphrase and archive integrity.")
+                raise typer.Exit(1)
+
+        try:
+            with tarfile.open(archive_to_extract, "r:gz") as tar:
+                tar.extractall(path=staging_dir, filter="data")
+        except (tarfile.TarError, EOFError, gzip.BadGzipFile, OSError) as exc:
+            error(f"Backup is neither a valid age archive nor a readable gzip tar: {exc}")
+            raise typer.Exit(1) from exc
 
         inner_archives = sorted(staging_dir.glob("*.tar.gz"))
 
@@ -211,6 +361,11 @@ def restore() -> None:
         success(f"Restore complete: {len(inner_archives)} item(s)")
 
     finally:
+        if decrypt_dir is not None:
+            try:
+                shutil.rmtree(decrypt_dir)
+            except OSError as exc:
+                warning(f"Failed to clean up decrypted backup archive: {exc}")
         try:
             shutil.rmtree(staging_dir)
         except OSError as e:

--- a/tests/test_commands/test_backup.py
+++ b/tests/test_commands/test_backup.py
@@ -205,7 +205,9 @@ class TestBackupCommand:
             assert archives[0].read_bytes().startswith(b"age-encryption.org/v1\n")
             assert str(staged_outer) not in added_paths
 
-    def test_backup_replaces_previous(self, tmp_path: Path) -> None:
+    def test_backup_replaces_previous(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
         backups_dir = tmp_path / "backups"
         backups_dir.mkdir()
         old_backup = backups_dir / "djinn-backup-2026-01-01.tar.gz"
@@ -237,6 +239,10 @@ class TestBackupCommand:
             assert not old_backup.exists()
             archives = list(backups_dir.glob("djinn-backup-*.tar.gz.age"))
             assert len(archives) == 1
+
+        message = capsys.readouterr().err
+        assert "Removed unencrypted backup" in message
+        assert old_backup.name in message
 
     def test_backup_aborts_on_volume_failure(self, tmp_path: Path) -> None:
         staging_dir = tmp_path / "staging"
@@ -514,6 +520,8 @@ class TestBackupCommand:
 
         def run_age(argv: list[str], **_: object) -> subprocess.CompletedProcess[str]:
             events.append("age")
+            temp_path = Path(argv[argv.index("-o") + 1])
+            temp_path.write_bytes(b"age-encryption.org/v1\n")
             return subprocess.CompletedProcess(argv, 0)
 
         with (
@@ -545,6 +553,59 @@ class TestBackupCommand:
         assert argv[2] == "-o"
         assert mock_subprocess.run.call_args.kwargs == {"check": False}
         assert events.index("warning") < events.index("age")
+
+    @pytest.mark.parametrize(
+        "age_output",
+        [
+            pytest.param(b"", id="zero-byte"),
+            pytest.param(b"not age", id="nonempty-without-header"),
+        ],
+    )
+    def test_zero_byte_age_success_preserves_same_day_previous_archive(
+        self, tmp_path: Path, age_output: bytes
+    ) -> None:
+        backups_dir = tmp_path / "backups"
+        backups_dir.mkdir()
+        date_str = datetime.now(tz=UTC).strftime("%Y-%m-%d")
+        previous = backups_dir / f"djinn-backup-{date_str}.tar.gz.age"
+        previous_bytes = b"age-encryption.org/v1\nknown-good"
+        previous.write_bytes(previous_bytes)
+        staging_dir = tmp_path / "staging"
+        staging_dir.mkdir()
+        inner_archive = staging_dir / "djinn-claude-config.tar.gz"
+        with tarfile.open(inner_archive, "w:gz"):
+            pass
+
+        def run_age(argv: list[str], **_: object) -> subprocess.CompletedProcess[str]:
+            temp_path = Path(argv[argv.index("-o") + 1])
+            temp_path.write_bytes(age_output)
+            return subprocess.CompletedProcess(argv, 0)
+
+        with (
+            patch("djinn_in_a_box.commands.backup.get_running_containers", return_value=[]),
+            patch(
+                "djinn_in_a_box.commands.backup.get_existing_volumes_by_category",
+                return_value=["djinn-claude-config"],
+            ),
+            patch(
+                "djinn_in_a_box.commands.backup.get_existing_sync_paths_by_category",
+                return_value=[],
+            ),
+            patch(
+                "djinn_in_a_box.commands.backup.backup_volume", return_value=RunResult(0, "", "")
+            ),
+            patch("djinn_in_a_box.commands.backup.BACKUPS_DIR", backups_dir),
+            patch("djinn_in_a_box.commands.backup.tempfile.mkdtemp", return_value=str(staging_dir)),
+            patch("djinn_in_a_box.commands.backup.subprocess") as mock_subprocess,
+            pytest.raises(typer.Exit) as exc_info,
+        ):
+            mock_subprocess.run.side_effect = run_age
+            backup_module.backup()
+
+        assert exc_info.value.exit_code == 1
+        assert previous.read_bytes() == previous_bytes
+        assert list(backups_dir.glob("djinn-backup-*.tar.gz.age")) == [previous]
+        assert not list(backups_dir.glob(".djinn-backup-*"))
 
     def test_backup_missing_age_explains_the_opt_out(
         self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
@@ -611,7 +672,10 @@ class TestBackupCommand:
             backup_module.backup()
 
         assert exc_info.value.exit_code == 1
-        assert "controlling terminal" in capsys.readouterr().err
+        message = capsys.readouterr().err
+        assert "controlling terminal" in message
+        assert "interactive terminal" in message
+        assert "--no-encrypt" in message
         assert not list(backups_dir.glob("djinn-backup-*"))
 
     def test_encryption_failure_preserves_previous_backup_and_cleans_temp(
@@ -663,6 +727,33 @@ class TestRestoreCommand:
                 backup_module.restore()
             assert exc_info.value.exit_code == 1
 
+    def test_restore_missing_age_explains_installation_without_backup_opt_out(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        backups_dir = tmp_path / "backups"
+        backups_dir.mkdir()
+        staging_dir = tmp_path / "staging"
+        staging_dir.mkdir()
+        (backups_dir / "djinn-backup-2026-03-13.tar.gz.age").write_bytes(
+            b"age-encryption.org/v1\nplaceholder"
+        )
+
+        with (
+            patch("djinn_in_a_box.commands.backup.get_running_containers", return_value=[]),
+            patch("djinn_in_a_box.commands.backup.BACKUPS_DIR", backups_dir),
+            patch("djinn_in_a_box.commands.backup.tempfile.mkdtemp", return_value=str(staging_dir)),
+            patch("djinn_in_a_box.commands.backup.typer.confirm"),
+            patch("djinn_in_a_box.commands.backup.shutil.which", return_value=None),
+            pytest.raises(typer.Exit) as exc_info,
+        ):
+            backup_module.restore()
+
+        assert exc_info.value.exit_code == 1
+        message = capsys.readouterr().err
+        assert "age is required to restore" in message
+        assert "Install age" in message
+        assert "--no-encrypt" not in message
+
     def test_exits_when_no_backup_found(self, tmp_path: Path) -> None:
         backups_dir = tmp_path / "backups"
         backups_dir.mkdir()
@@ -678,6 +769,8 @@ class TestRestoreCommand:
     def test_restore_restores_volumes(self, tmp_path: Path) -> None:
         backups_dir = tmp_path / "backups"
         backups_dir.mkdir()
+        backups_dir.chmod(0o775)
+        assert backups_dir.stat().st_mode & 0o777 == 0o775
         staging_dir = tmp_path / "staging"
         staging_dir.mkdir()
 
@@ -707,6 +800,8 @@ class TestRestoreCommand:
 
             mock_restore.assert_called_once_with("djinn-claude-config", staging_dir)
             mock_subprocess.run.assert_not_called()
+
+        assert backups_dir.stat().st_mode & 0o777 == 0o700
 
     def test_restore_handles_failure(self, tmp_path: Path) -> None:
         backups_dir = tmp_path / "backups"
@@ -928,7 +1023,35 @@ class TestRestoreCommand:
         mock_restore.assert_not_called()
         assert not staging_dir.exists()
 
-    def test_restore_rejects_age_name_without_header(self, tmp_path: Path) -> None:
+    def test_restore_without_controlling_terminal_exits_with_recovery_hint(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        backups_dir = tmp_path / "backups"
+        backups_dir.mkdir()
+        staging_dir = tmp_path / "staging"
+        staging_dir.mkdir()
+        (backups_dir / "djinn-backup-2026-03-13.tar.gz.age").write_bytes(
+            b"age-encryption.org/v1\nplaceholder"
+        )
+
+        with (
+            patch("djinn_in_a_box.commands.backup.get_running_containers", return_value=[]),
+            patch("djinn_in_a_box.commands.backup.BACKUPS_DIR", backups_dir),
+            patch("djinn_in_a_box.commands.backup.tempfile.mkdtemp", return_value=str(staging_dir)),
+            patch("djinn_in_a_box.commands.backup.typer.confirm"),
+            patch("djinn_in_a_box.commands.backup._has_controlling_terminal", return_value=False),
+            pytest.raises(typer.Exit) as exc_info,
+        ):
+            backup_module.restore()
+
+        assert exc_info.value.exit_code == 1
+        message = capsys.readouterr().err
+        assert "controlling terminal" in message
+        assert "interactive terminal" in message
+
+    def test_restore_rejects_age_name_without_header(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
         backups_dir = tmp_path / "backups"
         backups_dir.mkdir()
         (backups_dir / "djinn-backup-2026-03-13.tar.gz.age").write_bytes(b"not age")
@@ -943,8 +1066,11 @@ class TestRestoreCommand:
 
         assert exc_info.value.exit_code == 1
         mock_confirm.assert_not_called()
+        assert "intact age-encrypted archive" in capsys.readouterr().err
 
-    def test_restore_invalid_legacy_archive_has_format_error(self, tmp_path: Path) -> None:
+    def test_restore_invalid_legacy_archive_has_format_error(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
         backups_dir = tmp_path / "backups"
         backups_dir.mkdir()
         (backups_dir / "djinn-backup-2026-03-13.tar.gz").write_bytes(b"bad")
@@ -958,6 +1084,9 @@ class TestRestoreCommand:
             backup_module.restore()
 
         assert exc_info.value.exit_code == 1
+        message = capsys.readouterr().err
+        assert "neither a valid age archive nor a readable gzip tar" in message
+        assert "intact backup archive" in message
 
     def test_age_recipient_round_trip_uses_production_file_orchestration(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch

--- a/tests/test_commands/test_backup.py
+++ b/tests/test_commands/test_backup.py
@@ -2,8 +2,12 @@
 
 from __future__ import annotations
 
+import subprocess
 import tarfile
+from collections.abc import Callable, Generator, Iterator
+from datetime import UTC, datetime
 from pathlib import Path
+from typing import Any, cast
 from unittest.mock import patch
 
 import pytest
@@ -16,9 +20,28 @@ from djinn_in_a_box.core.docker import RunResult
 
 
 @pytest.fixture(autouse=True)
-def mock_backup_config(mock_app_config: AppConfig) -> None:
+def mock_backup_config(mock_app_config: AppConfig) -> Generator[None]:
     """Existing command tests do not exercise config loading."""
     with patch("djinn_in_a_box.commands.backup.load_config", return_value=mock_app_config):
+        yield
+
+
+@pytest.fixture(autouse=True)
+def mock_age_for_backup_commands() -> Generator[None]:
+    """Keep command tests non-interactive while preserving age orchestration."""
+
+    def encrypt_for_test(argv: list[str], **_: object) -> subprocess.CompletedProcess[str]:
+        temp_path = Path(argv[argv.index("-o") + 1])
+        archive_source = Path(argv[-1])
+        temp_path.write_bytes(b"age-encryption.org/v1\n" + archive_source.read_bytes())
+        return subprocess.CompletedProcess(argv, 0)
+
+    with (
+        patch("djinn_in_a_box.commands.backup.shutil.which", return_value="/usr/bin/age"),
+        patch("djinn_in_a_box.commands.backup._has_controlling_terminal", return_value=True),
+        patch("djinn_in_a_box.commands.backup.subprocess") as mock_subprocess,
+    ):
+        mock_subprocess.run.side_effect = encrypt_for_test
         yield
 
 
@@ -137,6 +160,22 @@ class TestBackupCommand:
         backups_dir = tmp_path / "backups"
         staging_dir = tmp_path / "staging"
         staging_dir.mkdir()
+        staged_outer = staging_dir / f"djinn-backup-{datetime.now(tz=UTC):%Y-%m-%d}.tar.gz"
+        real_iterdir = Path.iterdir
+        real_add = cast(Callable[..., Any], tarfile.TarFile.add)
+        added_paths: list[str] = []
+
+        def include_staged_outer(path: Path) -> Iterator[Path]:
+            children = list(real_iterdir(path))
+            if path == staging_dir:
+                children.append(staged_outer)
+            return iter(children)
+
+        def record_add(
+            archive: tarfile.TarFile, name: str, *args: object, **kwargs: object
+        ) -> None:
+            added_paths.append(name)
+            real_add(archive, name, *args, **kwargs)
 
         with (
             patch("djinn_in_a_box.commands.backup.get_running_containers", return_value=[]),
@@ -147,11 +186,12 @@ class TestBackupCommand:
             ),
             patch("djinn_in_a_box.commands.backup.backup_volume") as mock_backup,
             patch("djinn_in_a_box.commands.backup.BACKUPS_DIR", backups_dir),
-            patch("djinn_in_a_box.commands.backup.tempfile") as mock_tempfile,
+            patch("djinn_in_a_box.commands.backup.tempfile.mkdtemp", return_value=str(staging_dir)),
+            patch.object(Path, "iterdir", new=include_staged_outer),
+            patch.object(tarfile.TarFile, "add", new=record_add),
         ):
             mock_get.side_effect = [["djinn-claude-config"], [], []]
             mock_backup.return_value = RunResult(returncode=0, stdout="", stderr="")
-            mock_tempfile.mkdtemp.return_value = str(staging_dir)
 
             fake_archive = staging_dir / "djinn-claude-config.tar.gz"
             with tarfile.open(fake_archive, "w:gz") as _tar:
@@ -160,8 +200,10 @@ class TestBackupCommand:
             backup_module.backup()
 
             mock_backup.assert_called_once_with("djinn-claude-config", staging_dir)
-            archives = list(backups_dir.glob("djinn-backup-*.tar.gz"))
+            archives = list(backups_dir.glob("djinn-backup-*.tar.gz.age"))
             assert len(archives) == 1
+            assert archives[0].read_bytes().startswith(b"age-encryption.org/v1\n")
+            assert str(staged_outer) not in added_paths
 
     def test_backup_replaces_previous(self, tmp_path: Path) -> None:
         backups_dir = tmp_path / "backups"
@@ -181,11 +223,10 @@ class TestBackupCommand:
             ),
             patch("djinn_in_a_box.commands.backup.backup_volume") as mock_backup,
             patch("djinn_in_a_box.commands.backup.BACKUPS_DIR", backups_dir),
-            patch("djinn_in_a_box.commands.backup.tempfile") as mock_tempfile,
+            patch("djinn_in_a_box.commands.backup.tempfile.mkdtemp", return_value=str(staging_dir)),
         ):
             mock_get.return_value = ["djinn-claude-config"]
             mock_backup.return_value = RunResult(returncode=0, stdout="", stderr="")
-            mock_tempfile.mkdtemp.return_value = str(staging_dir)
 
             fake_archive = staging_dir / "djinn-claude-config.tar.gz"
             with tarfile.open(fake_archive, "w:gz") as _tar:
@@ -194,7 +235,7 @@ class TestBackupCommand:
             backup_module.backup()
 
             assert not old_backup.exists()
-            archives = list(backups_dir.glob("djinn-backup-*.tar.gz"))
+            archives = list(backups_dir.glob("djinn-backup-*.tar.gz.age"))
             assert len(archives) == 1
 
     def test_backup_aborts_on_volume_failure(self, tmp_path: Path) -> None:
@@ -233,11 +274,10 @@ class TestBackupCommand:
             ),
             patch("djinn_in_a_box.commands.backup.backup_volume") as mock_backup,
             patch("djinn_in_a_box.commands.backup.BACKUPS_DIR", backups_dir),
-            patch("djinn_in_a_box.commands.backup.tempfile") as mock_tempfile,
+            patch("djinn_in_a_box.commands.backup.tempfile.mkdtemp", return_value=str(staging_dir)),
         ):
             mock_get.return_value = ["djinn-uv-cache"]
             mock_backup.return_value = RunResult(returncode=0, stdout="", stderr="")
-            mock_tempfile.mkdtemp.return_value = str(staging_dir)
 
             fake_archive = staging_dir / "djinn-uv-cache.tar.gz"
             with tarfile.open(fake_archive, "w:gz") as _tar:
@@ -274,14 +314,344 @@ class TestBackupCommand:
             ),
             patch("djinn_in_a_box.commands.backup.backup_sync_path") as mock_backup_sync,
             patch("djinn_in_a_box.commands.backup.BACKUPS_DIR", backups_dir),
-            patch("djinn_in_a_box.commands.backup.tempfile") as mock_tempfile,
+            patch("djinn_in_a_box.commands.backup.tempfile.mkdtemp", return_value=str(staging_dir)),
         ):
             mock_backup_sync.return_value = RunResult(returncode=0, stdout="", stderr="")
-            mock_tempfile.mkdtemp.return_value = str(staging_dir)
 
             backup_module.backup(categories=["credentials"])
 
         mock_backup_sync.assert_called_once_with(configured_root / "claude", staging_dir)
+
+    def test_backup_tightens_existing_directory_and_archive_modes(self, tmp_path: Path) -> None:
+        backups_dir = tmp_path / "backups"
+        backups_dir.mkdir(mode=0o755)
+        backups_dir.chmod(0o755)
+        staging_dir = tmp_path / "staging"
+        staging_dir.mkdir()
+        inner_archive = staging_dir / "djinn-claude-config.tar.gz"
+        with tarfile.open(inner_archive, "w:gz"):
+            pass
+        real_mkstemp = backup_module.tempfile.mkstemp
+
+        with (
+            patch("djinn_in_a_box.commands.backup.get_running_containers", return_value=[]),
+            patch(
+                "djinn_in_a_box.commands.backup.get_existing_volumes_by_category",
+                return_value=["djinn-claude-config"],
+            ),
+            patch(
+                "djinn_in_a_box.commands.backup.get_existing_sync_paths_by_category",
+                return_value=[],
+            ),
+            patch(
+                "djinn_in_a_box.commands.backup.backup_volume", return_value=RunResult(0, "", "")
+            ),
+            patch("djinn_in_a_box.commands.backup.BACKUPS_DIR", backups_dir),
+            patch("djinn_in_a_box.commands.backup.tempfile.mkdtemp", return_value=str(staging_dir)),
+            patch(
+                "djinn_in_a_box.commands.backup.tempfile.mkstemp", wraps=real_mkstemp
+            ) as mock_mkstemp,
+        ):
+            backup_module.backup()
+
+        archive = next(backups_dir.glob("djinn-backup-*.tar.gz.age"))
+        assert backups_dir.stat().st_mode & 0o777 == 0o700
+        assert archive.stat().st_mode & 0o777 == 0o600
+        assert mock_mkstemp.call_args.kwargs["dir"] == backups_dir
+
+    def test_backup_preserves_previous_archive_when_publication_fails(self, tmp_path: Path) -> None:
+        backups_dir = tmp_path / "backups"
+        backups_dir.mkdir()
+        previous = backups_dir / "djinn-backup-2026-01-01.tar.gz"
+        previous.write_bytes(b"known-good")
+        staging_dir = tmp_path / "staging"
+        staging_dir.mkdir()
+        inner_archive = staging_dir / "djinn-claude-config.tar.gz"
+        with tarfile.open(inner_archive, "w:gz"):
+            pass
+
+        with (
+            patch("djinn_in_a_box.commands.backup.get_running_containers", return_value=[]),
+            patch(
+                "djinn_in_a_box.commands.backup.get_existing_volumes_by_category",
+                return_value=["djinn-claude-config"],
+            ),
+            patch(
+                "djinn_in_a_box.commands.backup.get_existing_sync_paths_by_category",
+                return_value=[],
+            ),
+            patch(
+                "djinn_in_a_box.commands.backup.backup_volume", return_value=RunResult(0, "", "")
+            ),
+            patch("djinn_in_a_box.commands.backup.BACKUPS_DIR", backups_dir),
+            patch("djinn_in_a_box.commands.backup.tempfile.mkdtemp", return_value=str(staging_dir)),
+            patch("djinn_in_a_box.commands.backup.os.replace", side_effect=OSError("disk full")),
+            pytest.raises(OSError, match="disk full"),
+        ):
+            backup_module.backup()
+
+        assert previous.read_bytes() == b"known-good"
+        assert not list(backups_dir.glob(".djinn-backup-*"))
+
+    def test_backup_reports_rotation_failure_after_publication(self, tmp_path: Path) -> None:
+        backups_dir = tmp_path / "backups"
+        backups_dir.mkdir()
+        previous = backups_dir / "djinn-backup-2026-01-01.tar.gz"
+        previous.touch()
+        staging_dir = tmp_path / "staging"
+        staging_dir.mkdir()
+        inner_archive = staging_dir / "djinn-claude-config.tar.gz"
+        with tarfile.open(inner_archive, "w:gz"):
+            pass
+        original_unlink = Path.unlink
+        events: list[tuple[str, str]] = []
+        warnings: list[str] = []
+
+        def fail_for_previous(path: Path, missing_ok: bool = False) -> None:
+            if path == previous:
+                raise OSError("permission denied")
+            original_unlink(path, missing_ok=missing_ok)
+
+        def record_success(message: str) -> None:
+            events.append(("success", message))
+
+        def record_warning(message: str) -> None:
+            events.append(("warning", message))
+            warnings.append(message)
+
+        with (
+            patch("djinn_in_a_box.commands.backup.get_running_containers", return_value=[]),
+            patch(
+                "djinn_in_a_box.commands.backup.get_existing_volumes_by_category",
+                return_value=["djinn-claude-config"],
+            ),
+            patch(
+                "djinn_in_a_box.commands.backup.get_existing_sync_paths_by_category",
+                return_value=[],
+            ),
+            patch(
+                "djinn_in_a_box.commands.backup.backup_volume", return_value=RunResult(0, "", "")
+            ),
+            patch("djinn_in_a_box.commands.backup.BACKUPS_DIR", backups_dir),
+            patch("djinn_in_a_box.commands.backup.tempfile.mkdtemp", return_value=str(staging_dir)),
+            patch.object(Path, "unlink", new=fail_for_previous),
+            patch(
+                "djinn_in_a_box.commands.backup.success",
+                side_effect=record_success,
+            ),
+            patch(
+                "djinn_in_a_box.commands.backup.warning",
+                side_effect=record_warning,
+            ),
+        ):
+            backup_module.backup()
+
+        assert previous.exists()
+        assert (
+            len(list(backups_dir.glob("djinn-backup-*.tar.gz")))
+            + len(list(backups_dir.glob("djinn-backup-*.tar.gz.age")))
+            == 2
+        )
+        saved_at = next(
+            index
+            for index, (_, message) in enumerate(events)
+            if message.startswith("Backup saved:")
+        )
+        warned_at = next(
+            index
+            for index, (kind, message) in enumerate(events)
+            if kind == "warning" and message.startswith("Failed to remove old backup")
+        )
+        assert saved_at < warned_at
+        assert "djinn-backup-2026-01-01.tar.gz" in warnings[-1]
+
+    def test_backup_no_encrypt_publishes_cleartext_without_calling_age(
+        self, tmp_path: Path
+    ) -> None:
+        backups_dir = tmp_path / "backups"
+        staging_dir = tmp_path / "staging"
+        staging_dir.mkdir()
+        inner_archive = staging_dir / "djinn-claude-config.tar.gz"
+        with tarfile.open(inner_archive, "w:gz"):
+            pass
+
+        with (
+            patch("djinn_in_a_box.commands.backup.get_running_containers", return_value=[]),
+            patch(
+                "djinn_in_a_box.commands.backup.get_existing_volumes_by_category",
+                return_value=["djinn-claude-config"],
+            ),
+            patch(
+                "djinn_in_a_box.commands.backup.get_existing_sync_paths_by_category",
+                return_value=[],
+            ),
+            patch(
+                "djinn_in_a_box.commands.backup.backup_volume", return_value=RunResult(0, "", "")
+            ),
+            patch("djinn_in_a_box.commands.backup.BACKUPS_DIR", backups_dir),
+            patch("djinn_in_a_box.commands.backup.tempfile.mkdtemp", return_value=str(staging_dir)),
+            patch("djinn_in_a_box.commands.backup.subprocess") as mock_subprocess,
+            patch("djinn_in_a_box.commands.backup.warning") as mock_warning,
+        ):
+            backup_module.backup(no_encrypt=True)
+
+        assert len(list(backups_dir.glob("djinn-backup-*.tar.gz"))) == 1
+        assert not list(backups_dir.glob("djinn-backup-*.tar.gz.age"))
+        mock_subprocess.run.assert_not_called()
+        assert "can contain credentials" in mock_warning.call_args.args[0]
+
+    def test_backup_invokes_age_passphrase_without_a_secret(self, tmp_path: Path) -> None:
+        backups_dir = tmp_path / "backups"
+        staging_dir = tmp_path / "staging"
+        staging_dir.mkdir()
+        inner_archive = staging_dir / "djinn-claude-config.tar.gz"
+        with tarfile.open(inner_archive, "w:gz"):
+            pass
+        events: list[str] = []
+
+        def record_warning_for_invocation(_: str) -> None:
+            events.append("warning")
+
+        def run_age(argv: list[str], **_: object) -> subprocess.CompletedProcess[str]:
+            events.append("age")
+            return subprocess.CompletedProcess(argv, 0)
+
+        with (
+            patch("djinn_in_a_box.commands.backup.get_running_containers", return_value=[]),
+            patch(
+                "djinn_in_a_box.commands.backup.get_existing_volumes_by_category",
+                return_value=["djinn-claude-config"],
+            ),
+            patch(
+                "djinn_in_a_box.commands.backup.get_existing_sync_paths_by_category",
+                return_value=[],
+            ),
+            patch(
+                "djinn_in_a_box.commands.backup.backup_volume", return_value=RunResult(0, "", "")
+            ),
+            patch("djinn_in_a_box.commands.backup.BACKUPS_DIR", backups_dir),
+            patch("djinn_in_a_box.commands.backup.tempfile.mkdtemp", return_value=str(staging_dir)),
+            patch("djinn_in_a_box.commands.backup.subprocess") as mock_subprocess,
+            patch(
+                "djinn_in_a_box.commands.backup.warning",
+                side_effect=record_warning_for_invocation,
+            ),
+        ):
+            mock_subprocess.run.side_effect = run_age
+            backup_module.backup()
+
+        argv = mock_subprocess.run.call_args.args[0]
+        assert argv[:2] == ["age", "--passphrase"]
+        assert argv[2] == "-o"
+        assert mock_subprocess.run.call_args.kwargs == {"check": False}
+        assert events.index("warning") < events.index("age")
+
+    def test_backup_missing_age_explains_the_opt_out(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        backups_dir = tmp_path / "backups"
+        staging_dir = tmp_path / "staging"
+        staging_dir.mkdir()
+        inner_archive = staging_dir / "djinn-claude-config.tar.gz"
+        with tarfile.open(inner_archive, "w:gz"):
+            pass
+
+        with (
+            patch("djinn_in_a_box.commands.backup.get_running_containers", return_value=[]),
+            patch(
+                "djinn_in_a_box.commands.backup.get_existing_volumes_by_category",
+                return_value=["djinn-claude-config"],
+            ),
+            patch(
+                "djinn_in_a_box.commands.backup.get_existing_sync_paths_by_category",
+                return_value=[],
+            ),
+            patch(
+                "djinn_in_a_box.commands.backup.backup_volume", return_value=RunResult(0, "", "")
+            ),
+            patch("djinn_in_a_box.commands.backup.BACKUPS_DIR", backups_dir),
+            patch("djinn_in_a_box.commands.backup.tempfile.mkdtemp", return_value=str(staging_dir)),
+            patch("djinn_in_a_box.commands.backup.shutil.which", return_value=None),
+            pytest.raises(typer.Exit) as exc_info,
+        ):
+            backup_module.backup()
+
+        assert exc_info.value.exit_code == 1
+        assert "Install age or use --no-encrypt" in capsys.readouterr().err
+        assert not list(backups_dir.glob("djinn-backup-*"))
+
+    def test_backup_without_a_controlling_terminal_exits_before_publication(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        backups_dir = tmp_path / "backups"
+        staging_dir = tmp_path / "staging"
+        staging_dir.mkdir()
+        inner_archive = staging_dir / "djinn-claude-config.tar.gz"
+        with tarfile.open(inner_archive, "w:gz"):
+            pass
+
+        with (
+            patch("djinn_in_a_box.commands.backup.get_running_containers", return_value=[]),
+            patch(
+                "djinn_in_a_box.commands.backup.get_existing_volumes_by_category",
+                return_value=["djinn-claude-config"],
+            ),
+            patch(
+                "djinn_in_a_box.commands.backup.get_existing_sync_paths_by_category",
+                return_value=[],
+            ),
+            patch(
+                "djinn_in_a_box.commands.backup.backup_volume", return_value=RunResult(0, "", "")
+            ),
+            patch("djinn_in_a_box.commands.backup.BACKUPS_DIR", backups_dir),
+            patch("djinn_in_a_box.commands.backup.tempfile.mkdtemp", return_value=str(staging_dir)),
+            patch("djinn_in_a_box.commands.backup._has_controlling_terminal", return_value=False),
+            pytest.raises(typer.Exit) as exc_info,
+        ):
+            backup_module.backup()
+
+        assert exc_info.value.exit_code == 1
+        assert "controlling terminal" in capsys.readouterr().err
+        assert not list(backups_dir.glob("djinn-backup-*"))
+
+    def test_encryption_failure_preserves_previous_backup_and_cleans_temp(
+        self, tmp_path: Path
+    ) -> None:
+        backups_dir = tmp_path / "backups"
+        backups_dir.mkdir()
+        previous = backups_dir / "djinn-backup-2026-01-01.tar.gz"
+        previous.write_bytes(b"known-good")
+        staging_dir = tmp_path / "staging"
+        staging_dir.mkdir()
+        inner_archive = staging_dir / "djinn-claude-config.tar.gz"
+        with tarfile.open(inner_archive, "w:gz"):
+            pass
+
+        with (
+            patch("djinn_in_a_box.commands.backup.get_running_containers", return_value=[]),
+            patch(
+                "djinn_in_a_box.commands.backup.get_existing_volumes_by_category",
+                return_value=["djinn-claude-config"],
+            ),
+            patch(
+                "djinn_in_a_box.commands.backup.get_existing_sync_paths_by_category",
+                return_value=[],
+            ),
+            patch(
+                "djinn_in_a_box.commands.backup.backup_volume", return_value=RunResult(0, "", "")
+            ),
+            patch("djinn_in_a_box.commands.backup.BACKUPS_DIR", backups_dir),
+            patch("djinn_in_a_box.commands.backup.tempfile.mkdtemp", return_value=str(staging_dir)),
+            patch("djinn_in_a_box.commands.backup.subprocess") as mock_subprocess,
+            pytest.raises(typer.Exit) as exc_info,
+        ):
+            mock_subprocess.run.return_value = subprocess.CompletedProcess([], 1)
+            backup_module.backup()
+
+        assert exc_info.value.exit_code == 1
+        assert previous.read_bytes() == b"known-good"
+        assert not list(backups_dir.glob(".djinn-backup-*"))
+        assert not list(backups_dir.glob("djinn-backup-*.tar.gz.age"))
 
 
 class TestRestoreCommand:
@@ -328,6 +698,7 @@ class TestRestoreCommand:
             patch("djinn_in_a_box.commands.backup.restore_volume") as mock_restore,
             patch("djinn_in_a_box.commands.backup.tempfile") as mock_tempfile,
             patch("djinn_in_a_box.commands.backup.typer.confirm"),
+            patch("djinn_in_a_box.commands.backup.subprocess") as mock_subprocess,
         ):
             mock_restore.return_value = RunResult(returncode=0, stdout="", stderr="")
             mock_tempfile.mkdtemp.return_value = str(staging_dir)
@@ -335,6 +706,7 @@ class TestRestoreCommand:
             backup_module.restore()
 
             mock_restore.assert_called_once_with("djinn-claude-config", staging_dir)
+            mock_subprocess.run.assert_not_called()
 
     def test_restore_handles_failure(self, tmp_path: Path) -> None:
         backups_dir = tmp_path / "backups"
@@ -489,9 +861,225 @@ class TestRestoreCommand:
 
         assert (configured_root / "claude" / "token.txt").read_text() == "secret\n"
 
+    def test_restore_decrypts_age_archive_before_restoring(self, tmp_path: Path) -> None:
+        backups_dir = tmp_path / "backups"
+        backups_dir.mkdir()
+        staging_dir = tmp_path / "staging"
+        staging_dir.mkdir()
+        inner_dir = tmp_path / "inner"
+        inner_dir.mkdir()
+        inner_archive = inner_dir / "djinn-claude-config.tar.gz"
+        with tarfile.open(inner_archive, "w:gz"):
+            pass
+        outer_archive = tmp_path / "outer.tar.gz"
+        with tarfile.open(outer_archive, "w:gz") as outer:
+            outer.add(inner_archive, arcname=inner_archive.name)
+        (backups_dir / "djinn-backup-2026-03-13.tar.gz").write_bytes(b"legacy")
+        encrypted_backup = backups_dir / "djinn-backup-2026-03-13.tar.gz.age"
+        encrypted_backup.write_bytes(b"age-encryption.org/v1\nplaceholder")
+
+        def decrypt_for_test(argv: list[str], **_: object) -> subprocess.CompletedProcess[str]:
+            Path(argv[argv.index("-o") + 1]).write_bytes(outer_archive.read_bytes())
+            return subprocess.CompletedProcess(argv, 0)
+
+        with (
+            patch("djinn_in_a_box.commands.backup.get_running_containers", return_value=[]),
+            patch("djinn_in_a_box.commands.backup.BACKUPS_DIR", backups_dir),
+            patch("djinn_in_a_box.commands.backup.restore_volume") as mock_restore,
+            patch("djinn_in_a_box.commands.backup.tempfile.mkdtemp", return_value=str(staging_dir)),
+            patch("djinn_in_a_box.commands.backup.typer.confirm"),
+            patch("djinn_in_a_box.commands.backup.subprocess") as mock_subprocess,
+        ):
+            mock_restore.return_value = RunResult(0, "", "")
+            mock_subprocess.run.side_effect = decrypt_for_test
+            backup_module.restore()
+
+        argv = mock_subprocess.run.call_args.args[0]
+        assert argv[:2] == ["age", "--decrypt"]
+        assert mock_restore.call_count == 1
+        assert mock_restore.call_args.args[0] == "djinn-claude-config"
+        assert not staging_dir.exists()
+
+    def test_restore_decryption_failure_cleans_partial_cleartext(self, tmp_path: Path) -> None:
+        backups_dir = tmp_path / "backups"
+        backups_dir.mkdir()
+        staging_dir = tmp_path / "staging"
+        staging_dir.mkdir()
+        encrypted_backup = backups_dir / "djinn-backup-2026-03-13.tar.gz.age"
+        encrypted_backup.write_bytes(b"age-encryption.org/v1\nplaceholder")
+
+        def partial_decrypt(argv: list[str], **_: object) -> subprocess.CompletedProcess[str]:
+            Path(argv[argv.index("-o") + 1]).write_bytes(b"partial cleartext")
+            return subprocess.CompletedProcess(argv, 1)
+
+        with (
+            patch("djinn_in_a_box.commands.backup.get_running_containers", return_value=[]),
+            patch("djinn_in_a_box.commands.backup.BACKUPS_DIR", backups_dir),
+            patch("djinn_in_a_box.commands.backup.tempfile.mkdtemp", return_value=str(staging_dir)),
+            patch("djinn_in_a_box.commands.backup.typer.confirm"),
+            patch("djinn_in_a_box.commands.backup.subprocess") as mock_subprocess,
+            patch("djinn_in_a_box.commands.backup.restore_volume") as mock_restore,
+            pytest.raises(typer.Exit) as exc_info,
+        ):
+            mock_subprocess.run.side_effect = partial_decrypt
+            backup_module.restore()
+
+        assert exc_info.value.exit_code == 1
+        mock_restore.assert_not_called()
+        assert not staging_dir.exists()
+
+    def test_restore_rejects_age_name_without_header(self, tmp_path: Path) -> None:
+        backups_dir = tmp_path / "backups"
+        backups_dir.mkdir()
+        (backups_dir / "djinn-backup-2026-03-13.tar.gz.age").write_bytes(b"not age")
+
+        with (
+            patch("djinn_in_a_box.commands.backup.get_running_containers", return_value=[]),
+            patch("djinn_in_a_box.commands.backup.BACKUPS_DIR", backups_dir),
+            patch("djinn_in_a_box.commands.backup.typer.confirm") as mock_confirm,
+            pytest.raises(typer.Exit) as exc_info,
+        ):
+            backup_module.restore()
+
+        assert exc_info.value.exit_code == 1
+        mock_confirm.assert_not_called()
+
+    def test_restore_invalid_legacy_archive_has_format_error(self, tmp_path: Path) -> None:
+        backups_dir = tmp_path / "backups"
+        backups_dir.mkdir()
+        (backups_dir / "djinn-backup-2026-03-13.tar.gz").write_bytes(b"bad")
+
+        with (
+            patch("djinn_in_a_box.commands.backup.get_running_containers", return_value=[]),
+            patch("djinn_in_a_box.commands.backup.BACKUPS_DIR", backups_dir),
+            patch("djinn_in_a_box.commands.backup.typer.confirm"),
+            pytest.raises(typer.Exit) as exc_info,
+        ):
+            backup_module.restore()
+
+        assert exc_info.value.exit_code == 1
+
+    def test_age_recipient_round_trip_uses_production_file_orchestration(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        identity = tmp_path / "test-identity.txt"
+        subprocess.run(["age-keygen", "-o", str(identity)], check=True, capture_output=True)
+        recipient = subprocess.run(
+            ["age-keygen", "-y", str(identity)], check=True, capture_output=True, text=True
+        ).stdout.strip()
+        backups_dir = tmp_path / "backups"
+
+        def write_inner_archive(_: str, staging_dir: Path) -> RunResult:
+            with tarfile.open(staging_dir / "djinn-claude-config.tar.gz", "w:gz"):
+                pass
+            return RunResult(0, "", "")
+
+        def encrypt_for_round_trip(source: Path, output: Path) -> list[str]:
+            return ["age", "-r", recipient, "-o", str(output), str(source)]
+
+        def decrypt_for_round_trip(source: Path, output: Path) -> list[str]:
+            return [
+                "age",
+                "--decrypt",
+                "-i",
+                str(identity),
+                "-o",
+                str(output),
+                str(source),
+            ]
+
+        monkeypatch.setattr(
+            backup_module,
+            "_age_encrypt_argv",
+            encrypt_for_round_trip,
+        )
+        monkeypatch.setattr(
+            backup_module,
+            "_age_decrypt_argv",
+            decrypt_for_round_trip,
+        )
+
+        with (
+            patch("djinn_in_a_box.commands.backup.get_running_containers", return_value=[]),
+            patch(
+                "djinn_in_a_box.commands.backup.get_existing_volumes_by_category",
+                return_value=["djinn-claude-config"],
+            ),
+            patch(
+                "djinn_in_a_box.commands.backup.get_existing_sync_paths_by_category",
+                return_value=[],
+            ),
+            patch("djinn_in_a_box.commands.backup.backup_volume", side_effect=write_inner_archive),
+            patch("djinn_in_a_box.commands.backup.BACKUPS_DIR", backups_dir),
+            patch("djinn_in_a_box.commands.backup.subprocess", subprocess),
+            patch("djinn_in_a_box.commands.backup.typer.confirm"),
+            patch("djinn_in_a_box.commands.backup.restore_volume") as mock_restore,
+        ):
+            mock_restore.return_value = RunResult(0, "", "")
+            backup_module.backup()
+            archive = next(backups_dir.glob("djinn-backup-*.tar.gz.age"))
+            assert archive.read_bytes().startswith(b"age-encryption.org/v1")
+            backup_module.restore()
+
+        mock_restore.assert_called_once()
+
 
 class TestBackupCleanup:
     """Tests for staging directory cleanup."""
+
+    def test_backup_search_uses_only_the_two_archive_patterns(self, tmp_path: Path) -> None:
+        """A trailing-wildcard pattern would sweep up partial writes and let
+        ``sorted()[-1]`` pick one as the newest archive. The unsuffixed name
+        below is the case a hidden temp prefix does not cover.
+        """
+        backups_dir = tmp_path / "backups"
+        backups_dir.mkdir()
+        plain = backups_dir / "djinn-backup-2026-01-01.tar.gz"
+        encrypted = backups_dir / "djinn-backup-2026-01-02.tar.gz.age"
+        hidden_temp = backups_dir / ".djinn-backup-orphan"
+        suffixed = backups_dir / "djinn-backup-2026-01-03.tar.gz.age.part"
+        for archive in (plain, encrypted, hidden_temp, suffixed):
+            archive.touch()
+
+        with patch("djinn_in_a_box.commands.backup.BACKUPS_DIR", backups_dir):
+            assert backup_module._list_backups() == [plain, encrypted]
+
+
+class TestControllingTerminalCheck:
+    """The terminal probe itself -- the module-wide fixture stubs it out."""
+
+    @pytest.fixture(autouse=True)
+    def mock_age_for_backup_commands(self) -> Generator[None]:
+        """Override the module fixture so the real probe runs."""
+        yield
+
+    def test_terminal_check_asks_for_the_controlling_terminal(self) -> None:
+        """`age -p` reads from /dev/tty, not stdin -- a `sys.stdin.isatty()`
+        gate would refuse `djinn backup < /dev/null` from an interactive shell.
+        This pins that the probe opens /dev/tty.
+        """
+        opened: list[str] = []
+
+        def record_open(path: str, *_args: object, **_kwargs: object) -> Any:
+            opened.append(path)
+            msg = "no controlling terminal"
+            raise OSError(msg)
+
+        with patch("builtins.open", side_effect=record_open):
+            assert backup_module._has_controlling_terminal() is False
+
+        assert opened == ["/dev/tty"]
+
+    def test_backup_removes_stale_temp_archives(self, tmp_path: Path) -> None:
+        backups_dir = tmp_path / "backups"
+        backups_dir.mkdir()
+        temp = backups_dir / ".djinn-backup-orphan"
+        temp.touch()
+
+        with patch("djinn_in_a_box.commands.backup.BACKUPS_DIR", backups_dir):
+            backup_module._remove_stale_temp_archives()
+
+        assert not temp.exists()
 
     def test_backup_cleans_staging_on_failure(self, tmp_path: Path) -> None:
         staging_dir = tmp_path / "staging"

--- a/tests/test_commands/test_backup.py
+++ b/tests/test_commands/test_backup.py
@@ -12,11 +12,15 @@ from unittest.mock import patch
 
 import pytest
 import typer
+from typer.testing import CliRunner
 
+from djinn_in_a_box.cli.djinn import app
 from djinn_in_a_box.commands import backup as backup_module
 from djinn_in_a_box.config.loader import load_config, save_config
 from djinn_in_a_box.config.models import AppConfig
 from djinn_in_a_box.core.docker import RunResult
+
+runner = CliRunner()
 
 
 @pytest.fixture(autouse=True)
@@ -243,6 +247,70 @@ class TestBackupCommand:
         message = capsys.readouterr().err
         assert "Removed unencrypted backup" in message
         assert old_backup.name in message
+
+    def test_no_encrypt_replaces_previous_encrypted_archive(self, tmp_path: Path) -> None:
+        backups_dir = tmp_path / "backups"
+        backups_dir.mkdir()
+        old_backup = backups_dir / "djinn-backup-2026-01-01.tar.gz.age"
+        old_backup.write_bytes(b"age-encryption.org/v1\nold")
+        staging_dir = tmp_path / "staging"
+        staging_dir.mkdir()
+        inner_archive = staging_dir / "djinn-claude-config.tar.gz"
+        with tarfile.open(inner_archive, "w:gz"):
+            pass
+
+        with (
+            patch("djinn_in_a_box.commands.backup.get_running_containers", return_value=[]),
+            patch(
+                "djinn_in_a_box.commands.backup.get_existing_volumes_by_category",
+                return_value=["djinn-claude-config"],
+            ),
+            patch(
+                "djinn_in_a_box.commands.backup.get_existing_sync_paths_by_category",
+                return_value=[],
+            ),
+            patch(
+                "djinn_in_a_box.commands.backup.backup_volume", return_value=RunResult(0, "", "")
+            ),
+            patch("djinn_in_a_box.commands.backup.BACKUPS_DIR", backups_dir),
+            patch("djinn_in_a_box.commands.backup.tempfile.mkdtemp", return_value=str(staging_dir)),
+        ):
+            backup_module.backup(no_encrypt=True)
+
+        assert not old_backup.exists()
+        assert len(list(backups_dir.glob("djinn-backup-*.tar.gz"))) == 1
+        assert not list(backups_dir.glob("djinn-backup-*.tar.gz.age"))
+
+    def test_backup_removes_stale_temp_archives_during_backup(self, tmp_path: Path) -> None:
+        backups_dir = tmp_path / "backups"
+        backups_dir.mkdir()
+        stale = backups_dir / ".djinn-backup-orphan"
+        stale.write_bytes(b"stale")
+        staging_dir = tmp_path / "staging"
+        staging_dir.mkdir()
+        inner_archive = staging_dir / "djinn-claude-config.tar.gz"
+        with tarfile.open(inner_archive, "w:gz"):
+            pass
+
+        with (
+            patch("djinn_in_a_box.commands.backup.get_running_containers", return_value=[]),
+            patch(
+                "djinn_in_a_box.commands.backup.get_existing_volumes_by_category",
+                return_value=["djinn-claude-config"],
+            ),
+            patch(
+                "djinn_in_a_box.commands.backup.get_existing_sync_paths_by_category",
+                return_value=[],
+            ),
+            patch(
+                "djinn_in_a_box.commands.backup.backup_volume", return_value=RunResult(0, "", "")
+            ),
+            patch("djinn_in_a_box.commands.backup.BACKUPS_DIR", backups_dir),
+            patch("djinn_in_a_box.commands.backup.tempfile.mkdtemp", return_value=str(staging_dir)),
+        ):
+            backup_module.backup()
+
+        assert not stale.exists()
 
     def test_backup_aborts_on_volume_failure(self, tmp_path: Path) -> None:
         staging_dir = tmp_path / "staging"
@@ -506,6 +574,55 @@ class TestBackupCommand:
         mock_subprocess.run.assert_not_called()
         assert "can contain credentials" in mock_warning.call_args.args[0]
 
+    def test_cli_no_encrypt_without_age_uses_atomic_private_publish(self, tmp_path: Path) -> None:
+        backups_dir = tmp_path / "backups"
+        backups_dir.mkdir(mode=0o775)
+        backups_dir.chmod(0o775)
+        staging_dir = tmp_path / "staging"
+        staging_dir.mkdir()
+        inner_archive = staging_dir / "djinn-claude-config.tar.gz"
+        with tarfile.open(inner_archive, "w:gz"):
+            pass
+        real_mkstemp = backup_module.tempfile.mkstemp
+        real_replace = backup_module.os.replace
+
+        with (
+            patch("djinn_in_a_box.commands.backup.get_running_containers", return_value=[]),
+            patch(
+                "djinn_in_a_box.commands.backup.get_existing_volumes_by_category",
+                return_value=["djinn-claude-config"],
+            ),
+            patch(
+                "djinn_in_a_box.commands.backup.get_existing_sync_paths_by_category",
+                return_value=[],
+            ),
+            patch(
+                "djinn_in_a_box.commands.backup.backup_volume", return_value=RunResult(0, "", "")
+            ),
+            patch("djinn_in_a_box.commands.backup.BACKUPS_DIR", backups_dir),
+            patch("djinn_in_a_box.commands.backup.tempfile.mkdtemp", return_value=str(staging_dir)),
+            patch("djinn_in_a_box.commands.backup.shutil.which", return_value=None),
+            patch(
+                "djinn_in_a_box.commands.backup.tempfile.mkstemp", wraps=real_mkstemp
+            ) as mock_mkstemp,
+            patch("djinn_in_a_box.commands.backup.os.replace", wraps=real_replace) as mock_replace,
+        ):
+            result = runner.invoke(app, ["backup", "--no-encrypt"])
+
+        assert result.exit_code == 0, result.output
+        archives = list(backups_dir.glob("djinn-backup-*.tar.gz"))
+        assert len(archives) == 1
+        archive = archives[0]
+        assert backups_dir.stat().st_mode & 0o777 == 0o700
+        assert archive.stat().st_mode & 0o777 == 0o600
+        mock_mkstemp.assert_called_once_with(prefix=".djinn-backup-", dir=backups_dir)
+        mock_replace.assert_called_once()
+        published_temp, published_archive = mock_replace.call_args.args
+        assert Path(published_temp).parent == backups_dir
+        assert Path(published_temp).name.startswith(".djinn-backup-")
+        assert Path(published_archive) == archive
+        assert not list(backups_dir.glob(".djinn-backup-*"))
+
     def test_backup_invokes_age_passphrase_without_a_secret(self, tmp_path: Path) -> None:
         backups_dir = tmp_path / "backups"
         staging_dir = tmp_path / "staging"
@@ -513,13 +630,13 @@ class TestBackupCommand:
         inner_archive = staging_dir / "djinn-claude-config.tar.gz"
         with tarfile.open(inner_archive, "w:gz"):
             pass
-        events: list[str] = []
+        events: list[tuple[str, str | None]] = []
 
-        def record_warning_for_invocation(_: str) -> None:
-            events.append("warning")
+        def record_warning_for_invocation(message: str) -> None:
+            events.append(("warning", message))
 
         def run_age(argv: list[str], **_: object) -> subprocess.CompletedProcess[str]:
-            events.append("age")
+            events.append(("age", None))
             temp_path = Path(argv[argv.index("-o") + 1])
             temp_path.write_bytes(b"age-encryption.org/v1\n")
             return subprocess.CompletedProcess(argv, 0)
@@ -551,8 +668,22 @@ class TestBackupCommand:
         argv = mock_subprocess.run.call_args.args[0]
         assert argv[:2] == ["age", "--passphrase"]
         assert argv[2] == "-o"
+        assert len(argv) == 5
+        assert Path(argv[3]).parent == backups_dir
+        assert Path(argv[4]).parent == staging_dir
+        assert Path(argv[4]).name.startswith("djinn-backup-")
+        assert Path(argv[4]).name.endswith(".tar.gz")
         assert mock_subprocess.run.call_args.kwargs == {"check": False}
-        assert events.index("warning") < events.index("age")
+        age_index = next(index for index, (kind, _) in enumerate(events) if kind == "age")
+        pre_age_warnings = [
+            message
+            for kind, message in events[:age_index]
+            if kind == "warning" and message is not None
+        ]
+        assert len(pre_age_warnings) == 1
+        warning = pre_age_warnings[0]
+        assert "empty input generates a passphrase shown once" in warning
+        assert "older unencrypted backup is removed" in warning
 
     @pytest.mark.parametrize(
         "age_output",
@@ -717,6 +848,68 @@ class TestBackupCommand:
         assert not list(backups_dir.glob(".djinn-backup-*"))
         assert not list(backups_dir.glob("djinn-backup-*.tar.gz.age"))
 
+    def test_backup_removes_publish_temp_when_age_is_interrupted(self, tmp_path: Path) -> None:
+        backups_dir = tmp_path / "backups"
+        staging_dir = tmp_path / "staging"
+        staging_dir.mkdir()
+        inner_archive = staging_dir / "djinn-claude-config.tar.gz"
+        with tarfile.open(inner_archive, "w:gz"):
+            pass
+
+        with (
+            patch("djinn_in_a_box.commands.backup.get_running_containers", return_value=[]),
+            patch(
+                "djinn_in_a_box.commands.backup.get_existing_volumes_by_category",
+                return_value=["djinn-claude-config"],
+            ),
+            patch(
+                "djinn_in_a_box.commands.backup.get_existing_sync_paths_by_category",
+                return_value=[],
+            ),
+            patch(
+                "djinn_in_a_box.commands.backup.backup_volume", return_value=RunResult(0, "", "")
+            ),
+            patch("djinn_in_a_box.commands.backup.BACKUPS_DIR", backups_dir),
+            patch("djinn_in_a_box.commands.backup.tempfile.mkdtemp", return_value=str(staging_dir)),
+            patch("djinn_in_a_box.commands.backup.subprocess") as mock_subprocess,
+            pytest.raises(KeyboardInterrupt),
+        ):
+            mock_subprocess.run.side_effect = KeyboardInterrupt
+            backup_module.backup()
+
+        assert not list(backups_dir.glob(".djinn-backup-*"))
+
+    def test_backup_removes_staging_when_age_is_interrupted(self, tmp_path: Path) -> None:
+        backups_dir = tmp_path / "backups"
+        staging_dir = tmp_path / "staging"
+        staging_dir.mkdir()
+        inner_archive = staging_dir / "djinn-claude-config.tar.gz"
+        with tarfile.open(inner_archive, "w:gz"):
+            pass
+
+        with (
+            patch("djinn_in_a_box.commands.backup.get_running_containers", return_value=[]),
+            patch(
+                "djinn_in_a_box.commands.backup.get_existing_volumes_by_category",
+                return_value=["djinn-claude-config"],
+            ),
+            patch(
+                "djinn_in_a_box.commands.backup.get_existing_sync_paths_by_category",
+                return_value=[],
+            ),
+            patch(
+                "djinn_in_a_box.commands.backup.backup_volume", return_value=RunResult(0, "", "")
+            ),
+            patch("djinn_in_a_box.commands.backup.BACKUPS_DIR", backups_dir),
+            patch("djinn_in_a_box.commands.backup.tempfile.mkdtemp", return_value=str(staging_dir)),
+            patch("djinn_in_a_box.commands.backup.subprocess") as mock_subprocess,
+            pytest.raises(KeyboardInterrupt),
+        ):
+            mock_subprocess.run.side_effect = KeyboardInterrupt
+            backup_module.backup()
+
+        assert not staging_dir.exists()
+
 
 class TestRestoreCommand:
     """Tests for the restore command."""
@@ -753,6 +946,36 @@ class TestRestoreCommand:
         assert "age is required to restore" in message
         assert "Install age" in message
         assert "--no-encrypt" not in message
+
+    def test_restore_legacy_archive_works_without_age(self, tmp_path: Path) -> None:
+        backups_dir = tmp_path / "backups"
+        backups_dir.mkdir()
+        staging_dir = tmp_path / "staging"
+        staging_dir.mkdir()
+        inner_staging = tmp_path / "inner"
+        inner_staging.mkdir()
+        inner_archive = inner_staging / "djinn-claude-config.tar.gz"
+        with tarfile.open(inner_archive, "w:gz"):
+            pass
+        backup_file = backups_dir / "djinn-backup-2026-03-13.tar.gz"
+        with tarfile.open(backup_file, "w:gz") as outer:
+            outer.add(inner_archive, arcname=inner_archive.name)
+
+        with (
+            patch("djinn_in_a_box.commands.backup.get_running_containers", return_value=[]),
+            patch("djinn_in_a_box.commands.backup.BACKUPS_DIR", backups_dir),
+            patch("djinn_in_a_box.commands.backup.restore_volume") as mock_restore,
+            patch("djinn_in_a_box.commands.backup.tempfile.mkdtemp", return_value=str(staging_dir)),
+            patch("djinn_in_a_box.commands.backup.typer.confirm"),
+            patch("djinn_in_a_box.commands.backup.shutil.which", return_value=None),
+            patch("djinn_in_a_box.commands.backup.subprocess") as mock_subprocess,
+        ):
+            mock_restore.return_value = RunResult(0, "", "")
+            backup_module.restore()
+
+        mock_restore.assert_called_once_with("djinn-claude-config", staging_dir)
+        mock_subprocess.run.assert_not_called()
+        assert not staging_dir.exists()
 
     def test_exits_when_no_backup_found(self, tmp_path: Path) -> None:
         backups_dir = tmp_path / "backups"
@@ -1023,6 +1246,74 @@ class TestRestoreCommand:
         mock_restore.assert_not_called()
         assert not staging_dir.exists()
 
+    def test_restore_decryption_exit_failure_precedes_valid_partial_cleartext(
+        self, tmp_path: Path
+    ) -> None:
+        backups_dir = tmp_path / "backups"
+        backups_dir.mkdir()
+        staging_dir = tmp_path / "staging"
+        staging_dir.mkdir()
+        inner_staging = tmp_path / "inner"
+        inner_staging.mkdir()
+        inner_archive = inner_staging / "djinn-claude-config.tar.gz"
+        with tarfile.open(inner_archive, "w:gz"):
+            pass
+        valid_outer = tmp_path / "valid-outer.tar.gz"
+        with tarfile.open(valid_outer, "w:gz") as outer:
+            outer.add(inner_archive, arcname=inner_archive.name)
+        encrypted_backup = backups_dir / "djinn-backup-2026-03-13.tar.gz.age"
+        encrypted_backup.write_bytes(b"age-encryption.org/v1\nplaceholder")
+
+        def failed_decrypt(argv: list[str], **_: object) -> subprocess.CompletedProcess[str]:
+            Path(argv[argv.index("-o") + 1]).write_bytes(valid_outer.read_bytes())
+            return subprocess.CompletedProcess(argv, 1)
+
+        with (
+            patch("djinn_in_a_box.commands.backup.get_running_containers", return_value=[]),
+            patch("djinn_in_a_box.commands.backup.BACKUPS_DIR", backups_dir),
+            patch("djinn_in_a_box.commands.backup.tempfile.mkdtemp", return_value=str(staging_dir)),
+            patch("djinn_in_a_box.commands.backup.typer.confirm"),
+            patch("djinn_in_a_box.commands.backup.subprocess") as mock_subprocess,
+            patch("djinn_in_a_box.commands.backup.restore_volume") as mock_restore,
+            pytest.raises(typer.Exit) as exc_info,
+        ):
+            mock_subprocess.run.side_effect = failed_decrypt
+            mock_restore.return_value = RunResult(0, "", "")
+            backup_module.restore()
+
+        assert exc_info.value.exit_code == 1
+        mock_restore.assert_not_called()
+        assert not staging_dir.exists()
+
+    def test_restore_removes_staging_when_age_is_interrupted(self, tmp_path: Path) -> None:
+        backups_dir = tmp_path / "backups"
+        backups_dir.mkdir()
+        staging_dir = tmp_path / "staging"
+        staging_dir.mkdir()
+        encrypted_backup = backups_dir / "djinn-backup-2026-03-13.tar.gz.age"
+        encrypted_backup.write_bytes(b"age-encryption.org/v1\nplaceholder")
+
+        def interrupted_decrypt(argv: list[str], **_: object) -> subprocess.CompletedProcess[str]:
+            Path(argv[argv.index("-o") + 1]).write_bytes(b"partial cleartext")
+            raise KeyboardInterrupt
+
+        with (
+            patch("djinn_in_a_box.commands.backup.get_running_containers", return_value=[]),
+            patch("djinn_in_a_box.commands.backup.BACKUPS_DIR", backups_dir),
+            patch("djinn_in_a_box.commands.backup.tempfile.mkdtemp", return_value=str(staging_dir)),
+            patch("djinn_in_a_box.commands.backup.typer.confirm"),
+            patch("djinn_in_a_box.commands.backup.subprocess") as mock_subprocess,
+            patch("djinn_in_a_box.commands.backup.restore_volume") as mock_restore_volume,
+            patch("djinn_in_a_box.commands.backup.restore_sync_path") as mock_restore_sync_path,
+            pytest.raises(KeyboardInterrupt),
+        ):
+            mock_subprocess.run.side_effect = interrupted_decrypt
+            backup_module.restore()
+
+        mock_restore_volume.assert_not_called()
+        mock_restore_sync_path.assert_not_called()
+        assert not staging_dir.exists()
+
     def test_restore_without_controlling_terminal_exits_with_recovery_hint(
         self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
     ) -> None:
@@ -1087,6 +1378,25 @@ class TestRestoreCommand:
         message = capsys.readouterr().err
         assert "neither a valid age archive nor a readable gzip tar" in message
         assert "intact backup archive" in message
+
+    def test_restore_three_byte_gzip_has_format_error(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        backups_dir = tmp_path / "backups"
+        backups_dir.mkdir()
+        (backups_dir / "djinn-backup-2026-03-13.tar.gz").write_bytes(b"\x1f\x8b\x08")
+
+        with (
+            patch("djinn_in_a_box.commands.backup.get_running_containers", return_value=[]),
+            patch("djinn_in_a_box.commands.backup.BACKUPS_DIR", backups_dir),
+            patch("djinn_in_a_box.commands.backup.typer.confirm"),
+            pytest.raises(typer.Exit) as exc_info,
+        ):
+            backup_module.restore()
+
+        assert exc_info.value.exit_code == 1
+        message = capsys.readouterr().err
+        assert "neither a valid age archive nor a readable gzip tar" in message
 
     def test_age_recipient_round_trip_uses_production_file_orchestration(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch


### PR DESCRIPTION
Closes #4.

## What

`djinn backup` runs the finished archive through `age --passphrase` and writes
`djinn-backup-YYYY-MM-DD.tar.gz.age`. age prompts at the terminal itself — djinn
never holds the passphrase, so there is nothing to leak into a log, a traceback
or a process listing. `djinn restore` reads both formats.

```
$ djinn backup
  age will prompt twice. An empty entry makes age generate a random
  passphrase and show it once. A plaintext archive is removed after success.
  Enter passphrase: ****
  -> djinn-backup-2026-08-01.tar.gz.age   (0600)
```

## Why not a recipient key

The obvious choice was `age -r` against the identity djinn already persists. It
is wrong here: `${DJINN_CONFIG_ROOT}/age` belongs to the `credentials` category,
so the identity travels *inside* the archive. Encrypting against it would make a
restore on a fresh machine impossible — you would need the key to reach the key.
A passphrase never travels with the backup.

## A pre-existing bug this fixes

`tarfile.open(target, "w:gz")` truncates on open. A second backup on the same day
already destroyed the only good archive before writing the new one — no
encryption needed. Archives are now built in staging, written to a temp file
**inside the target directory** (os.replace() fails across filesystems, and /tmp
is tmpfs on many hosts), and published atomically. os.replace() is the point of
no return: the success message precedes rotation, and a rotation error is a
warning naming the leftover file, never a non-zero exit.

## How it was reviewed

**Plan-loop before any code**: 11 perspectives, 33 findings. It caught three
defects that would otherwise have surfaced only after the build — including a
data-loss path the feature itself introduced, and a spec promise that was too
broad. Two measurements corrected my own claims.

**Code-loop after**: 5 perspectives, 5 findings, no critical. Then a 24-mutation
pass that found **no product defect** and fourteen unguarded rules; eight became
tests.

Two findings are worth naming because they recur:

An existing test simulated "age exits 0 without writing" and passed — while
publishing a 0-byte archive and rotating the good one away. It only asserted how
age was called. The output is now checked for header and size before publication.

Another test proved less than its name claimed: its partial cleartext was not
valid gzip, so the abort came from the format error, not the exit-code gate. It
now uses a valid gzip tar.

**One recommendation was declined.** A reviewer derived an attack from the 0775
directory and proposed ownership checks plus a fail-closed abort. The threat
model here is the user's own foot, not a second local account — the directory is
hardened, nothing more.

## Deliberately left open

Five residuals are documented in the spec rather than fixed, chiefly that a
corrupted *inner* archive still clears its target before extraction fails — that
is pre-existing behaviour, and a non-destructive restore is its own undertaking.

## Numbers

811 → 840 tests. ruff clean, `pyright src/` clean, `pyright tests/` unchanged at
5 pre-existing errors. CI installs `age`, which the round-trip test needs.