### PR TITLE
fix(doctor): tighten credential directories that predate the 0700 default

### DIFF
--- a/IMPLEMENTATION.md
+++ b/IMPLEMENTATION.md
@@ -394,7 +394,11 @@ the Docker daemon does not auto-create missing paths as root-owned directories.
 It creates credential subdirectories from `SYNC_PATHS["credentials"]`,
 `~/.djinn/sessions`, `~/.djinn/backups`, `~/.ssh`, and `~/.gitconfig`.
 Credential subdirectories and `~/.ssh` are created with mode `0700`. The mode
-applies on creation only; directories that already exist are left unchanged.
+applies on creation only; directories that already exist are left unchanged by
+`ensure_host_env`. `djinn doctor` reports such drift as a `Credential dir modes`
+row, and `djinn doctor --fix` tightens the affected directories — only names from
+`SYNC_PATHS["credentials"]`, only directly under the config root, and skipping
+symlinked names rather than following them.
 
 ## Host-Side Seeding
 

--- a/README.md
+++ b/README.md
@@ -505,8 +505,9 @@ model before you store a high-value key such as an `age` identity.
 
 - **Cleartext on the host.** Credential directories under the config root are
   ordinary files guarded by filesystem permissions. Djinn creates new credential
-  directories with mode `0700`. Directories that already exist are not tightened
-  retroactively.
+  directories with mode `0700`. A config root provisioned before that became the
+  default keeps the looser mode until you repair it: `djinn doctor` reports the
+  drift, `djinn doctor --fix` tightens those directories to `0700`.
 - **Readable by every agent in the container.** Each credential is mounted where
   its tool expects it, so the `dev` user — and therefore every coding agent you
   run — can read all of them. An `age` identity is a master decryption key. An

--- a/src/djinn_in_a_box/commands/doctor.py
+++ b/src/djinn_in_a_box/commands/doctor.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import os
 import shutil
+import stat
 import subprocess
 from dataclasses import dataclass
 from enum import Enum
@@ -22,6 +23,7 @@ import typer
 from rich.table import Table
 from rich.text import Text
 
+from djinn_in_a_box.config.defaults import SYNC_PATHS
 from djinn_in_a_box.config.models import AppConfig
 from djinn_in_a_box.core.config_sync import audit_config_sync as audit_workflow_config
 from djinn_in_a_box.core.console import blank, console, error, rule, warning
@@ -56,6 +58,39 @@ class Check:
     status: Status
     detail: str
     remedy: str = ""
+
+
+CREDENTIAL_DIR_MODE = 0o700
+"""Intended mode for credential directories under the config root."""
+
+
+def loose_credential_dirs(config: AppConfig | None) -> list[Path]:
+    """Credential directories that are group- or other-accessible.
+
+    ``ensure_host_env`` creates these with ``mode=0o700``, but ``Path.mkdir``
+    applies a mode only at creation — a config root provisioned before that
+    change keeps the umask default. This finds the drift so ``doctor --fix``
+    can repair it.
+
+    Deliberately narrow, per the safety constraints of the issue: only the
+    names in ``SYNC_PATHS["credentials"]``, only directly under the resolved
+    root, and ``lstat`` rather than ``stat`` so a symlinked name is skipped
+    instead of followed — a redirect is someone's deliberate arrangement, not
+    ours to chmod.
+    """
+    root = get_config_root(config)
+    loose: list[Path] = []
+    for name in SYNC_PATHS.get("credentials", []):
+        path = root / name
+        try:
+            info = path.lstat()
+        except OSError:
+            continue
+        if not stat.S_ISDIR(info.st_mode):
+            continue
+        if stat.S_IMODE(info.st_mode) & 0o077:
+            loose.append(path)
+    return loose
 
 
 # -----------------------------------------------------------------------------
@@ -275,6 +310,16 @@ def run_checks(config: AppConfig | None, config_error: str | None = None) -> lis
             )
         )
 
+        loose = loose_credential_dirs(config)
+        checks.append(
+            Check(
+                "Credential dir modes",
+                Status.PASS if not loose else Status.WARN,
+                "0700" if not loose else ", ".join(path.name for path in loose),
+                "" if not loose else "Run `djinn doctor --fix` to tighten them to 0700.",
+            )
+        )
+
     image = daemon and _image_built()
     checks.append(
         Check(
@@ -398,6 +443,18 @@ def _doctor_fix(config: AppConfig) -> bool:
     except OSError as e:
         failed = True
         console.print(f"Could not fix: host environment (check host paths are writable: {e})")
+
+    # After ensure_host_env, so a directory it just created is already tight and
+    # does not show up here. Reported per path: a silent chmod on a credential
+    # store is exactly the kind of change that should be visible.
+    for path in loose_credential_dirs(config):
+        try:
+            path.chmod(CREDENTIAL_DIR_MODE)
+        except OSError as e:
+            failed = True
+            console.print(f"Could not fix: {path} ({e})")
+        else:
+            console.print(f"Fixed: tightened {path} to 0700")
 
     try:
         network_ok = ensure_network()

--- a/tests/test_ws3_doctor_session.py
+++ b/tests/test_ws3_doctor_session.py
@@ -326,3 +326,113 @@ def test_session_create_traversal_project_exits_without_creating_outside(
         assert result.exit_code == 1
         assert "Invalid project name" in result.output
         assert not outside.exists()
+
+
+def _credential_root(tmp_path: Path) -> tuple[Path, AppConfig]:
+    """A config root with one loose, one tight, and two decoys."""
+    root = tmp_path / "config-root"
+    root.mkdir()
+    # chmod after mkdir: mkdir's mode is masked by the umask, so 0o777 would
+    # silently become 0o755 and the decoy would not be the wide-open case.
+    (root / "claude").mkdir()
+    (root / "claude").chmod(0o755)
+    (root / "gh").mkdir()
+    (root / "gh").chmod(0o700)
+    (root / "not-a-credential-dir").mkdir()
+    (root / "not-a-credential-dir").chmod(0o777)
+    return root, AppConfig(code_dir=tmp_path, config_root=root)
+
+
+def test_loose_credential_dirs_finds_only_group_or_other_accessible(tmp_path: Path) -> None:
+    """Would fail if the mode test dropped the 0o077 mask and flagged every dir."""
+    root, config = _credential_root(tmp_path)
+
+    loose = doctor_mod.loose_credential_dirs(config)
+
+    assert [path.name for path in loose] == ["claude"]
+    assert (root / "gh").stat().st_mode & 0o077 == 0
+
+
+def test_loose_credential_dirs_leaves_a_stricter_mode_alone(tmp_path: Path) -> None:
+    """The test is "group or other bits set", not "differs from 0700". A
+    directory at 0500 is stricter than required; treating it as drift would
+    *loosen* it. Would fail if the 0o077 mask became a `!= 0o700` comparison.
+    """
+    root, config = _credential_root(tmp_path)
+    (root / "codex").mkdir()
+    (root / "codex").chmod(0o500)
+
+    loose = doctor_mod.loose_credential_dirs(config)
+
+    assert "codex" not in [path.name for path in loose]
+
+
+def test_loose_credential_dirs_skips_a_symlinked_name(tmp_path: Path) -> None:
+    """lstat, not stat: a redirected credential name is someone's deliberate
+    arrangement. Would fail if the check followed the link and chmod'd its target.
+    """
+    root, config = _credential_root(tmp_path)
+    target = tmp_path / "elsewhere"
+    target.mkdir(mode=0o755)
+    (root / "codex").symlink_to(target)
+
+    loose = doctor_mod.loose_credential_dirs(config)
+
+    assert "codex" not in [path.name for path in loose]
+    assert target.stat().st_mode & 0o777 == 0o755
+
+
+def test_loose_credential_dirs_ignores_files_and_unlisted_names(tmp_path: Path) -> None:
+    """Only SYNC_PATHS["credentials"] names, and only directories."""
+    root, config = _credential_root(tmp_path)
+    (root / "gemini").write_text("a file, not a directory")
+
+    loose = doctor_mod.loose_credential_dirs(config)
+
+    names = [path.name for path in loose]
+    assert "gemini" not in names
+    assert "not-a-credential-dir" not in names
+
+
+def test_doctor_warns_about_loose_credential_dirs_and_names_them(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    root, config = _credential_root(tmp_path)
+    monkeypatch.setattr("djinn_in_a_box.config.loader.load_config", lambda: config)
+    monkeypatch.setattr(doctor_mod, "get_config_root", lambda _config=None: root)
+
+    checks = doctor_mod.run_checks(config, None)
+
+    row = next(check for check in checks if check.name == "Credential dir modes")
+    assert row.status is doctor_mod.Status.WARN
+    assert "claude" in row.detail
+    assert "--fix" in row.remedy
+
+
+def test_doctor_fix_tightens_loose_credential_dirs_and_is_idempotent(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """The acceptance criterion in full: tighten, report, and change nothing on
+    a second run -- while leaving an unlisted directory alone.
+    """
+    root, config = _credential_root(tmp_path)
+    monkeypatch.setattr("djinn_in_a_box.config.loader.load_config", lambda: config)
+    monkeypatch.setattr(doctor_mod, "get_config_root", lambda _config=None: root)
+    monkeypatch.setattr(doctor_mod, "run_checks", MagicMock(return_value=[]))
+    monkeypatch.setattr(doctor_mod, "ensure_host_env", MagicMock())
+    monkeypatch.setattr(doctor_mod, "seed_config", MagicMock(return_value=[]))
+    monkeypatch.setattr(doctor_mod, "ensure_network", MagicMock(return_value=True))
+    monkeypatch.setattr(doctor_mod, "get_project_root", lambda: tmp_path)
+
+    first = runner.invoke(app, ["doctor", "--fix"])
+
+    assert first.exit_code == 0, first.output
+    assert "tightened" in first.output
+    assert "claude" in first.output
+    assert (root / "claude").stat().st_mode & 0o777 == 0o700
+    assert (root / "not-a-credential-dir").stat().st_mode & 0o777 == 0o777
+
+    second = runner.invoke(app, ["doctor", "--fix"])
+
+    assert second.exit_code == 0, second.output
+    assert "tightened" not in second.output

--- a/tests/test_ws3_doctor_session.py
+++ b/tests/test_ws3_doctor_session.py
@@ -426,13 +426,17 @@ def test_doctor_fix_tightens_loose_credential_dirs_and_is_idempotent(
 
     first = runner.invoke(app, ["doctor", "--fix"])
 
+    # Rich wraps to the terminal width, and a long tmp_path splits the directory
+    # name across lines -- 80 columns in CI, wider locally. Compare against the
+    # unwrapped text so the assertion does not depend on the environment.
+    unwrapped = first.output.replace("\n", "")
     assert first.exit_code == 0, first.output
-    assert "tightened" in first.output
-    assert "claude" in first.output
+    assert "tightened" in unwrapped
+    assert "claude" in unwrapped
     assert (root / "claude").stat().st_mode & 0o777 == 0o700
     assert (root / "not-a-credential-dir").stat().st_mode & 0o777 == 0o777
 
     second = runner.invoke(app, ["doctor", "--fix"])
 
     assert second.exit_code == 0, second.output
-    assert "tightened" not in second.output
+    assert "tightened" not in second.output.replace("\n", "")


### PR DESCRIPTION
Closes #6.

## The drift is real, not hypothetical

Measured on this host before the fix:

```
claude 755   gemini 755   codex 755   opencode 755   gh 755
age    700   repo-dotfiles 775
```

Five directories holding OAuth tokens, readable by any local user. `ensure_host_env`
creates them with `0700`, but `Path.mkdir` applies a mode only at creation — a config
root provisioned before that change keeps the umask default forever, and nothing
reconciled it.

Same root cause as the backup-directory finding in #4: `mkdir(mode=…)` is not a
guarantee, only an initial value.

## What it does

`djinn doctor` reports a `Credential dir modes` row naming the offending directories;
`djinn doctor --fix` chmods them to `0700` and prints each one it changed.

Narrow by design, following the issue's safety constraints: only names from
`SYNC_PATHS["credentials"]`, only directly under the resolved config root, never
recursing, and `lstat` rather than `stat` — a symlinked credential name is someone's
deliberate arrangement, not ours to chmod.

## One distinction a mutation pass caught

The test is **"group or other bits set"**, not "differs from 0700". Replacing the
`& 0o077` mask with a `!= 0o700` comparison left every test green — but it would treat
a directory at `0500` as drift and *loosen* it to `0700`. That case now has its own
test, alongside the symlink, file, and unlisted-name cases.

Four of five mutations were caught by the tests as written; this was the fifth.

## Numbers

840 → 846 tests. ruff clean, `pyright src/` clean.