### PR TITLE
chore(agents): bump gemini to 0.53.1 and opencode to 1.18.11

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -81,9 +81,9 @@ RUN eval "$(fnm env)" && fnm install --lts && fnm default lts-latest
 
 # CLI Agent versions - update with: ./scripts/update-agents.sh
 ARG CLAUDE_CODE_VERSION=2.1.220
-ARG GEMINI_CLI_VERSION=0.53.0
+ARG GEMINI_CLI_VERSION=0.53.1
 ARG CODEX_VERSION=0.146.0
-ARG OPENCODE_VERSION=1.18.10
+ARG OPENCODE_VERSION=1.18.11
 
 # Claude Code via native installer (no npm/Node.js dependency)
 # Installs to ~/.local/bin/claude (already in PATH via .zshrc)


### PR DESCRIPTION
Both versions already run in the production image. They got there as uncommitted local edits, because `scripts/update-agents.sh` was run in the production checkout rather than here.

That has now happened three merges in a row, and each time the bump blocked the `git pull` that was meant to deliver the merged work — twice it was *newer* than master, so discarding it would have downgraded the image.

Landing them makes this checkout the single source again. Going forward `update-agents.sh` runs here, so a bump travels the normal way: commit, PR, pull.