### PR TITLE
feat: zone model for the agent config root

### DIFF
--- a/IMPLEMENTATION.md
+++ b/IMPLEMENTATION.md
@@ -193,6 +193,10 @@ Shell UI consumers include `scripts/entrypoint.sh`, `scripts/mcp-register.sh`,
 - `timezone: str`: IANA timezone, default `UTC`
 - `config_root: Path`: local credential/config bind-mount root, default
   `~/.djinn/config`
+- `shared_root: Path | None`: optional mirrorable, non-backed-up zone root;
+  defaults to `<config_root>.shared`
+- `local_root: Path | None`: optional host-local, non-backed-up zone root;
+  defaults to `<config_root>.local`
 - `resources: ResourceLimits`
 - `shell: ShellConfig`
 - `config_sync: ConfigSyncConfig`
@@ -392,13 +396,12 @@ variable is left to inherited host environment or Compose defaults.
 `ensure_host_env(config)` provisions bind-mount sources before Compose runs, so
 the Docker daemon does not auto-create missing paths as root-owned directories.
 It creates credential subdirectories from `SYNC_PATHS["credentials"]`,
-`~/.djinn/sessions`, `~/.djinn/backups`, `~/.ssh`, and `~/.gitconfig`.
-Credential subdirectories and `~/.ssh` are created with mode `0700`. The mode
-applies on creation only; directories that already exist are left unchanged by
-`ensure_host_env`. `djinn doctor` reports such drift as a `Credential dir modes`
-row, and `djinn doctor --fix` tightens the affected directories — only names from
-`SYNC_PATHS["credentials"]`, only directly under the config root, and skipping
-symlinked names rather than following them.
+`~/.djinn/sessions`, `~/.djinn/backups`, `~/.ssh`, and `~/.gitconfig`. The three
+zone roots, credential subdirectories, and zone directories created by migration
+are mode `0700`. The mode applies on creation only; directories that already
+exist are left unchanged by `ensure_host_env`. `djinn doctor` reports credential
+and managed-zone permission drift, and `djinn doctor --fix` tightens those
+directories while skipping symlinked names rather than following them.
 
 ## Host-Side Seeding
 
@@ -655,15 +658,25 @@ The same module owns the repeatable user-mount contract:
   `/home/dev/mount/<basename>`. A duplicate basename first receives one parent
   component (`parent-basename`), then a numeric suffix (`-2`, `-3`, ...).
 - `validate_container_mounts()` checks the targets actually occupied by this
-  `dev` invocation, including Compose, image-alias, runtime, Direct-socket, and
-  user mounts. Equal targets and user targets that are ancestors of an occupied
-  target raise `MountCollisionError`; child targets remain valid.
+  `dev` invocation, including Compose, image-alias, runtime, Direct-socket,
+  zone-overlay, and user mounts. Equal targets and user targets that are
+  ancestors of an occupied target raise `MountCollisionError`; child targets
+  remain valid except that assigned zone targets are reserved too.
 - `MountSpecificationError` reports invalid mount grammar or reserved targets;
   `MountCollisionError` reports the two involved mounts and the conflict path.
 
 When a mount exists, `compose_run()` uses the first mount target as
 `--workdir`. With no mount it omits `--workdir`, so the Compose service's
 `working_dir: /home/dev/projects` remains effective.
+
+`config/zones.py` resolves the additive shipped and user `zones.toml`
+assignments. `compose_run()` turns each existing zone source directory into an
+additional `-v` argument over the config-zone bind mount; an empty source is
+still mounted because it records a completed migration. These overlays are kept
+outside `ContainerOptions.mounts`, so they cannot change the user mount that
+supplies `--workdir`. `migrate-zones` owns the explicit, locked data move and
+creates empty zone targets; `doctor` reports unmigrated paths, collisions, drift,
+permission drift, and large direct files that cannot safely be overlaid.
 
 ## Image Build
 
@@ -750,7 +763,8 @@ backed by named volumes.
 - `clean_volumes()`: lists or deletes named volume categories and clears
   config-root sync paths by category.
 - `clean_all()`: stops containers, deletes all known named volumes, clears all
-  sync paths, and deletes the network.
+  config-zone sync paths, and deletes the network. It does not clear shared or
+  local zone data.
 - `audit()`: prints Docker proxy logs.
 - `update()`: runs `scripts/update-agents.sh`.
 - `enter()`: opens a zsh shell in the first running Djinn container.

--- a/README.md
+++ b/README.md
@@ -527,6 +527,18 @@ model before you store a high-value key such as an `age` identity.
   A forgotten passphrase makes that archive unrecoverable. Use `--no-encrypt`
   only when you explicitly need a cleartext archive, and protect it as
   carefully as the credentials themselves.
+- **Zones separate credentials from agent data.** The config root is the
+  credential/config zone: Djinn backs it up and you may mirror it. Its sibling
+  `<config-root>.shared` holds transcript directories: Djinn does not archive
+  it, so add it to your own backup and, when desired, cross-machine mirror.
+  `<config-root>.local` holds caches and scratch: Djinn neither archives nor
+  mirrors it. Run `djinn migrate-zones` only after adding the shared root to
+  mirroring or pausing mirroring; the move appears as deletions from the config
+  root to a synchronizer.
+- **Transcript retention belongs to the agent.** Djinn never deletes
+  agent-owned transcript data. For Claude Code, configure its native
+  `cleanupPeriodDays` setting or use `claude project purge`; use the equivalent
+  native setting or command for other agents.
 
 Read [DOCKER-SOCKET-SECURITY.md](DOCKER-SOCKET-SECURITY.md) before enabling
 Docker socket access, which widens this surface further.
@@ -668,7 +680,8 @@ djinn clean volumes djinn-uv-cache
 `djinn clean volumes NAME` refuses names that do not start with `djinn-`.
 
 Remove containers, managed named volumes, config-root sync-path contents, and the
-Docker network:
+Docker network. This does not remove zone data in `<config-root>.shared` or
+`<config-root>.local`:
 
 ```sh
 djinn clean all

--- a/docs/sync-across-machines.md
+++ b/docs/sync-across-machines.md
@@ -10,9 +10,17 @@ Sync these deliberately:
 
 - The repo itself: clone or pull it with Git on `host-a` and `host-b`.
 - The app config directory: `~/.config/djinn_in_a_box/`.
-- Your configured credential/config root, usually `~/.djinn/config/`.
+- Your configured credential/config root, usually `~/.djinn/config/`. This is
+  the credential/config zone that Djinn backs up.
+- Its shared sibling, usually `~/.djinn/config.shared/`, when you want
+  transcripts on both machines. Djinn does not back this zone up.
 - The repo-local `config/` directory if you want the same local seed overlays,
   agent settings, and MCP registry files on both hosts.
+
+Do not mirror the local sibling, usually `~/.djinn/config.local/`. It holds
+rebuildable caches and scratch and is intentionally host-local. If you use
+explicit `shared_root` or `local_root` values, apply the same policy to those
+paths instead of the derived siblings.
 
 `~/.config/djinn_in_a_box/config.toml` may contain host-specific paths. If
 `code_dir` differs between machines, keep separate copies or edit it after sync
@@ -40,7 +48,10 @@ djinn build
 ```
 
 Then configure your file synchronizer to mirror the local config paths listed
-above.
+above. Before the first `djinn migrate-zones`, add the shared root to that set
+or pause synchronization. The migration moves data out of the config root, so a
+synchronizer otherwise sees source deletions and can propagate them before the
+shared copy is protected.
 
 ## Second Host
 
@@ -69,10 +80,11 @@ djinn backup
 djinn restore
 ```
 
-By default, `djinn backup` archives existing credential/config-root paths
+By default, `djinn backup` archives the config-zone credential/config-root paths
 (`claude`, `gemini`, `codex`, `opencode`, `gh`, `age`), `repo-dotfiles`, and data
-volumes (`djinn-opencode-data`, `djinn-vscode-workspaces`). Cache volumes are
-not included by default because they are rebuildable.
+volumes (`djinn-opencode-data`, `djinn-vscode-workspaces`). It does not archive
+the shared transcript zone or the local cache/scratch zone. Cache volumes are not
+included by default because they are rebuildable.
 
 Backups are age-encrypted with a passphrase by default and use the filename
 `djinn-backup-YYYY-MM-DD.tar.gz.age`. `age` asks for that passphrase directly at
@@ -87,6 +99,6 @@ Stop Djinn containers before backup or restore; the command enforces this.
 ## What Not To Sync
 
 Do not sync live containers, Docker volume directories, Unix sockets, PID files,
-or runtime cache directories. Do not run a file synchronizer against Docker's
-internal storage. Use `djinn clean`, `djinn backup`, and `djinn restore` for
-Djinn-managed runtime state.
+or the local zone's runtime cache directories. Do not run a file synchronizer
+against Docker's internal storage. Use `djinn clean`, `djinn backup`, and
+`djinn restore` for Djinn-managed runtime state.

--- a/src/djinn_in_a_box/cli/djinn.py
+++ b/src/djinn_in_a_box/cli/djinn.py
@@ -28,6 +28,7 @@ from djinn_in_a_box.commands.container import (
     update,
 )
 from djinn_in_a_box.commands.doctor import doctor
+from djinn_in_a_box.commands.migrate_zones import migrate_zones
 from djinn_in_a_box.commands.session import session
 
 app = typer.Typer(
@@ -89,6 +90,7 @@ app.command()(build)
 app.command()(start)
 app.command()(status)
 app.command()(doctor)
+app.command("migrate-zones")(migrate_zones)
 app.command()(audit)
 app.command()(update)
 app.command()(enter)

--- a/src/djinn_in_a_box/commands/agent.py
+++ b/src/djinn_in_a_box/commands/agent.py
@@ -3,14 +3,18 @@
 from __future__ import annotations
 
 import json
+from collections.abc import Callable
+from contextvars import ContextVar
+from functools import wraps
 from pathlib import Path
-from typing import Annotated, cast
+from typing import Annotated, ParamSpec, TypeIs, TypeVar, cast
 
 import typer
 from rich.table import Table
 
+from djinn_in_a_box.commands.zone_gate import zone_command_gate
 from djinn_in_a_box.config.loader import load_agents, load_config
-from djinn_in_a_box.config.models import ConfigSyncSource
+from djinn_in_a_box.config.models import AppConfig, ConfigSyncSource
 from djinn_in_a_box.core.agent_runner import (
     AgentNetworkError,
     UnknownAgentError,
@@ -46,6 +50,38 @@ from djinn_in_a_box.core.exceptions import (
     RuntimeMountSpecificationError,
 )
 from djinn_in_a_box.core.paths import get_project_root
+
+P = ParamSpec("P")
+R = TypeVar("R")
+_NO_GATED_CONFIG = object()
+_gated_config: ContextVar[object] = ContextVar("gated_config", default=_NO_GATED_CONFIG)
+
+
+def _is_app_config(value: object) -> TypeIs[AppConfig]:
+    return isinstance(value, AppConfig)
+
+
+def _active_config() -> AppConfig:
+    config = _gated_config.get()
+    if config is _NO_GATED_CONFIG:
+        return load_config()
+    return cast(AppConfig, config)
+
+
+def _zone_gated_run(func: Callable[P, R]) -> Callable[P, R]:
+    @wraps(func)
+    def wrapper(*args: P.args, **kwargs: P.kwargs) -> R:
+        candidate: object = load_config()
+        token = _gated_config.set(candidate)
+        try:
+            if not _is_app_config(candidate):
+                return func(*args, **kwargs)
+            with zone_command_gate(candidate, "run"):
+                return func(*args, **kwargs)
+        finally:
+            _gated_config.reset(token)
+
+    return wrapper
 
 
 def _agent_table(title: str) -> Table:
@@ -112,6 +148,7 @@ def _show_run_status(
 
 
 @handle_config_errors
+@_zone_gated_run
 def run(
     agent: Annotated[
         str,
@@ -197,7 +234,7 @@ def run(
 
     checked_config = None
     delivery_targets: tuple[WorkflowDeliveryTarget, ...] = ()
-    config = load_config()
+    config = _active_config()
     checked_config = config
     if agent in {"claude", "codex"}:
         selected_agent = cast(ConfigSyncSource, agent)

--- a/src/djinn_in_a_box/commands/backup.py
+++ b/src/djinn_in_a_box/commands/backup.py
@@ -55,14 +55,16 @@ _AGE_HEADER = b"age-encryption.org/v1"
 _BACKUP_GLOBS = ("djinn-backup-*.tar.gz", "djinn-backup-*.tar.gz.age")
 
 
-def _zone_gated(command: GatedCommand) -> Callable[[Callable[P, R]], Callable[P, R]]:
+def _zone_gated(
+    command: GatedCommand, *, exclusive: bool = False
+) -> Callable[[Callable[P, R]], Callable[P, R]]:
     def decorator(func: Callable[P, R]) -> Callable[P, R]:
         @wraps(func)
         def wrapper(*args: P.args, **kwargs: P.kwargs) -> R:
             config = load_config()
             token = _gated_config.set(config)
             try:
-                with zone_command_gate(config, command):
+                with zone_command_gate(config, command, exclusive=exclusive):
                     return func(*args, **kwargs)
             finally:
                 _gated_config.reset(token)
@@ -327,7 +329,7 @@ def backup(
 
 
 @handle_config_errors
-@_zone_gated("restore")
+@_zone_gated("restore", exclusive=True)
 def restore() -> None:
     """Restore Docker volumes and sync paths from a backup archive.
 

--- a/src/djinn_in_a_box/commands/backup.py
+++ b/src/djinn_in_a_box/commands/backup.py
@@ -6,6 +6,7 @@ import gzip
 import os
 import re
 import shutil
+import stat
 import subprocess
 import tarfile
 import tempfile
@@ -36,6 +37,7 @@ from djinn_in_a_box.core.docker import (
     restore_sync_path,
     restore_volume,
 )
+from djinn_in_a_box.core.exceptions import ZoneConfigurationError
 from djinn_in_a_box.core.paths import BACKUPS_DIR
 from djinn_in_a_box.core.zone_migration import (
     adopt_archive_collision,
@@ -75,8 +77,26 @@ def _active_config() -> AppConfig:
     return load_config() if config is None else config
 
 
+def _harden_restored_sync_directories(path: Path) -> None:
+    info = path.lstat()
+    if not stat.S_ISDIR(info.st_mode):
+        msg = f"Restored sync path is not a directory: {path}"
+        raise ZoneConfigurationError(msg)
+    os.chmod(path, 0o700, follow_symlinks=False)
+    with os.scandir(path) as entries:
+        for entry in entries:
+            if entry.is_symlink():
+                continue
+            if entry.is_dir(follow_symlinks=False):
+                _harden_restored_sync_directories(Path(entry.path))
+
+
 def _guard_no_containers_running() -> None:
     running = get_running_containers()
+    if running is None:
+        error("Could not determine whether Djinn containers are running.")
+        error("Restore Docker access before backup/restore, then retry.")
+        raise typer.Exit(1)
     if running:
         error(f"Containers are running: {', '.join(running)}")
         error("Stop all containers before backup/restore (djinn clean)")
@@ -390,11 +410,18 @@ def restore() -> None:
 
         failed = False
         for archive in inner_archives:
+            hardening_error: OSError | None = None
             if is_sync_archive(archive.name):
                 path_name = extract_sync_path_name(archive.name)
                 label = f"sync/{path_name}"
                 info(f"  {label}")
                 result = restore_sync_path(path_name, staging_dir, config)
+                try:
+                    _harden_restored_sync_directories(
+                        resolve_zone_roots(config).config_root / path_name
+                    )
+                except OSError as exc:
+                    hardening_error = exc
             else:
                 vol_name = archive.name.removesuffix(".tar.gz")
                 if not _VOLUME_NAME_RE.fullmatch(vol_name):
@@ -405,10 +432,14 @@ def restore() -> None:
                 info(f"  {label}")
                 result = restore_volume(vol_name, staging_dir)
 
-            if result.success:
+            if result.success and hardening_error is None:
                 success(f"  {label}")
             else:
-                error(f"  {label}: {result.stderr.strip()}")
+                detail = result.stderr.strip()
+                if hardening_error is not None:
+                    hardened_detail = f"failed to secure restored sync directory: {hardening_error}"
+                    detail = f"{detail}; {hardened_detail}" if detail else hardened_detail
+                error(f"  {label}: {detail}")
                 failed = True
 
         if not failed:

--- a/src/djinn_in_a_box/commands/backup.py
+++ b/src/djinn_in_a_box/commands/backup.py
@@ -10,12 +10,15 @@ import subprocess
 import tarfile
 import tempfile
 from collections.abc import Callable
+from contextvars import ContextVar
 from datetime import UTC, datetime
+from functools import wraps
 from pathlib import Path
-from typing import Annotated
+from typing import Annotated, ParamSpec, TypeVar
 
 import typer
 
+from djinn_in_a_box.commands.zone_gate import GatedCommand, zone_command_gate
 from djinn_in_a_box.config.defaults import SYNC_PATHS, VOLUME_CATEGORIES
 from djinn_in_a_box.config.loader import load_config
 from djinn_in_a_box.config.models import AppConfig
@@ -29,16 +32,47 @@ from djinn_in_a_box.core.docker import (
     get_existing_volumes_by_category,
     get_running_containers,
     is_sync_archive,
+    resolve_zone_roots,
     restore_sync_path,
     restore_volume,
 )
 from djinn_in_a_box.core.paths import BACKUPS_DIR
+from djinn_in_a_box.core.zone_migration import (
+    adopt_archive_collision,
+    reconcile_zone_assignments,
+)
+
+P = ParamSpec("P")
+R = TypeVar("R")
+_gated_config: ContextVar[AppConfig | None] = ContextVar("gated_config", default=None)
 
 # "cache" excluded: uv-cache/tools-cache/vscode-server are large and rebuildable
 DEFAULT_CATEGORIES: list[str] = ["credentials", "repo-dotfiles", "data"]
 _VOLUME_NAME_RE = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9_.-]+$")
 _AGE_HEADER = b"age-encryption.org/v1"
 _BACKUP_GLOBS = ("djinn-backup-*.tar.gz", "djinn-backup-*.tar.gz.age")
+
+
+def _zone_gated(command: GatedCommand) -> Callable[[Callable[P, R]], Callable[P, R]]:
+    def decorator(func: Callable[P, R]) -> Callable[P, R]:
+        @wraps(func)
+        def wrapper(*args: P.args, **kwargs: P.kwargs) -> R:
+            config = load_config()
+            token = _gated_config.set(config)
+            try:
+                with zone_command_gate(config, command):
+                    return func(*args, **kwargs)
+            finally:
+                _gated_config.reset(token)
+
+        return wrapper
+
+    return decorator
+
+
+def _active_config() -> AppConfig:
+    config = _gated_config.get()
+    return load_config() if config is None else config
 
 
 def _guard_no_containers_running() -> None:
@@ -141,6 +175,7 @@ def _require_age(*, restore: bool = False) -> None:
 
 
 @handle_config_errors
+@_zone_gated("backup")
 def backup(
     categories: Annotated[
         list[str] | None,
@@ -166,7 +201,7 @@ def backup(
     """
     _guard_no_containers_running()
 
-    config = load_config()
+    config = _active_config()
     selected = categories or DEFAULT_CATEGORIES
     volumes, sync_paths = _collect_items(selected, config)
 
@@ -272,6 +307,7 @@ def backup(
 
 
 @handle_config_errors
+@_zone_gated("restore")
 def restore() -> None:
     """Restore Docker volumes and sync paths from a backup archive.
 
@@ -279,7 +315,7 @@ def restore() -> None:
     volumes and sync paths. Existing contents are overwritten.
     """
     _guard_no_containers_running()
-    config = load_config()
+    config = _active_config()
 
     BACKUPS_DIR.mkdir(parents=True, exist_ok=True)
     BACKUPS_DIR.chmod(0o700)
@@ -374,6 +410,32 @@ def restore() -> None:
             else:
                 error(f"  {label}: {result.stderr.strip()}")
                 failed = True
+
+        if not failed:
+            reconciliation = reconcile_zone_assignments(config, stop_on_collision=False)
+            for collision in reconciliation.collisions:
+                config_path = (
+                    resolve_zone_roots(config).config_root
+                    / collision.assignment.agent
+                    / collision.assignment.relative_path
+                )
+                if typer.confirm(
+                    "The restored archive and zone both contain "
+                    f"{collision.assignment.agent}/{collision.assignment.relative_path}. "
+                    "Keep the archive copy and move the existing zone tree aside?",
+                    default=False,
+                ):
+                    displaced = adopt_archive_collision(collision, config)
+                    warning(
+                        "Moved the existing zone tree aside at "
+                        f"{displaced}; restored archive data now lives at "
+                        f"{collision.destination}."
+                    )
+                else:
+                    warning(
+                        "Zone collision preserved between "
+                        f"{config_path} and {collision.destination}."
+                    )
 
         blank()
         if failed:

--- a/src/djinn_in_a_box/commands/config.py
+++ b/src/djinn_in_a_box/commands/config.py
@@ -36,7 +36,7 @@ from djinn_in_a_box.core.config_sync import (
 )
 from djinn_in_a_box.core.console import blank, console, error, info, rule, success, warning
 from djinn_in_a_box.core.decorators import handle_config_errors
-from djinn_in_a_box.core.docker import ensure_host_env
+from djinn_in_a_box.core.docker import ensure_host_env, resolve_zone_roots
 from djinn_in_a_box.core.exceptions import ConfigNotFoundError, ConfigValidationError
 from djinn_in_a_box.core.hostinfo import detect_timezone, suggest_resources
 from djinn_in_a_box.core.paths import CONFIG_DIR, CONFIG_FILE, get_project_root
@@ -46,6 +46,8 @@ ALLOWED_CONFIG_KEYS: tuple[str, ...] = (
     "general.code_dir",
     "general.timezone",
     "general.config_root",
+    "general.shared_root",
+    "general.local_root",
     "resources.cpu_limit",
     "resources.memory_limit",
     "resources.cpu_reservation",
@@ -55,6 +57,13 @@ ALLOWED_CONFIG_KEYS: tuple[str, ...] = (
     "config_sync.source",
 )
 _LOCK_PROBLEM_IDENTIFIER = "canonical-lock-failed"
+
+
+class _Unset:
+    pass
+
+
+_UNSET = _Unset()
 
 
 def _print_config_table(
@@ -275,6 +284,8 @@ def _build_config(
     code_dir: Path | None = None,
     timezone: str | None = None,
     config_root: Path | None = None,
+    shared_root: Path | None | _Unset = _UNSET,
+    local_root: Path | None | _Unset = _UNSET,
     resources: ResourceLimits | None = None,
     shell: ShellConfig | None = None,
     config_sync: ConfigSyncConfig | None = None,
@@ -283,6 +294,8 @@ def _build_config(
         code_dir=config.code_dir if code_dir is None else code_dir,
         timezone=config.timezone if timezone is None else timezone,
         config_root=config.config_root if config_root is None else config_root,
+        shared_root=config.shared_root if isinstance(shared_root, _Unset) else shared_root,
+        local_root=config.local_root if isinstance(local_root, _Unset) else local_root,
         resources=config.resources if resources is None else resources,
         shell=config.shell if shell is None else shell,
         config_sync=config.config_sync if config_sync is None else config_sync,
@@ -303,11 +316,25 @@ def _set_config_value(config: AppConfig, key: str, value: str) -> AppConfig:
     if key == "general.config_root":
         config_root = Path(value).expanduser()
         if config_root != config.config_root:
+            updated = _build_config(config, config_root=config_root)
+            old_roots = resolve_zone_roots(config)
+            new_roots = resolve_zone_roots(updated)
             warning(
-                f"Existing credentials/config remain at {config.config_root}; "
-                f"new empty directories will be provisioned at {config_root}."
+                "Existing credentials/config remain at "
+                f"config={old_roots.config_root}, shared={old_roots.shared_root}, "
+                f"local={old_roots.local_root}; new roots are "
+                f"config={new_roots.config_root}, shared={new_roots.shared_root}, "
+                f"local={new_roots.local_root}. Zone data does not follow. "
+                f"New empty directories will be provisioned at {new_roots.config_root}."
             )
+            return updated
         return _build_config(config, config_root=config_root)
+    if key in {"general.shared_root", "general.local_root"}:
+        normalized = value.strip().lower()
+        root = None if normalized in {"", "none", "null"} else Path(value).expanduser()
+        if key == "general.shared_root":
+            return _build_config(config, shared_root=root)
+        return _build_config(config, local_root=root)
     if key == "resources.cpu_limit":
         resources = ResourceLimits(
             cpu_limit=_parse_int_config_value(key, value),
@@ -369,6 +396,10 @@ def _format_config_value(config: AppConfig, key: str) -> str:
         return config.timezone
     if key == "general.config_root":
         return str(config.config_root)
+    if key == "general.shared_root":
+        return "derived" if config.shared_root is None else str(config.shared_root)
+    if key == "general.local_root":
+        return "derived" if config.local_root is None else str(config.local_root)
     if key == "resources.cpu_limit":
         return str(config.resources.cpu_limit)
     if key == "resources.memory_limit":
@@ -491,6 +522,7 @@ def config_show(
         output = json.dumps(config.model_dump(mode="json"), indent=2)
         console.print(output, highlight=False)
     else:
+        roots = resolve_zone_roots(config)
         # Human-readable output
         rule("Current Configuration")
         console.print(
@@ -503,8 +535,11 @@ def config_show(
             [
                 ("code_dir", config.code_dir),
                 ("timezone", config.timezone),
+                ("config_root", roots.config_root),
+                ("shared_root", roots.shared_root),
+                ("local_root", roots.local_root),
             ],
-            path_labels={"code_dir"},
+            path_labels={"code_dir", "config_root", "shared_root", "local_root"},
         )
         console.print()
 

--- a/src/djinn_in_a_box/commands/config.py
+++ b/src/djinn_in_a_box/commands/config.py
@@ -316,28 +316,28 @@ def _set_config_value(config: AppConfig, key: str, value: str) -> AppConfig:
         return _build_config(config, code_dir=code_dir)
     if key == "general.timezone":
         return _build_config(config, timezone=value)
-    if key == "general.config_root":
-        config_root = Path(value).expanduser()
-        if config_root != config.config_root:
-            updated = _build_config(config, config_root=config_root)
-            old_roots = resolve_zone_roots(config)
-            new_roots = resolve_zone_roots(updated)
+    if key in {"general.config_root", "general.shared_root", "general.local_root"}:
+        if key == "general.config_root":
+            updated = _build_config(config, config_root=Path(value).expanduser())
+        else:
+            normalized = value.strip().lower()
+            root = None if normalized in {"", "none", "null"} else Path(value).expanduser()
+            if key == "general.shared_root":
+                updated = _build_config(config, shared_root=root)
+            else:
+                updated = _build_config(config, local_root=root)
+        old_roots = resolve_zone_roots(config)
+        new_roots = resolve_zone_roots(updated)
+        if old_roots != new_roots:
             warning(
                 "Existing credentials/config remain at "
                 f"config={old_roots.config_root}, shared={old_roots.shared_root}, "
                 f"local={old_roots.local_root}; new roots are "
                 f"config={new_roots.config_root}, shared={new_roots.shared_root}, "
                 f"local={new_roots.local_root}. Zone data does not follow. "
-                f"New empty directories will be provisioned at {new_roots.config_root}."
+                "New empty directories will be provisioned at the configured roots."
             )
-            return updated
-        return _build_config(config, config_root=config_root)
-    if key in {"general.shared_root", "general.local_root"}:
-        normalized = value.strip().lower()
-        root = None if normalized in {"", "none", "null"} else Path(value).expanduser()
-        if key == "general.shared_root":
-            return _build_config(config, shared_root=root)
-        return _build_config(config, local_root=root)
+        return updated
     if key == "resources.cpu_limit":
         resources = ResourceLimits(
             cpu_limit=_parse_int_config_value(key, value),

--- a/src/djinn_in_a_box/commands/config.py
+++ b/src/djinn_in_a_box/commands/config.py
@@ -242,9 +242,12 @@ def init_config(
 
     rule("Next steps")
     console.print("  [muted]1.[/muted] djinn build    [muted]# Build the Docker image[/muted]")
-    console.print("  [muted]2.[/muted] djinn start    [muted]# Start development shell[/muted]")
     console.print(
-        "  [muted]3.[/muted] (optional) mcpgateway start   "
+        "  [muted]2.[/muted] djinn migrate-zones    [muted]# Create zone overlays[/muted]"
+    )
+    console.print("  [muted]3.[/muted] djinn start    [muted]# Start development shell[/muted]")
+    console.print(
+        "  [muted]4.[/muted] (optional) mcpgateway start   "
         "[muted]# MCP tools — not required[/muted]"
     )
     blank()

--- a/src/djinn_in_a_box/commands/container.py
+++ b/src/djinn_in_a_box/commands/container.py
@@ -849,6 +849,10 @@ def enter() -> None:
         raise typer.Exit(1)
 
     containers = get_running_containers("djinn")
+    if containers is None:
+        error("Could not determine whether a Djinn container is running.")
+        err_console.print("Restore Docker access, then retry.")
+        raise typer.Exit(1)
     if not containers:
         error("No running Djinn container found.")
         err_console.print("Start one with: djinn start")

--- a/src/djinn_in_a_box/commands/container.py
+++ b/src/djinn_in_a_box/commands/container.py
@@ -4,13 +4,17 @@ from __future__ import annotations
 
 import subprocess
 import sys
+from collections.abc import Callable
+from contextvars import ContextVar
+from functools import wraps
 from pathlib import Path
-from typing import Annotated
+from typing import Annotated, ParamSpec, TypeIs, TypeVar, cast
 
 import typer
 from rich.table import Table
 
 from djinn_in_a_box.commands.doctor import preflight
+from djinn_in_a_box.commands.zone_gate import GatedCommand, zone_command_gate
 from djinn_in_a_box.config.defaults import SYNC_PATHS, VOLUME_CATEGORIES
 from djinn_in_a_box.config.loader import load_config
 from djinn_in_a_box.config.models import AppConfig
@@ -67,6 +71,53 @@ from djinn_in_a_box.core.exceptions import (
 )
 from djinn_in_a_box.core.paths import get_project_root
 
+P = ParamSpec("P")
+R = TypeVar("R")
+_NO_GATED_CONFIG = object()
+_gated_config: ContextVar[object] = ContextVar("gated_config", default=_NO_GATED_CONFIG)
+
+
+def _is_app_config(value: object) -> TypeIs[AppConfig]:
+    return isinstance(value, AppConfig)
+
+
+def _active_config() -> AppConfig:
+    config = _gated_config.get()
+    if config is _NO_GATED_CONFIG:
+        return load_config()
+    return cast(AppConfig, config)
+
+
+def _active_optional_config() -> AppConfig | None:
+    config = _gated_config.get()
+    if config is _NO_GATED_CONFIG:
+        return _load_optional_config()
+    return cast(AppConfig | None, config)
+
+
+def _zone_gated(
+    command: GatedCommand, *, optional_config: bool = False
+) -> Callable[[Callable[P, R]], Callable[P, R]]:
+    def decorator(func: Callable[P, R]) -> Callable[P, R]:
+        @wraps(func)
+        def wrapper(*args: P.args, **kwargs: P.kwargs) -> R:
+            candidate: object = _load_optional_config() if optional_config else load_config()
+            token = _gated_config.set(candidate)
+            try:
+                if candidate is None:
+                    with zone_command_gate(None, command):
+                        return func(*args, **kwargs)
+                if not _is_app_config(candidate):
+                    return func(*args, **kwargs)
+                with zone_command_gate(candidate, command):
+                    return func(*args, **kwargs)
+            finally:
+                _gated_config.reset(token)
+
+        return wrapper
+
+    return decorator
+
 
 def _sync_build_files(config: AppConfig | None = None) -> None:
     """Copy build-time files from sync dir into the repo (both are gitignored).
@@ -120,6 +171,7 @@ def build(
 
 
 @handle_config_errors
+@_zone_gated("start")
 def start(
     docker: Annotated[
         bool,
@@ -187,7 +239,7 @@ def start(
         err_console.print("Attach to it with: djinn enter")
         raise typer.Exit(1)
 
-    config = load_config()
+    config = _active_config()
     preflight(config, provision_host=False)
 
     config_root = get_config_root(config)
@@ -519,6 +571,7 @@ clean_app = typer.Typer(
 
 
 @clean_app.callback(invoke_without_command=True)
+@_zone_gated("clean", optional_config=True)
 def clean_default(ctx: typer.Context) -> None:
     """Remove containers only (default action when no subcommand given).
 
@@ -543,6 +596,7 @@ def clean_default(ctx: typer.Context) -> None:
 
 
 @clean_app.command("volumes")
+@_zone_gated("clean", optional_config=True)
 def clean_volumes(
     credentials: Annotated[
         bool,
@@ -614,7 +668,7 @@ def clean_volumes(
         selected.append("data")
 
     if not selected:
-        config = _load_optional_config()
+        config = _active_optional_config()
         rule("Volumes by category")
         blank()
         volume_entries = _list_existing_volumes()
@@ -635,7 +689,7 @@ def clean_volumes(
         )
         return
 
-    config = _load_optional_config()
+    config = _active_optional_config()
     sync_selected = [c for c in selected if c in SYNC_PATHS]
     if sync_selected and not force:
         warning(
@@ -674,6 +728,7 @@ def clean_volumes(
 
 
 @clean_app.command("all")
+@_zone_gated("clean", optional_config=True)
 def clean_all(
     force: Annotated[
         bool,
@@ -701,7 +756,7 @@ def clean_all(
             info("Aborted.")
             raise typer.Exit(0)
 
-    config = _load_optional_config()
+    config = _active_optional_config()
 
     info("Stopping and removing containers...")
     down_result = compose_down()

--- a/src/djinn_in_a_box/commands/container.py
+++ b/src/djinn_in_a_box/commands/container.py
@@ -735,21 +735,22 @@ def clean_all(
         typer.Option("--force", "-f", help="Skip confirmation prompt"),
     ] = False,
 ) -> None:
-    """Remove EVERYTHING: containers, volumes, sync path contents, and network.
+    """Remove containers, volumes, config-zone sync paths, and network.
 
     This is a destructive operation that removes:
     - All djinn containers
     - All djinn named volumes (cache, data)
-    - All contents of sync paths under $DJINN_CONFIG_ROOT — if you mirror them
-      across machines the deletion will propagate.
+    - Contents of config-zone sync paths under $DJINN_CONFIG_ROOT — if you
+      mirror them across machines the deletion will propagate. Shared and local
+      zone data are not removed.
     - The djinn-network
 
     """
     if not force:
         confirm = typer.confirm(
-            "This will delete ALL containers, volumes, sync path contents, and the "
-            "network. If you mirror sync paths across machines the deletion will "
-            "propagate. Continue?",
+            "This will delete ALL containers, volumes, config-zone sync path contents, "
+            "and the network. Shared and local zone data are not removed. If you mirror "
+            "config-zone paths across machines the deletion will propagate. Continue?",
             default=False,
         )
         if not confirm:

--- a/src/djinn_in_a_box/commands/container.py
+++ b/src/djinn_in_a_box/commands/container.py
@@ -571,6 +571,7 @@ clean_app = typer.Typer(
 
 
 @clean_app.callback(invoke_without_command=True)
+@handle_config_errors
 @_zone_gated("clean", optional_config=True)
 def clean_default(ctx: typer.Context) -> None:
     """Remove containers only (default action when no subcommand given).
@@ -596,6 +597,7 @@ def clean_default(ctx: typer.Context) -> None:
 
 
 @clean_app.command("volumes")
+@handle_config_errors
 @_zone_gated("clean", optional_config=True)
 def clean_volumes(
     credentials: Annotated[
@@ -728,6 +730,7 @@ def clean_volumes(
 
 
 @clean_app.command("all")
+@handle_config_errors
 @_zone_gated("clean", optional_config=True)
 def clean_all(
     force: Annotated[

--- a/src/djinn_in_a_box/commands/doctor.py
+++ b/src/djinn_in_a_box/commands/doctor.py
@@ -25,7 +25,12 @@ from rich.text import Text
 
 from djinn_in_a_box.config.defaults import KNOWN_CONFIG_ROOT_ENTRIES, SYNC_PATHS
 from djinn_in_a_box.config.models import AppConfig
-from djinn_in_a_box.config.zones import ZoneAssignment, ZoneAssignments, load_zone_assignments
+from djinn_in_a_box.config.zones import (
+    MIGRATING_ZONE_PREFIX,
+    ZoneAssignment,
+    ZoneAssignments,
+    load_zone_assignments,
+)
 from djinn_in_a_box.core.config_sync import audit_config_sync as audit_workflow_config
 from djinn_in_a_box.core.console import blank, console, error, rule, warning
 from djinn_in_a_box.core.docker import (
@@ -303,7 +308,11 @@ def _zone_drift_entries(config: AppConfig, assignments: ZoneAssignments) -> tupl
             children = tuple(agent_root.iterdir())
         except OSError:
             continue
-        drift.extend(child for child in children if child.name not in accounted)
+        drift.extend(
+            child
+            for child in children
+            if child.name not in accounted and not child.name.startswith(MIGRATING_ZONE_PREFIX)
+        )
     return tuple(drift)
 
 

--- a/src/djinn_in_a_box/commands/doctor.py
+++ b/src/djinn_in_a_box/commands/doctor.py
@@ -164,29 +164,47 @@ def _docker_mcp_ok() -> bool:
 
 
 def _old_sync_root_present(config: AppConfig | None) -> bool:
-    """True if a populated legacy ~/.djinn/sync exists while the new root is empty.
+    """True if a legacy agent has content absent from every current zone.
 
     Covers the no-migration rename: the user's old credentials live under the
     legacy root and would be silently orphaned otherwise.
     """
     legacy = Path.home() / ".djinn" / "sync"
     try:
-        legacy_populated = legacy.is_dir() and any(legacy.iterdir())
+        if not legacy.is_dir():
+            return False
     except OSError:
         # An unreadable (e.g. root-owned) legacy dir is itself the strongest signal
         # the migration hint is needed — degrade to "present", never raise. A
         # diagnostic must not crash on the condition it exists to diagnose.
         return True
-    if not legacy_populated:
-        return False
 
-    new_root = get_config_root(config)
-    try:
-        return not new_root.is_dir() or not any(new_root.iterdir())
-    except OSError:
-        # A new-root access problem is not a legacy-migration signal — don't emit
-        # the misleading "mv ~/.djinn/sync" remedy for it.
-        return False
+    roots = resolve_zone_roots(config)
+    current_roots = (roots.config_root, roots.shared_root, roots.local_root)
+    for agent in SYNC_PATHS["credentials"]:
+        legacy_agent = legacy / agent
+        try:
+            legacy_entries = tuple(legacy_agent.iterdir()) if legacy_agent.is_dir() else ()
+        except OSError:
+            return True
+        for legacy_entry in legacy_entries:
+            try:
+                present = any(
+                    _path_has_content(root / agent / legacy_entry.name) for root in current_roots
+                )
+            except OSError:
+                # A new-root access problem is not a legacy-migration signal — don't emit
+                # the misleading migration remedy for it.
+                return False
+            if not present:
+                return True
+    return False
+
+
+def _path_has_content(path: Path) -> bool:
+    if path.is_symlink() or path.is_file():
+        return True
+    return path.is_dir() and any(path.iterdir())
 
 
 def _seed_target_has_expected_type(path: Path, kind: str) -> bool:
@@ -315,6 +333,15 @@ def _unmigrated_detail(roots: ZoneRoots, assignment: ZoneAssignment) -> str:
     return f"{assignment.agent}/{assignment.relative_path} ({_format_size(_path_size_bytes(path))})"
 
 
+def _skipped_default_detail(roots: ZoneRoots, assignment: ZoneAssignment) -> tuple[str, Path]:
+    path = roots.config_root / assignment.agent
+    for part in assignment.relative_path.parts:
+        path /= part
+        if path.is_file():
+            break
+    return f"{assignment.agent}/{assignment.relative_path} (blocked by {path})", path
+
+
 def _zone_diagnostic_checks(config: AppConfig, assignments: ZoneAssignments) -> list[Check]:
     roots = resolve_zone_roots(config)
     unmigrated = find_unmigrated_assignments(assignments, roots)
@@ -329,6 +356,21 @@ def _zone_diagnostic_checks(config: AppConfig, assignments: ZoneAssignments) -> 
             "Run `djinn migrate-zones` to move the assigned paths." if unmigrated else "",
         )
     ]
+
+    skipped_defaults = tuple(
+        _skipped_default_detail(roots, assignment) for assignment in assignments.skipped_defaults
+    )
+    skipped_paths = ", ".join(str(path) for _, path in skipped_defaults)
+    checks.append(
+        Check(
+            "Skipped shipped zone defaults",
+            Status.WARN if skipped_defaults else Status.PASS,
+            "; ".join(detail for detail, _ in skipped_defaults) if skipped_defaults else "none",
+            f"Move or remove the conflicting regular file: {skipped_paths}."
+            if skipped_defaults
+            else "",
+        )
+    )
 
     collisions = find_zone_collisions(assignments, roots)
     collision_details = "; ".join(
@@ -535,9 +577,10 @@ def run_checks(config: AppConfig | None, config_error: str | None = None) -> lis
             Check(
                 "Legacy sync root",
                 Status.WARN,
-                "~/.djinn/sync is populated but the new config root is empty",
-                "Move it once: `mv ~/.djinn/sync ~/.djinn/config` "
-                "(DJINN_SYNC_ROOT was renamed to DJINN_CONFIG_ROOT).",
+                "~/.djinn/sync has agent content absent from the current zone roots",
+                "Merge each agent entry into its matching current root; do not move the whole "
+                "legacy root into an existing config root (DJINN_SYNC_ROOT was renamed to "
+                "DJINN_CONFIG_ROOT).",
             )
         )
 

--- a/src/djinn_in_a_box/commands/doctor.py
+++ b/src/djinn_in_a_box/commands/doctor.py
@@ -17,27 +17,34 @@ import subprocess
 from dataclasses import dataclass
 from enum import Enum
 from pathlib import Path
-from typing import Annotated
+from typing import Annotated, Final
 
 import typer
 from rich.table import Table
 from rich.text import Text
 
-from djinn_in_a_box.config.defaults import SYNC_PATHS
+from djinn_in_a_box.config.defaults import KNOWN_CONFIG_ROOT_ENTRIES, SYNC_PATHS
 from djinn_in_a_box.config.models import AppConfig
+from djinn_in_a_box.config.zones import ZoneAssignment, ZoneAssignments, load_zone_assignments
 from djinn_in_a_box.core.config_sync import audit_config_sync as audit_workflow_config
 from djinn_in_a_box.core.console import blank, console, error, rule, warning
 from djinn_in_a_box.core.docker import (
     DJINN_NETWORK,
+    ZoneRoots,
     ensure_host_env,
     ensure_network,
     get_config_root,
     get_dbus_mount_args,
     network_exists,
+    resolve_zone_roots,
 )
 from djinn_in_a_box.core.exceptions import ConfigNotFoundError, ConfigValidationError
 from djinn_in_a_box.core.paths import CONFIG_FILE, get_project_root
 from djinn_in_a_box.core.seeding import SEED_MANIFEST, SeedingError, seed_config
+from djinn_in_a_box.core.zone_migration import (
+    find_unmigrated_assignments,
+    find_zone_collisions,
+)
 
 _IMAGE: str = "djinn-in-a-box:latest"
 
@@ -63,25 +70,47 @@ class Check:
 CREDENTIAL_DIR_MODE = 0o700
 """Intended mode for credential directories under the config root."""
 
+LARGE_NON_OVERLAYABLE_FILE_BYTES: Final = 10 * 1024 * 1024
+"""Report individual config-zone files at least this large."""
 
-def loose_credential_dirs(config: AppConfig | None) -> list[Path]:
-    """Credential directories that are group- or other-accessible.
+
+def loose_credential_dirs(
+    config: AppConfig | None,
+    assignments: ZoneAssignments | None = None,
+) -> list[Path]:
+    """Managed credential and zone directories that are group- or other-accessible.
 
     ``ensure_host_env`` creates these with ``mode=0o700``, but ``Path.mkdir``
     applies a mode only at creation — a config root provisioned before that
     change keeps the umask default. This finds the drift so ``doctor --fix``
     can repair it.
 
-    Deliberately narrow, per the safety constraints of the issue: only the
-    names in ``SYNC_PATHS["credentials"]``, only directly under the resolved
-    root, and ``lstat`` rather than ``stat`` so a symlinked name is skipped
+    The audit includes zone roots and the agent/assignment directories Djinn
+    creates beneath them. It still uses ``lstat`` so a symlinked name is skipped
     instead of followed — a redirect is someone's deliberate arrangement, not
     ours to chmod.
     """
-    root = get_config_root(config)
+    roots = resolve_zone_roots(config)
+    candidates: list[Path] = [roots.config_root, roots.shared_root, roots.local_root]
+    candidates.extend(roots.config_root / name for name in SYNC_PATHS.get("credentials", []))
+    if assignments is not None:
+        zone_roots = {"local": roots.local_root, "shared": roots.shared_root}
+        for agent, by_zone in assignments.by_agent.items():
+            for zone in ("local", "shared"):
+                root = zone_roots[zone]
+                for relative_path in by_zone[zone]:
+                    current = root / agent
+                    candidates.append(current)
+                    for part in relative_path.parts:
+                        current /= part
+                        candidates.append(current)
+
     loose: list[Path] = []
-    for name in SYNC_PATHS.get("credentials", []):
-        path = root / name
+    seen: set[Path] = set()
+    for path in candidates:
+        if path in seen:
+            continue
+        seen.add(path)
         try:
             info = path.lstat()
         except OSError:
@@ -211,6 +240,145 @@ def _config_workflow_check(config: AppConfig | None) -> Check:
     )
 
 
+def _format_size(size: int) -> str:
+    if size < 1024:
+        return f"{size} B"
+    value = float(size)
+    for unit in ("KiB", "MiB", "GiB", "TiB"):
+        value /= 1024
+        if value < 1024:
+            return f"{value:.1f} {unit}"
+    return f"{value:.1f} PiB"
+
+
+def _path_size_bytes(path: Path) -> int:
+    """Return a path's size without following symlinks; unreadable entries count as zero."""
+    try:
+        info = path.lstat()
+    except OSError:
+        return 0
+    if stat.S_ISREG(info.st_mode):
+        return info.st_size
+    if not stat.S_ISDIR(info.st_mode):
+        return 0
+    total = 0
+    try:
+        children = tuple(path.iterdir())
+    except OSError:
+        return 0
+    for child in children:
+        total += _path_size_bytes(child)
+    return total
+
+
+def _zone_drift_entries(config: AppConfig, assignments: ZoneAssignments) -> tuple[Path, ...]:
+    roots = resolve_zone_roots(config)
+    drift: list[Path] = []
+    for agent, by_zone in assignments.by_agent.items():
+        agent_root = roots.config_root / agent
+        if not agent_root.is_dir() or agent_root.is_symlink():
+            continue
+        accounted = set(KNOWN_CONFIG_ROOT_ENTRIES[agent])
+        for zone in ("local", "shared"):
+            accounted.update(path.parts[0] for path in by_zone[zone])
+        try:
+            children = tuple(agent_root.iterdir())
+        except OSError:
+            continue
+        drift.extend(child for child in children if child.name not in accounted)
+    return tuple(drift)
+
+
+def _large_non_overlayable_files(config: AppConfig) -> tuple[Path, ...]:
+    root = get_config_root(config)
+    large_files: list[Path] = []
+    for agent in KNOWN_CONFIG_ROOT_ENTRIES:
+        agent_root = root / agent
+        if not agent_root.is_dir() or agent_root.is_symlink():
+            continue
+        try:
+            children = tuple(agent_root.iterdir())
+        except OSError:
+            continue
+        for child in children:
+            try:
+                info = child.lstat()
+            except OSError:
+                continue
+            if stat.S_ISREG(info.st_mode) and info.st_size >= LARGE_NON_OVERLAYABLE_FILE_BYTES:
+                large_files.append(child)
+    return tuple(large_files)
+
+
+def _unmigrated_detail(roots: ZoneRoots, assignment: ZoneAssignment) -> str:
+    path = roots.config_root / assignment.agent / assignment.relative_path
+    return f"{assignment.agent}/{assignment.relative_path} ({_format_size(_path_size_bytes(path))})"
+
+
+def _zone_diagnostic_checks(config: AppConfig, assignments: ZoneAssignments) -> list[Check]:
+    roots = resolve_zone_roots(config)
+    unmigrated = find_unmigrated_assignments(assignments, roots)
+    unmigrated_details = "; ".join(
+        _unmigrated_detail(roots, assignment) for assignment in unmigrated
+    )
+    checks = [
+        Check(
+            "Unmigrated zone assignments",
+            Status.WARN if unmigrated else Status.PASS,
+            unmigrated_details if unmigrated else "none",
+            "Run `djinn migrate-zones` to move the assigned paths." if unmigrated else "",
+        )
+    ]
+
+    collisions = find_zone_collisions(assignments, roots)
+    collision_details = "; ".join(
+        ", ".join(
+            f"{path} ({_format_size(_path_size_bytes(path))})" for path in collision.populated_paths
+        )
+        for collision in collisions
+    )
+    checks.append(
+        Check(
+            "Unresolved zone collisions",
+            Status.WARN if collisions else Status.PASS,
+            collision_details if collisions else "none",
+            "Keep the config-root copy, keep the zone copy, or merge the trees by hand."
+            if collisions
+            else "",
+        )
+    )
+
+    drift = _zone_drift_entries(config, assignments)
+    checks.append(
+        Check(
+            "Zone drift",
+            Status.WARN if drift else Status.PASS,
+            ", ".join(str(path) for path in drift) if drift else "none",
+            (
+                "Review these agent-root entries; add directory assignments in zones.toml "
+                "when appropriate."
+            )
+            if drift
+            else "",
+        )
+    )
+
+    large_files = _large_non_overlayable_files(config)
+    checks.append(
+        Check(
+            "Large non-overlayable files",
+            Status.WARN if large_files else Status.PASS,
+            ", ".join(f"{path} ({_format_size(_path_size_bytes(path))})" for path in large_files)
+            if large_files
+            else "none",
+            "Review or remove these config-zone files; Djinn only overlays directories."
+            if large_files
+            else "",
+        )
+    )
+    return checks
+
+
 # -----------------------------------------------------------------------------
 # Check assembly
 # -----------------------------------------------------------------------------
@@ -310,15 +478,27 @@ def run_checks(config: AppConfig | None, config_error: str | None = None) -> lis
             )
         )
 
-        loose = loose_credential_dirs(config)
-        checks.append(
-            Check(
-                "Credential dir modes",
-                Status.PASS if not loose else Status.WARN,
-                "0700" if not loose else ", ".join(path.name for path in loose),
-                "" if not loose else "Run `djinn doctor --fix` to tighten them to 0700.",
+        try:
+            assignments = load_zone_assignments(config)
+            loose = loose_credential_dirs(config, assignments)
+            checks.append(
+                Check(
+                    "Credential and zone dir modes",
+                    Status.PASS if not loose else Status.WARN,
+                    "0700" if not loose else ", ".join(str(path) for path in loose),
+                    "" if not loose else "Run `djinn doctor --fix` to tighten them to 0700.",
+                )
             )
-        )
+            checks.extend(_zone_diagnostic_checks(config, assignments))
+        except (ConfigValidationError, OSError) as exc:
+            checks.append(
+                Check(
+                    "Zone configuration",
+                    Status.WARN,
+                    str(exc),
+                    "Fix the zone roots or zones.toml, then re-run `djinn doctor`.",
+                )
+            )
 
     image = daemon and _image_built()
     checks.append(
@@ -447,7 +627,13 @@ def _doctor_fix(config: AppConfig) -> bool:
     # After ensure_host_env, so a directory it just created is already tight and
     # does not show up here. Reported per path: a silent chmod on a credential
     # store is exactly the kind of change that should be visible.
-    for path in loose_credential_dirs(config):
+    try:
+        assignments = load_zone_assignments(config)
+    except ConfigValidationError as exc:
+        failed = True
+        console.print(f"Could not fix: zone directory modes ({exc})")
+        assignments = None
+    for path in loose_credential_dirs(config, assignments):
         try:
             path.chmod(CREDENTIAL_DIR_MODE)
         except OSError as e:

--- a/src/djinn_in_a_box/commands/migrate_zones.py
+++ b/src/djinn_in_a_box/commands/migrate_zones.py
@@ -1,0 +1,65 @@
+"""Explicit, locked migration of agent config paths into their assigned zones."""
+
+from __future__ import annotations
+
+import typer
+
+from djinn_in_a_box.config.loader import load_config
+from djinn_in_a_box.config.zones import load_zone_assignments
+from djinn_in_a_box.core.config_lock import (
+    ConfigDirectoryLockBusyError,
+    config_directory_lock,
+)
+from djinn_in_a_box.core.console import error, info, success
+from djinn_in_a_box.core.decorators import handle_config_errors
+from djinn_in_a_box.core.docker import ensure_zone_roots, get_running_containers
+from djinn_in_a_box.core.zone_migration import reconcile_zone_assignments
+
+
+def _guard_no_containers_running() -> None:
+    running = get_running_containers()
+    if running:
+        error(f"Containers are running: {', '.join(running)}")
+        error("Stop all containers before migrating zones (djinn clean)")
+        raise typer.Exit(1)
+
+
+@handle_config_errors
+def migrate_zones() -> None:
+    """Move assigned agent paths out of the backed-up config root."""
+    config = load_config()
+    roots = ensure_zone_roots(config)
+    try:
+        with config_directory_lock(roots.local_root, exclusive=True, blocking=False):
+            _guard_no_containers_running()
+            assignments = load_zone_assignments(config)
+            typer.confirm(
+                "Migration removes paths from the config root, which your mirroring layer "
+                "will see as deletions. Add the shared root to mirroring (keep the local "
+                "root out), or pause mirroring before continuing. Continue?",
+                abort=True,
+            )
+            result = reconcile_zone_assignments(
+                config,
+                assignments=assignments,
+                before_publish=_guard_no_containers_running,
+            )
+    except ConfigDirectoryLockBusyError:
+        error(f"Zone migration is already in progress at {roots.local_root}. Wait, then retry.")
+        raise typer.Exit(1) from None
+
+    if result.collisions:
+        for collision in result.collisions:
+            locations = ", ".join(str(path) for path in collision.populated_paths)
+            error(
+                "Unresolved zone collision; no paths were moved: "
+                f"{locations}. Run `djinn doctor` to inspect the copies."
+            )
+        raise typer.Exit(1)
+    if not result.moves:
+        success("Zone migration is already complete.")
+        return
+    for move in result.moves:
+        method = "copied and published" if move.copied_across_filesystems else "renamed"
+        info(f"{method}: {move.source} -> {move.destination}")
+    success(f"Zone migration complete: {len(result.moves)} path(s) moved.")

--- a/src/djinn_in_a_box/commands/migrate_zones.py
+++ b/src/djinn_in_a_box/commands/migrate_zones.py
@@ -33,9 +33,9 @@ def migrate_zones() -> None:
     """Move assigned agent paths out of the backed-up config root."""
     config = load_config()
     roots = ensure_zone_roots(config)
+    _guard_no_containers_running()
     try:
         with config_directory_lock(roots.local_root, exclusive=True, blocking=False):
-            _guard_no_containers_running()
             assignments = load_zone_assignments(config)
             typer.confirm(
                 "Migration removes paths from the config root, which your mirroring layer "

--- a/src/djinn_in_a_box/commands/migrate_zones.py
+++ b/src/djinn_in_a_box/commands/migrate_zones.py
@@ -18,6 +18,10 @@ from djinn_in_a_box.core.zone_migration import reconcile_zone_assignments
 
 def _guard_no_containers_running() -> None:
     running = get_running_containers()
+    if running is None:
+        error("Could not determine whether Djinn containers are running.")
+        error("Restore Docker access before migrating zones, then retry.")
+        raise typer.Exit(1)
     if running:
         error(f"Containers are running: {', '.join(running)}")
         error("Stop all containers before migrating zones (djinn clean)")

--- a/src/djinn_in_a_box/commands/zone_gate.py
+++ b/src/djinn_in_a_box/commands/zone_gate.py
@@ -1,0 +1,64 @@
+"""Shared migration locks and refusal messages for zone-sensitive commands."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Literal
+
+import typer
+
+from djinn_in_a_box.config.models import AppConfig
+from djinn_in_a_box.config.zones import load_zone_assignments
+from djinn_in_a_box.core.config_lock import (
+    ConfigDirectoryLockBusyError,
+    config_directory_lock,
+)
+from djinn_in_a_box.core.console import error
+from djinn_in_a_box.core.docker import ensure_zone_roots
+from djinn_in_a_box.core.zone_migration import (
+    find_unmigrated_assignments,
+    find_zone_collisions,
+)
+
+type GatedCommand = Literal["start", "run", "backup", "restore", "clean"]
+
+
+@contextmanager
+def zone_command_gate(config: AppConfig | None, command: GatedCommand) -> Iterator[None]:
+    roots = ensure_zone_roots(config)
+    try:
+        with config_directory_lock(roots.local_root, exclusive=False, blocking=False):
+            assignments = load_zone_assignments(config)
+            collisions = find_zone_collisions(assignments, roots)
+            if collisions:
+                _refuse_collision(collisions[0].populated_paths, collisions[0].destination)
+            unmigrated = find_unmigrated_assignments(assignments, roots)
+            if unmigrated and command in {"start", "run"}:
+                _refuse_unmigrated(unmigrated[0].agent, unmigrated[0].relative_path)
+            yield
+    except ConfigDirectoryLockBusyError:
+        error(
+            "Zone migration is in progress at "
+            f"{roots.local_root}. Wait for it to finish, then retry."
+        )
+        raise typer.Exit(1) from None
+
+
+def _refuse_unmigrated(agent: str, relative_path: Path) -> None:
+    error(
+        f"Zone data remains in the config root at {agent}/{relative_path}. "
+        "Run `djinn migrate-zones` before starting an agent."
+    )
+    raise typer.Exit(1)
+
+
+def _refuse_collision(paths: tuple[Path, ...], destination: Path) -> None:
+    locations = ", ".join(str(path) for path in paths)
+    error(
+        "Unresolved zone collision between "
+        f"{locations} (destination: {destination}). Run `djinn doctor` to inspect and "
+        "resolve the copies manually."
+    )
+    raise typer.Exit(1)

--- a/src/djinn_in_a_box/commands/zone_gate.py
+++ b/src/djinn_in_a_box/commands/zone_gate.py
@@ -27,10 +27,12 @@ type GatedCommand = Literal["start", "run", "backup", "restore", "clean"]
 
 
 @contextmanager
-def zone_command_gate(config: AppConfig | None, command: GatedCommand) -> Iterator[None]:
+def zone_command_gate(
+    config: AppConfig | None, command: GatedCommand, *, exclusive: bool = False
+) -> Iterator[None]:
     roots = ensure_zone_roots(config)
     try:
-        with config_directory_lock(roots.local_root, exclusive=False, blocking=False):
+        with config_directory_lock(roots.local_root, exclusive=exclusive, blocking=False):
             assignments = load_zone_assignments(config)
             if command in {"start", "run"}:
                 ensure_zone_targets(assignments, roots)

--- a/src/djinn_in_a_box/commands/zone_gate.py
+++ b/src/djinn_in_a_box/commands/zone_gate.py
@@ -18,6 +18,7 @@ from djinn_in_a_box.core.config_lock import (
 from djinn_in_a_box.core.console import error
 from djinn_in_a_box.core.docker import ensure_zone_roots
 from djinn_in_a_box.core.zone_migration import (
+    ensure_zone_targets,
     find_unmigrated_assignments,
     find_zone_collisions,
 )
@@ -31,6 +32,8 @@ def zone_command_gate(config: AppConfig | None, command: GatedCommand) -> Iterat
     try:
         with config_directory_lock(roots.local_root, exclusive=False, blocking=False):
             assignments = load_zone_assignments(config)
+            if command in {"start", "run"}:
+                ensure_zone_targets(assignments, roots)
             collisions = find_zone_collisions(assignments, roots)
             if collisions:
                 _refuse_collision(collisions[0].populated_paths, collisions[0].destination)

--- a/src/djinn_in_a_box/config/defaults.py
+++ b/src/djinn_in_a_box/config/defaults.py
@@ -39,6 +39,57 @@ SYNC_PATHS: Final[dict[str, list[str]]] = {
 machines by the user)."""
 
 
+DEFAULT_ZONES: Final[dict[str, dict[str, list[str]]]] = {
+    "claude": {
+        "local": [
+            "jobs",
+            "cache",
+            "file-history",
+            "ide",
+            "paste-cache",
+            "session-env",
+            "shell-snapshots",
+            "tasks",
+            "telemetry",
+            "work",
+            "sessions",
+            "daemon",
+            "plugins/marketplaces",
+            "plugins/cache",
+        ],
+        "shared": ["projects", "transcripts"],
+    },
+    "codex": {
+        "local": [
+            ".tmp",
+            "tmp",
+            "cache",
+            "log",
+            "mcp-oauth-locks",
+            "shell_snapshots",
+            "plugins/cache",
+        ],
+        "shared": ["sessions"],
+    },
+    "opencode": {
+        "local": ["node_modules", "native"],
+        "shared": [],
+    },
+    "gemini": {
+        "local": ["tmp"],
+        "shared": ["history"],
+    },
+    "gh": {
+        "local": [],
+        "shared": [],
+    },
+    "age": {
+        "local": [],
+        "shared": [],
+    },
+}
+
+
 DEFAULT_AGENTS: Final[dict[str, AgentConfig]] = {
     "claude": AgentConfig(
         binary="claude",

--- a/src/djinn_in_a_box/config/defaults.py
+++ b/src/djinn_in_a_box/config/defaults.py
@@ -90,6 +90,82 @@ DEFAULT_ZONES: Final[dict[str, dict[str, list[str]]]] = {
 }
 
 
+KNOWN_CONFIG_ROOT_ENTRIES: Final[dict[str, frozenset[str]]] = {
+    "claude": frozenset(
+        {
+            ".credentials.json",
+            "claude.json",
+            "settings.json",
+            "secrets",
+            "plugins",
+            "agents",
+            "commands",
+            "context",
+            "scripts",
+            "skills",
+            "CLAUDE.md",
+            "AGENTS.md",
+            "backups",
+            "history.jsonl",
+            "bin-shellcheck",
+            "daemon.log",
+            "daemon.lock",
+            "daemon.status.json",
+            "stats-cache.json",
+            "gh-pr-status-cache.json",
+            ".last-cleanup",
+            ".last-update-result.json",
+            "plugin-catalog-cache.json",
+        }
+    ),
+    "codex": frozenset(
+        {
+            "auth.json",
+            "config.toml",
+            "config.example.toml",
+            "hooks.json",
+            "hooks",
+            "rules",
+            "memories",
+            "version.json",
+            ".djinn-workflow-state.json",
+            ".personality_migration",
+            ".sandbox_migration",
+            "agents",
+            "context",
+            "scripts",
+            "skills",
+            "CLAUDE.md",
+            "AGENTS.md",
+            "backups",
+            "logs_2.sqlite",
+            "state_5.sqlite",
+            "goals_1.sqlite",
+            "memories_1.sqlite",
+            "models_cache.json",
+            "history.jsonl",
+            "session_index.jsonl",
+            "installation_id",
+        }
+    ),
+    "opencode": frozenset(
+        {
+            "auth.json",
+            "mcp-auth.json",
+            ".opencode.json",
+            "package.json",
+            "package-lock.json",
+            "seed",
+            ".gitignore",
+        }
+    ),
+    "gemini": frozenset({"settings.json", "installation_id"}),
+    "gh": frozenset({"hosts.yml"}),
+    "age": frozenset({"keys.txt"}),
+}
+"""Known top-level agent configuration entries retained in the config zone."""
+
+
 DEFAULT_AGENTS: Final[dict[str, AgentConfig]] = {
     "claude": AgentConfig(
         binary="claude",

--- a/src/djinn_in_a_box/config/loader.py
+++ b/src/djinn_in_a_box/config/loader.py
@@ -159,6 +159,8 @@ def save_config(config: AppConfig, path: Path | None = None) -> None:
             "code_dir": data.pop("code_dir"),
             "timezone": data.pop("timezone"),
             "config_root": data.pop("config_root"),
+            **({"shared_root": data.pop("shared_root")} if "shared_root" in data else {}),
+            **({"local_root": data.pop("local_root")} if "local_root" in data else {}),
         },
         **data,
     }

--- a/src/djinn_in_a_box/config/models.py
+++ b/src/djinn_in_a_box/config/models.py
@@ -172,6 +172,12 @@ class AppConfig(BaseModel):
     config_root: Path = Field(default_factory=lambda: Path.home() / ".djinn" / "config")
     """Root for config/credential bind-mounts (DJINN_CONFIG_ROOT). Local, per-host."""
 
+    shared_root: Path | None = None
+    """Optional root for mirrorable, non-backed-up agent data."""
+
+    local_root: Path | None = None
+    """Optional root for host-local, rebuildable agent data."""
+
     resources: ResourceLimits = Field(default_factory=ResourceLimits)
     """Docker resource limits and reservations."""
 
@@ -206,5 +212,13 @@ class AppConfig(BaseModel):
     @field_validator("config_root", mode="before")
     @classmethod
     def expand_config_root(cls, value: str | Path) -> Path:
+        path = Path(value) if isinstance(value, str) else value
+        return path.expanduser().resolve()
+
+    @field_validator("shared_root", "local_root", mode="before")
+    @classmethod
+    def expand_optional_zone_root(cls, value: str | Path | None) -> Path | None:
+        if value is None:
+            return None
         path = Path(value) if isinstance(value, str) else value
         return path.expanduser().resolve()

--- a/src/djinn_in_a_box/config/zones.py
+++ b/src/djinn_in_a_box/config/zones.py
@@ -148,6 +148,8 @@ def _validate_assignment(
     source_path = Path(agent) / relative_path
     has_symlink, has_file = _source_has_symlink_or_file(source, source_path)
     if has_symlink:
+        if candidate.is_default:
+            return None
         msg = (
             f"Zone assignment for {agent}.{candidate.zone} has a symlinked component: "
             f"{candidate.raw_path!r}"

--- a/src/djinn_in_a_box/config/zones.py
+++ b/src/djinn_in_a_box/config/zones.py
@@ -22,6 +22,8 @@ from djinn_in_a_box.core.paths import ZONES_FILE
 
 type ZoneName = Literal["local", "shared"]
 _ZONE_NAMES: Final[tuple[ZoneName, ...]] = ("local", "shared")
+MIGRATING_ZONE_PREFIX: Final[str] = ".djinn-migrating-"
+"""Reserved directory prefix for an in-progress cross-filesystem migration."""
 
 ZONE_CONTAINER_TARGETS: Final[dict[str, Path]] = {
     "claude": Path("/home/dev/.claude"),
@@ -99,6 +101,9 @@ def _validate_relative_path(agent: str, zone: ZoneName, raw_path: str) -> Path:
         raise ZoneConfigurationError(msg)
     if not raw_path or any(part in {"", ".", ".."} for part in parts):
         msg = f"Zone assignment for {agent}.{zone} contains an invalid path component: {raw_path!r}"
+        raise ZoneConfigurationError(msg)
+    if any(part.startswith(MIGRATING_ZONE_PREFIX) for part in parts):
+        msg = f"Zone assignment for {agent}.{zone} uses a reserved migration path: {raw_path!r}"
         raise ZoneConfigurationError(msg)
     return path
 

--- a/src/djinn_in_a_box/config/zones.py
+++ b/src/djinn_in_a_box/config/zones.py
@@ -1,0 +1,229 @@
+from __future__ import annotations
+
+import tomllib
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Final, Literal
+
+from pydantic import BaseModel, ConfigDict, Field, ValidationError
+
+from djinn_in_a_box.config.defaults import DEFAULT_ZONES
+from djinn_in_a_box.config.models import AppConfig
+from djinn_in_a_box.core.docker import (
+    ZoneRoots,
+    repo_owned_submount_targets,
+    resolve_zone_roots,
+)
+from djinn_in_a_box.core.exceptions import (
+    ConfigNotFoundError,
+    ZoneConfigurationError,
+)
+from djinn_in_a_box.core.paths import ZONES_FILE
+
+type ZoneName = Literal["local", "shared"]
+_ZONE_NAMES: Final[tuple[ZoneName, ...]] = ("local", "shared")
+
+ZONE_CONTAINER_TARGETS: Final[dict[str, Path]] = {
+    "claude": Path("/home/dev/.claude"),
+    "codex": Path("/home/dev/.codex"),
+    "opencode": Path("/home/dev/.opencode"),
+    "gemini": Path("/home/dev/.gemini"),
+    "gh": Path("/home/dev/.config/gh"),
+    "age": Path("/home/dev/.config/age"),
+}
+
+
+class _ZoneLists(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    local: tuple[str, ...] = ()
+    shared: tuple[str, ...] = ()
+
+
+class _ZoneFile(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    zones: dict[str, _ZoneLists] = Field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class ZoneAssignment:
+    agent: str
+    zone: ZoneName
+    relative_path: Path
+
+
+@dataclass(frozen=True)
+class ZoneAssignments:
+    by_agent: dict[str, dict[ZoneName, tuple[Path, ...]]]
+    skipped_defaults: tuple[ZoneAssignment, ...]
+
+
+@dataclass(frozen=True)
+class _Candidate:
+    zone: ZoneName
+    raw_path: str
+    is_default: bool
+
+
+def _load_zone_overrides(path: Path) -> dict[str, _ZoneLists]:
+    try:
+        with path.open("rb") as file:
+            data = tomllib.load(file)
+    except tomllib.TOMLDecodeError as error:
+        msg = f"Invalid TOML syntax in {path}: {error}"
+        raise ZoneConfigurationError(msg) from error
+
+    try:
+        return _ZoneFile.model_validate(data).zones
+    except ValidationError as error:
+        details = "\n".join(
+            f"  - {'.'.join(str(item) for item in entry['loc'])}: {entry['msg']}"
+            for entry in error.errors()
+        )
+        msg = f"Invalid zone configuration in {path}:\n{details}"
+        raise ZoneConfigurationError(msg) from error
+
+
+def _validate_agent(agent: str) -> None:
+    if agent not in ZONE_CONTAINER_TARGETS:
+        msg = f"Zone assignment for {agent!r} has no container mount target"
+        raise ZoneConfigurationError(msg)
+
+
+def _validate_relative_path(agent: str, zone: ZoneName, raw_path: str) -> Path:
+    parts = raw_path.split("/")
+    path = Path(raw_path)
+    if path.is_absolute():
+        msg = f"Zone assignment for {agent}.{zone} must be relative: {raw_path!r}"
+        raise ZoneConfigurationError(msg)
+    if not raw_path or any(part in {"", ".", ".."} for part in parts):
+        msg = f"Zone assignment for {agent}.{zone} contains an invalid path component: {raw_path!r}"
+        raise ZoneConfigurationError(msg)
+    return path
+
+
+def _repo_owned_target(agent: str, relative_path: Path) -> Path | None:
+    agent_target = ZONE_CONTAINER_TARGETS[agent]
+    target = agent_target / relative_path
+    for mount_target in repo_owned_submount_targets(agent_target):
+        if target == mount_target or target.is_relative_to(mount_target):
+            return mount_target
+    return None
+
+
+def _source_has_symlink_or_file(source: Path, relative_path: Path) -> tuple[bool, bool]:
+    current = source
+    if current.is_symlink():
+        return True, False
+    for part in relative_path.parts:
+        current /= part
+        if current.is_symlink():
+            return True, False
+        if current.is_file():
+            return False, True
+    return False, False
+
+
+def _validate_assignment(
+    roots: ZoneRoots,
+    agent: str,
+    candidate: _Candidate,
+) -> Path | None:
+    relative_path = _validate_relative_path(agent, candidate.zone, candidate.raw_path)
+    repo_owned_target = _repo_owned_target(agent, relative_path)
+    if repo_owned_target is not None:
+        msg = (
+            f"Zone assignment for {agent}.{candidate.zone} is under repo-owned mount "
+            f"{repo_owned_target}: {candidate.raw_path!r}"
+        )
+        raise ZoneConfigurationError(msg)
+
+    source = roots.config_root / agent
+    has_symlink, has_file = _source_has_symlink_or_file(source, relative_path)
+    if has_symlink:
+        msg = (
+            f"Zone assignment for {agent}.{candidate.zone} has a symlinked component: "
+            f"{candidate.raw_path!r}"
+        )
+        raise ZoneConfigurationError(msg)
+    if has_file:
+        if candidate.is_default:
+            return None
+        msg = (
+            f"Zone assignment for {agent}.{candidate.zone} resolves to a regular file: "
+            f"{candidate.raw_path!r}"
+        )
+        raise ZoneConfigurationError(msg)
+    return relative_path
+
+
+def _check_overlaps(agent: str, assignments: list[ZoneAssignment]) -> None:
+    for index, assignment in enumerate(assignments):
+        for other in assignments[index + 1 :]:
+            if assignment.relative_path == other.relative_path and assignment.zone != other.zone:
+                msg = (
+                    f"Zone assignment {assignment.relative_path!s} is in both "
+                    f"{assignment.zone} and {other.zone} for {agent}"
+                )
+                raise ZoneConfigurationError(msg)
+            first_is_nested = assignment.relative_path.is_relative_to(other.relative_path)
+            second_is_nested = other.relative_path.is_relative_to(assignment.relative_path)
+            if first_is_nested or second_is_nested:
+                msg = (
+                    f"Zone assignments overlap for {agent}: "
+                    f"{assignment.relative_path!s} and {other.relative_path!s}"
+                )
+                raise ZoneConfigurationError(msg)
+
+
+def _agent_candidates(agent: str, override: _ZoneLists | None) -> tuple[_Candidate, ...]:
+    candidates: list[_Candidate] = []
+    for zone in _ZONE_NAMES:
+        candidates.extend(
+            _Candidate(zone, path, True) for path in DEFAULT_ZONES[agent][zone]
+        )
+        if override is not None:
+            candidates.extend(_Candidate(zone, path, False) for path in getattr(override, zone))
+    return tuple(candidates)
+
+
+def load_zone_assignments(
+    config: AppConfig | None = None,
+    *,
+    path: Path | None = None,
+) -> ZoneAssignments:
+    roots = resolve_zone_roots(config)
+    zones_path = path or ZONES_FILE
+    if path is not None and not zones_path.exists():
+        raise ConfigNotFoundError(zones_path)
+    overrides = _load_zone_overrides(zones_path) if zones_path.exists() else {}
+
+    for agent in overrides:
+        _validate_agent(agent)
+
+    by_agent: dict[str, dict[ZoneName, tuple[Path, ...]]] = {}
+    skipped_defaults: list[ZoneAssignment] = []
+    for agent in ZONE_CONTAINER_TARGETS:
+        paths_by_zone: dict[ZoneName, list[Path]] = {"local": [], "shared": []}
+        assignments: list[ZoneAssignment] = []
+        seen_by_zone: dict[ZoneName, set[Path]] = {"local": set(), "shared": set()}
+        for candidate in _agent_candidates(agent, overrides.get(agent)):
+            relative_path = _validate_assignment(roots, agent, candidate)
+            if relative_path is None:
+                skipped_defaults.append(
+                    ZoneAssignment(agent, candidate.zone, Path(candidate.raw_path))
+                )
+                continue
+            if relative_path in seen_by_zone[candidate.zone]:
+                continue
+            seen_by_zone[candidate.zone].add(relative_path)
+            paths_by_zone[candidate.zone].append(relative_path)
+            assignments.append(ZoneAssignment(agent, candidate.zone, relative_path))
+        _check_overlaps(agent, assignments)
+        by_agent[agent] = {
+            "local": tuple(paths_by_zone["local"]),
+            "shared": tuple(paths_by_zone["shared"]),
+        }
+
+    return ZoneAssignments(by_agent, tuple(skipped_defaults))

--- a/src/djinn_in_a_box/config/zones.py
+++ b/src/djinn_in_a_box/config/zones.py
@@ -139,8 +139,9 @@ def _validate_assignment(
         )
         raise ZoneConfigurationError(msg)
 
-    source = roots.config_root / agent
-    has_symlink, has_file = _source_has_symlink_or_file(source, relative_path)
+    source = roots.config_root
+    source_path = Path(agent) / relative_path
+    has_symlink, has_file = _source_has_symlink_or_file(source, source_path)
     if has_symlink:
         msg = (
             f"Zone assignment for {agent}.{candidate.zone} has a symlinked component: "
@@ -152,6 +153,24 @@ def _validate_assignment(
             return None
         msg = (
             f"Zone assignment for {agent}.{candidate.zone} resolves to a regular file: "
+            f"{candidate.raw_path!r}"
+        )
+        raise ZoneConfigurationError(msg)
+
+    destination_root = roots.local_root if candidate.zone == "local" else roots.shared_root
+    destination_symlink, destination_file = _source_has_symlink_or_file(
+        destination_root,
+        source_path,
+    )
+    if destination_symlink:
+        msg = (
+            f"Zone assignment for {agent}.{candidate.zone} has a symlinked destination "
+            f"component: {candidate.raw_path!r}"
+        )
+        raise ZoneConfigurationError(msg)
+    if destination_file:
+        msg = (
+            f"Zone assignment for {agent}.{candidate.zone} has a destination regular file: "
             f"{candidate.raw_path!r}"
         )
         raise ZoneConfigurationError(msg)

--- a/src/djinn_in_a_box/core/config_lock.py
+++ b/src/djinn_in_a_box/core/config_lock.py
@@ -13,6 +13,10 @@ class ConfigDirectoryLockError(OSError):
     """A config-directory lock operation failed."""
 
 
+class ConfigDirectoryLockBusyError(ConfigDirectoryLockError):
+    """A non-blocking config-directory lock could not be acquired."""
+
+
 def _lock_error(config_dir: Path, error: OSError) -> ConfigDirectoryLockError:
     return ConfigDirectoryLockError(
         "Configuration directory lock failed at "
@@ -21,7 +25,9 @@ def _lock_error(config_dir: Path, error: OSError) -> ConfigDirectoryLockError:
 
 
 @contextmanager
-def config_directory_lock(config_dir: Path, *, exclusive: bool) -> Iterator[int]:
+def config_directory_lock(
+    config_dir: Path, *, exclusive: bool, blocking: bool = True
+) -> Iterator[int]:
     try:
         descriptor = os.open(config_dir, os.O_RDONLY | os.O_DIRECTORY)
     except OSError as error:
@@ -29,8 +35,14 @@ def config_directory_lock(config_dir: Path, *, exclusive: bool) -> Iterator[int]
     locked = False
     try:
         operation = fcntl.LOCK_EX if exclusive else fcntl.LOCK_SH
+        if not blocking:
+            operation |= fcntl.LOCK_NB
         try:
             fcntl.flock(descriptor, operation)
+        except BlockingIOError as error:
+            raise ConfigDirectoryLockBusyError(
+                f"Configuration directory lock is held at {config_dir}"
+            ) from error
         except OSError as error:
             raise _lock_error(config_dir, error) from error
         locked = True

--- a/src/djinn_in_a_box/core/docker.py
+++ b/src/djinn_in_a_box/core/docker.py
@@ -530,6 +530,41 @@ def get_dbus_mount_args() -> list[str]:
     ]
 
 
+def get_zone_overlay_mount_args(config: AppConfig) -> list[str]:
+    """Build bind-mount arguments for existing zone directories."""
+    args, _ = _zone_overlay_mount_args_and_targets(config)
+    return args
+
+
+def _zone_overlay_mount_args_and_targets(config: AppConfig) -> tuple[list[str], tuple[Path, ...]]:
+    """Return overlay arguments and every configured overlay target.
+
+    The targets are returned independently of source existence: a user mount at
+    an assigned target would otherwise be reported as applied and then silently
+    hidden when a later migration creates the overlay source.
+    """
+    # ``config.zones`` imports root resolution from this module, so retain this
+    # import at the runtime boundary rather than creating an import cycle.
+    from djinn_in_a_box.config.zones import ZONE_CONTAINER_TARGETS, load_zone_assignments
+
+    roots = resolve_zone_roots(config)
+    assignments = load_zone_assignments(config)
+    args: list[str] = []
+    targets: list[Path] = []
+    zone_roots = {"local": roots.local_root, "shared": roots.shared_root}
+    for agent, target_root in ZONE_CONTAINER_TARGETS.items():
+        for zone in ("local", "shared"):
+            for relative_path in assignments.by_agent[agent][zone]:
+                target = target_root / relative_path
+                targets.append(target)
+                source = zone_roots[zone] / agent / relative_path
+                # An empty directory is the completed-migration marker. It must
+                # overlay just like populated data; only a missing source skips.
+                if source.is_dir():
+                    args.extend(["-v", f"{source}:{target}"])
+    return args, tuple(targets)
+
+
 def _mount_targets_from_args(args: list[str]) -> list[Path]:
     """Extract container targets from volume arguments built in this module."""
     targets: list[Path] = []
@@ -613,9 +648,12 @@ def _reserved_mount_targets(
     shell_args: list[str] | None = None,
     audio_args: list[str] | None = None,
     dbus_args: list[str] | None = None,
+    zone_overlay_targets: tuple[Path, ...] | None = None,
 ) -> list[Path]:
     """Return targets occupied by this particular ``dev`` container invocation."""
-    targets = [*_COMPOSE_DEV_MOUNT_TARGETS, _MOUNT_ROOT]
+    if zone_overlay_targets is None:
+        _, zone_overlay_targets = _zone_overlay_mount_args_and_targets(config)
+    targets = [*_COMPOSE_DEV_MOUNT_TARGETS, *zone_overlay_targets, _MOUNT_ROOT]
     if docker_mode is DockerMode.DIRECT:
         targets.extend(_DIRECT_DOCKER_SOCKET_TARGETS)
     if shell_args is None:
@@ -652,6 +690,7 @@ def validate_container_mounts(
     shell_args: list[str] | None = None,
     audio_args: list[str] | None = None,
     dbus_args: list[str] | None = None,
+    zone_overlay_targets: tuple[Path, ...] | None = None,
 ) -> None:
     """Reject user targets that equal or are ancestors of an occupied target."""
     normalized_mounts = tuple(
@@ -665,6 +704,7 @@ def validate_container_mounts(
         shell_args=shell_args,
         audio_args=audio_args,
         dbus_args=dbus_args,
+        zone_overlay_targets=zone_overlay_targets,
     )
     occupied: list[tuple[Path, str, Path]] = []
     for target in reserved_targets:
@@ -817,6 +857,7 @@ def compose_run(
     dbus_args = _canonicalize_runtime_mount_args(
         get_dbus_mount_args() if dbus_mount_args is None else dbus_mount_args
     )
+    zone_overlay_args, zone_overlay_targets = _zone_overlay_mount_args_and_targets(config)
     validate_container_mounts(
         mounts,
         config,
@@ -824,6 +865,7 @@ def compose_run(
         shell_args=shell_args,
         audio_args=audio_args,
         dbus_args=dbus_args,
+        zone_overlay_targets=zone_overlay_targets,
     )
 
     for mount in mounts:
@@ -838,6 +880,7 @@ def compose_run(
         cmd.extend(["--workdir", str(workdir)])
 
     # Shell mounts (skip_mounts check is inside get_shell_mount_args)
+    cmd.extend(zone_overlay_args)
     cmd.extend(shell_args)
     cmd.extend(audio_args)
     cmd.extend(dbus_args)

--- a/src/djinn_in_a_box/core/docker.py
+++ b/src/djinn_in_a_box/core/docker.py
@@ -23,6 +23,7 @@ from djinn_in_a_box.core.console import warning
 from djinn_in_a_box.core.exceptions import (
     MountSpecificationError,
     RuntimeMountSpecificationError,
+    ZoneConfigurationError,
     ZoneRootValidationError,
 )
 from djinn_in_a_box.core.paths import get_project_root, resolve_mount_path
@@ -343,16 +344,16 @@ def _decode_timeout_output(
     return stdout, stderr
 
 
-def _docker_list(cmd: list[str]) -> list[str]:
+def _docker_list(cmd: list[str]) -> list[str] | None:
     try:
         result = subprocess.run(cmd, capture_output=True, text=True, check=False)
     except FileNotFoundError:
         warning("Docker is not installed")
-        return []
+        return None
     if result.returncode != 0:
         stderr_msg = result.stderr.strip() if result.stderr else f"exit code {result.returncode}"
         warning(f"Docker command failed: {stderr_msg}")
-        return []
+        return None
     if not result.stdout.strip():
         return []
     return [line for line in result.stdout.strip().split("\n") if line]
@@ -560,6 +561,9 @@ def _zone_overlay_mount_args_and_targets(config: AppConfig) -> tuple[list[str], 
                 source = zone_roots[zone] / agent / relative_path
                 # An empty directory is the completed-migration marker. It must
                 # overlay just like populated data; only a missing source skips.
+                if source.is_symlink() or (source.exists() and not source.is_dir()):
+                    msg = f"Zone overlay source is not a directory: {source}"
+                    raise ZoneConfigurationError(msg)
                 if source.is_dir():
                     args.extend(["-v", f"{source}:{target}"])
     return args, tuple(targets)
@@ -1166,10 +1170,10 @@ def cleanup_docker_proxy(docker_mode: DockerMode, config: AppConfig | None = Non
 
 def is_container_running(name: str) -> bool:
     names = _docker_list(["docker", "ps", "--format", "{{.Names}}", "--filter", f"name=^{name}$"])
-    return name in names
+    return names is not None and name in names
 
 
-def get_running_containers(prefix: str = "djinn") -> list[str]:
+def get_running_containers(prefix: str = "djinn") -> list[str] | None:
     return _docker_list(["docker", "ps", "--format", "{{.Names}}", "--filter", f"name={prefix}"])
 
 

--- a/src/djinn_in_a_box/core/docker.py
+++ b/src/djinn_in_a_box/core/docker.py
@@ -2,11 +2,13 @@
 
 from __future__ import annotations
 
+import errno
 import json
 import os
 import re
 import shutil
 import socket
+import stat
 import subprocess
 import sys
 import tempfile
@@ -1276,9 +1278,35 @@ def resolve_zone_roots(config: AppConfig | None = None) -> ZoneRoots:
 def ensure_zone_roots(config: AppConfig | None = None) -> ZoneRoots:
     roots = resolve_zone_roots(config)
     for root in (roots.config_root, roots.shared_root, roots.local_root):
-        root.mkdir(parents=True, exist_ok=True, mode=0o700)
-        root.chmod(0o700)
+        _ensure_zone_root(root)
     return roots
+
+
+def _ensure_zone_root(root: Path) -> None:
+    try:
+        info = root.lstat()
+    except FileNotFoundError:
+        try:
+            root.mkdir(parents=True, exist_ok=True, mode=0o700)
+            info = root.lstat()
+        except OSError as error:
+            msg = f"Cannot create zone root {root}: {error}"
+            raise ZoneRootValidationError(msg) from error
+    except OSError as error:
+        msg = f"Cannot inspect zone root {root}: {error}"
+        raise ZoneRootValidationError(msg) from error
+
+    if stat.S_ISLNK(info.st_mode):
+        msg = f"Zone root must not be a symlink: {root}"
+        raise ZoneRootValidationError(msg)
+    if not stat.S_ISDIR(info.st_mode):
+        msg = f"Zone root is not a directory: {root}"
+        raise ZoneRootValidationError(msg)
+    try:
+        root.chmod(0o700)
+    except OSError as error:
+        msg = f"Cannot secure zone root {root}: {error}"
+        raise ZoneRootValidationError(msg) from error
 
 
 def workflow_image_compatible(
@@ -1426,10 +1454,25 @@ def clear_sync_path(path: Path) -> bool:
 
 def _clear_directory_contents(path: Path) -> None:
     for item in path.iterdir():
-        if item.is_dir() and not item.is_symlink():
-            shutil.rmtree(item)
-        else:
-            item.unlink()
+        _remove_sync_path_item(item)
+
+
+def _remove_sync_path_item(path: Path) -> bool:
+    if path.is_dir() and not path.is_symlink():
+        for child in path.iterdir():
+            if not _remove_sync_path_item(child):
+                return False
+        try:
+            path.rmdir()
+        except OSError as error:
+            if error.errno not in {errno.EACCES, errno.EBUSY, errno.EPERM, None}:
+                raise
+            if next(path.iterdir(), None) is None:
+                return False
+            raise
+        return True
+    path.unlink()
+    return True
 
 
 def is_sync_archive(archive_name: str) -> bool:

--- a/src/djinn_in_a_box/core/docker.py
+++ b/src/djinn_in_a_box/core/docker.py
@@ -23,6 +23,7 @@ from djinn_in_a_box.core.console import warning
 from djinn_in_a_box.core.exceptions import (
     MountSpecificationError,
     RuntimeMountSpecificationError,
+    ZoneRootValidationError,
 )
 from djinn_in_a_box.core.paths import get_project_root, resolve_mount_path
 from djinn_in_a_box.core.seeding import workflow_root_is_uninitialized
@@ -76,6 +77,14 @@ _COMPOSE_DEV_MOUNT_TARGETS = (
     Path("/home/dev/projects"),
     Path("/home/dev/sessions"),
 )
+
+
+def repo_owned_submount_targets(agent_root: Path) -> tuple[Path, ...]:
+    return tuple(
+        target
+        for target in _COMPOSE_DEV_MOUNT_TARGETS
+        if target != agent_root and target.is_relative_to(agent_root)
+    )
 
 
 def _resolve_image_aliases(target: Path) -> Path:
@@ -1188,6 +1197,43 @@ def get_config_root(config: AppConfig | None = None) -> Path:
     return Path.home() / ".djinn" / "config"
 
 
+@dataclass(frozen=True)
+class ZoneRoots:
+    config_root: Path
+    shared_root: Path
+    local_root: Path
+
+
+def resolve_zone_roots(config: AppConfig | None = None) -> ZoneRoots:
+    config_root = get_config_root(config)
+    shared_root = (
+        config.shared_root
+        if config is not None and config.shared_root is not None
+        else Path(f"{config_root}.shared")
+    )
+    local_root = (
+        config.local_root
+        if config is not None and config.local_root is not None
+        else Path(f"{config_root}.local")
+    )
+    roots = ZoneRoots(config_root, shared_root, local_root)
+    root_paths = (roots.config_root, roots.shared_root, roots.local_root)
+    for index, root in enumerate(root_paths):
+        for other in root_paths[index + 1 :]:
+            if root == other or root.is_relative_to(other) or other.is_relative_to(root):
+                msg = f"Zone roots must be distinct and not nested: {root} and {other}"
+                raise ZoneRootValidationError(msg)
+    return roots
+
+
+def ensure_zone_roots(config: AppConfig | None = None) -> ZoneRoots:
+    roots = resolve_zone_roots(config)
+    for root in (roots.config_root, roots.shared_root, roots.local_root):
+        root.mkdir(parents=True, exist_ok=True, mode=0o700)
+        root.chmod(0o700)
+    return roots
+
+
 def workflow_image_compatible(
     image: str = _WORKFLOW_IMAGE,
 ) -> WorkflowImageCompatibility:
@@ -1254,11 +1300,14 @@ def ensure_host_env(config: AppConfig | None = None) -> None:
     is a host-side input read by ``_sync_build_files`` (a no-op when absent), not a
     compose bind-mount, so it cannot trigger the root-owned-mount footgun.
     """
-    root = get_config_root(config)
+    roots = ensure_zone_roots(config)
+    root = roots.config_root
     for name in SYNC_PATHS.get("credentials", []):
         # 0700: credential stores hold secrets (OAuth tokens, age identities).
         # Applies on creation only, matching the ~/.ssh precedent below.
-        (root / name).mkdir(parents=True, exist_ok=True, mode=0o700)
+        path = root / name
+        path.mkdir(parents=True, exist_ok=True, mode=0o700)
+        path.chmod(0o700)
 
     claude_root = get_project_root() / "config" / "claude"
     companion = claude_root / "AGENTS.md"

--- a/src/djinn_in_a_box/core/exceptions.py
+++ b/src/djinn_in_a_box/core/exceptions.py
@@ -15,6 +15,14 @@ class ConfigValidationError(ValueError):
     pass
 
 
+class ZoneConfigurationError(ConfigValidationError):
+    pass
+
+
+class ZoneRootValidationError(ZoneConfigurationError):
+    pass
+
+
 class MountSpecificationError(ValueError):
     """Raised when a ``--mount`` value cannot be resolved or parsed."""
 

--- a/src/djinn_in_a_box/core/paths.py
+++ b/src/djinn_in_a_box/core/paths.py
@@ -18,6 +18,9 @@ CONFIG_FILE: Path = CONFIG_DIR / "config.toml"
 AGENTS_FILE: Path = CONFIG_DIR / "agents.toml"
 """Agent definitions file path (optional user override)."""
 
+ZONES_FILE: Path = CONFIG_DIR / "zones.toml"
+"""Zone assignment overrides (optional user configuration)."""
+
 BACKUPS_DIR: Path = Path.home() / ".djinn" / "backups"
 """Backup directory for volume archives (~/.djinn/backups/)."""
 

--- a/src/djinn_in_a_box/core/zone_migration.py
+++ b/src/djinn_in_a_box/core/zone_migration.py
@@ -1,0 +1,272 @@
+"""Migration and reconciliation for assigned agent config zones."""
+
+from __future__ import annotations
+
+import errno
+import filecmp
+import os
+import shutil
+import tempfile
+from collections.abc import Callable, Iterable
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+
+from djinn_in_a_box.config.models import AppConfig
+from djinn_in_a_box.config.zones import ZoneAssignment, ZoneAssignments, load_zone_assignments
+from djinn_in_a_box.core.docker import ZoneRoots, ensure_zone_roots, resolve_zone_roots
+from djinn_in_a_box.core.exceptions import ZoneConfigurationError
+
+type BeforePublish = Callable[[], None]
+
+
+@dataclass(frozen=True)
+class ZoneCollision:
+    assignment: ZoneAssignment
+    destination: Path
+    populated_paths: tuple[Path, ...]
+
+
+@dataclass(frozen=True)
+class ZoneMove:
+    assignment: ZoneAssignment
+    source: Path
+    destination: Path
+    copied_across_filesystems: bool
+
+
+@dataclass(frozen=True)
+class ZoneReconciliation:
+    moves: tuple[ZoneMove, ...]
+    collisions: tuple[ZoneCollision, ...]
+
+
+def path_has_content(path: Path) -> bool:
+    if path.is_symlink() or path.is_file():
+        return True
+    if not path.is_dir():
+        return False
+    return next(path.iterdir(), None) is not None
+
+
+def find_unmigrated_assignments(
+    assignments: ZoneAssignments, roots: ZoneRoots
+) -> tuple[ZoneAssignment, ...]:
+    return tuple(
+        assignment
+        for assignment in _iter_assignments(assignments)
+        if path_has_content(roots.config_root / assignment.agent / assignment.relative_path)
+    )
+
+
+def find_zone_collisions(
+    assignments: ZoneAssignments, roots: ZoneRoots
+) -> tuple[ZoneCollision, ...]:
+    collisions: list[ZoneCollision] = []
+    for assignment in _iter_assignments(assignments):
+        destination = _zone_path(roots, assignment.zone, assignment)
+        populated_paths = tuple(
+            path for path in _assignment_paths(roots, assignment) if path_has_content(path)
+        )
+        if len(populated_paths) > 1:
+            collisions.append(ZoneCollision(assignment, destination, populated_paths))
+    return tuple(collisions)
+
+
+def reconcile_zone_assignments(
+    config: AppConfig | None = None,
+    *,
+    assignments: ZoneAssignments | None = None,
+    before_publish: BeforePublish | None = None,
+    stop_on_collision: bool = True,
+) -> ZoneReconciliation:
+    roots = ensure_zone_roots(config)
+    resolved_assignments = assignments or load_zone_assignments(config)
+    collisions = find_zone_collisions(resolved_assignments, roots)
+    if collisions and stop_on_collision:
+        return ZoneReconciliation((), collisions)
+
+    moves: list[ZoneMove] = []
+    for assignment in _iter_assignments(resolved_assignments):
+        if any(collision.assignment == assignment for collision in collisions):
+            continue
+        destination = _zone_path(roots, assignment.zone, assignment)
+        _ensure_directory(_zone_root(roots, assignment.zone), destination)
+        source = next(
+            (
+                path
+                for path in _assignment_paths(roots, assignment)
+                if path != destination and path_has_content(path)
+            ),
+            None,
+        )
+        if source is None:
+            _remove_empty_source_directories(roots, assignment, destination)
+            continue
+        moves.append(
+            ZoneMove(
+                assignment,
+                source,
+                destination,
+                _move_directory(source, destination, before_publish),
+            )
+        )
+    return ZoneReconciliation(tuple(moves), collisions)
+
+
+def adopt_archive_collision(
+    collision: ZoneCollision,
+    config: AppConfig | None = None,
+    *,
+    before_publish: BeforePublish | None = None,
+) -> Path:
+    roots = resolve_zone_roots(config)
+    config_path = (
+        roots.config_root / collision.assignment.agent / collision.assignment.relative_path
+    )
+    destination = collision.destination
+    if (
+        collision.destination not in collision.populated_paths
+        or config_path not in collision.populated_paths
+        or len(collision.populated_paths) != 2
+    ):
+        msg = (
+            "Archive adoption requires exactly the config-root and destination zone "
+            f"trees to be populated for {collision.assignment.agent}/"
+            f"{collision.assignment.relative_path}"
+        )
+        raise ZoneConfigurationError(msg)
+
+    displaced = _timestamped_sibling(destination)
+    os.replace(destination, displaced)
+    try:
+        _ensure_directory(_zone_root(roots, collision.assignment.zone), destination)
+        _move_directory(config_path, destination, before_publish)
+    except (OSError, ZoneConfigurationError):
+        os.replace(displaced, destination)
+        raise
+    return displaced
+
+
+def _iter_assignments(assignments: ZoneAssignments) -> Iterable[ZoneAssignment]:
+    for agent, by_zone in assignments.by_agent.items():
+        for zone in ("local", "shared"):
+            for relative_path in by_zone[zone]:
+                yield ZoneAssignment(agent, zone, relative_path)
+
+
+def _zone_path(roots: ZoneRoots, zone: str, assignment: ZoneAssignment) -> Path:
+    return _zone_root(roots, zone) / assignment.agent / assignment.relative_path
+
+
+def _zone_root(roots: ZoneRoots, zone: str) -> Path:
+    if zone == "local":
+        return roots.local_root
+    if zone == "shared":
+        return roots.shared_root
+    msg = f"Unsupported zone: {zone}"
+    raise ZoneConfigurationError(msg)
+
+
+def _assignment_paths(roots: ZoneRoots, assignment: ZoneAssignment) -> tuple[Path, ...]:
+    suffix = Path(assignment.agent) / assignment.relative_path
+    return (
+        roots.config_root / suffix,
+        roots.shared_root / suffix,
+        roots.local_root / suffix,
+    )
+
+
+def _ensure_directory(root: Path, path: Path) -> None:
+    root.chmod(0o700)
+    current = root
+    for part in path.relative_to(root).parts:
+        current /= part
+        current.mkdir(exist_ok=True, mode=0o700)
+        current.chmod(0o700)
+
+
+def _remove_empty_source_directories(
+    roots: ZoneRoots, assignment: ZoneAssignment, destination: Path
+) -> None:
+    for path in _assignment_paths(roots, assignment):
+        if (
+            path != destination
+            and path.is_dir()
+            and not path.is_symlink()
+            and not path_has_content(path)
+        ):
+            path.rmdir()
+
+
+def _move_directory(source: Path, destination: Path, before_publish: BeforePublish | None) -> bool:
+    if not source.is_dir() or source.is_symlink():
+        msg = f"Zone migration source is not a directory: {source}"
+        raise ZoneConfigurationError(msg)
+    if not destination.is_dir() or path_has_content(destination):
+        msg = f"Zone migration destination is not empty: {destination}"
+        raise ZoneConfigurationError(msg)
+    if before_publish is not None:
+        before_publish()
+    try:
+        os.replace(source, destination)
+    except OSError as error:
+        if error.errno != errno.EXDEV:
+            raise
+        _copy_then_publish(source, destination, before_publish)
+        return True
+    return False
+
+
+def _copy_then_publish(
+    source: Path, destination: Path, before_publish: BeforePublish | None
+) -> None:
+    staging_parent = Path(tempfile.mkdtemp(prefix=".djinn-zone-migrate-", dir=destination.parent))
+    staged_tree = staging_parent / "tree"
+    try:
+        shutil.copytree(source, staged_tree, symlinks=True)
+        if not _trees_match(source, staged_tree):
+            msg = f"Zone migration verification failed for {source}"
+            raise ZoneConfigurationError(msg)
+        if before_publish is not None:
+            before_publish()
+        os.replace(staged_tree, destination)
+        shutil.rmtree(source)
+    finally:
+        shutil.rmtree(staging_parent, ignore_errors=True)
+
+
+def _trees_match(source: Path, copied: Path) -> bool:
+    source_entries = {entry.name: entry for entry in os.scandir(source)}
+    copied_entries = {entry.name: entry for entry in os.scandir(copied)}
+    if source_entries.keys() != copied_entries.keys():
+        return False
+    for name, source_entry in source_entries.items():
+        copied_entry = copied_entries[name]
+        source_path = Path(source_entry.path)
+        copied_path = Path(copied_entry.path)
+        if source_entry.is_symlink() or copied_entry.is_symlink():
+            if not source_entry.is_symlink() or not copied_entry.is_symlink():
+                return False
+            if os.readlink(source_path) != os.readlink(copied_path):
+                return False
+        elif source_entry.is_dir(follow_symlinks=False):
+            if not copied_entry.is_dir(follow_symlinks=False) or not _trees_match(
+                source_path, copied_path
+            ):
+                return False
+        elif not copied_entry.is_file(follow_symlinks=False) or not filecmp.cmp(
+            source_path, copied_path, shallow=False
+        ):
+            return False
+    return True
+
+
+def _timestamped_sibling(path: Path) -> Path:
+    timestamp = datetime.now(tz=UTC).strftime("%Y%m%dT%H%M%SZ")
+    candidate = path.with_name(f"{path.name}.pre-restore-{timestamp}")
+    index = 1
+    while candidate.exists():
+        candidate = path.with_name(f"{path.name}.pre-restore-{timestamp}-{index}")
+        index += 1
+    return candidate

--- a/src/djinn_in_a_box/core/zone_migration.py
+++ b/src/djinn_in_a_box/core/zone_migration.py
@@ -43,11 +43,22 @@ class ZoneReconciliation:
 
 
 def path_has_content(path: Path) -> bool:
-    if path.is_symlink() or path.is_file():
-        return True
-    if not path.is_dir():
+    try:
+        info = path.lstat()
+    except FileNotFoundError:
         return False
-    return next(path.iterdir(), None) is not None
+    except OSError as error:
+        msg = f"Cannot inspect zone path {path}: {error}"
+        raise ZoneConfigurationError(msg) from error
+    if stat.S_ISLNK(info.st_mode) or stat.S_ISREG(info.st_mode):
+        return True
+    if not stat.S_ISDIR(info.st_mode):
+        return False
+    try:
+        return next(path.iterdir(), None) is not None
+    except OSError as error:
+        msg = f"Cannot inspect zone path {path}: {error}"
+        raise ZoneConfigurationError(msg) from error
 
 
 def find_unmigrated_assignments(
@@ -171,11 +182,23 @@ def _zone_root(roots: ZoneRoots, zone: str) -> Path:
 
 def _assignment_paths(roots: ZoneRoots, assignment: ZoneAssignment) -> tuple[Path, ...]:
     suffix = Path(assignment.agent) / assignment.relative_path
-    return (
-        roots.config_root / suffix,
-        roots.shared_root / suffix,
-        roots.local_root / suffix,
-    )
+    roots_by_zone = (roots.config_root, roots.shared_root, roots.local_root)
+    paths = tuple(root / suffix for root in roots_by_zone)
+    for root, path in zip(roots_by_zone, paths, strict=True):
+        _reject_symlinked_components(root, path)
+    return paths
+
+
+def _reject_symlinked_components(root: Path, path: Path) -> None:
+    current = root
+    if current.is_symlink():
+        msg = f"Zone migration source has a symlinked component: {current}"
+        raise ZoneConfigurationError(msg)
+    for part in path.relative_to(root).parts:
+        current /= part
+        if current.is_symlink():
+            msg = f"Zone migration source has a symlinked component: {current}"
+            raise ZoneConfigurationError(msg)
 
 
 def _ensure_directory(root: Path, path: Path) -> None:

--- a/src/djinn_in_a_box/core/zone_migration.py
+++ b/src/djinn_in_a_box/core/zone_migration.py
@@ -113,6 +113,8 @@ def reconcile_zone_assignments(
             None,
         )
         if source is None:
+            if path_has_content(destination):
+                _harden_published_directories(destination)
             _remove_empty_source_directories(roots, assignment, destination)
             continue
         moves.append(
@@ -270,6 +272,9 @@ def _copy_then_publish(
             before_publish()
         os.replace(staged_tree, destination)
         _harden_published_directories(destination)
+        if not _trees_match(source, destination):
+            msg = f"Zone migration source changed during publish: {source}"
+            raise ZoneConfigurationError(msg)
         shutil.rmtree(source)
     finally:
         shutil.rmtree(staging_parent, ignore_errors=True)

--- a/src/djinn_in_a_box/core/zone_migration.py
+++ b/src/djinn_in_a_box/core/zone_migration.py
@@ -6,6 +6,7 @@ import errno
 import filecmp
 import os
 import shutil
+import stat
 import tempfile
 from collections.abc import Callable, Iterable
 from dataclasses import dataclass
@@ -178,12 +179,25 @@ def _assignment_paths(roots: ZoneRoots, assignment: ZoneAssignment) -> tuple[Pat
 
 
 def _ensure_directory(root: Path, path: Path) -> None:
-    root.chmod(0o700)
+    _ensure_private_directory(root)
     current = root
     for part in path.relative_to(root).parts:
         current /= part
-        current.mkdir(exist_ok=True, mode=0o700)
-        current.chmod(0o700)
+        _ensure_private_directory(current)
+
+
+def _ensure_private_directory(path: Path) -> None:
+    if path.is_symlink() or (path.exists() and not path.is_dir()):
+        msg = f"Zone directory is not a directory: {path}"
+        raise ZoneConfigurationError(msg)
+    path.mkdir(exist_ok=True, mode=0o700)
+    path.chmod(0o700)
+
+
+def ensure_zone_targets(assignments: ZoneAssignments, roots: ZoneRoots) -> None:
+    for assignment in _iter_assignments(assignments):
+        destination = _zone_path(roots, assignment.zone, assignment)
+        _ensure_directory(_zone_root(roots, assignment.zone), destination)
 
 
 def _remove_empty_source_directories(
@@ -215,6 +229,7 @@ def _move_directory(source: Path, destination: Path, before_publish: BeforePubli
             raise
         _copy_then_publish(source, destination, before_publish)
         return True
+    _harden_published_directories(destination)
     return False
 
 
@@ -231,6 +246,7 @@ def _copy_then_publish(
         if before_publish is not None:
             before_publish()
         os.replace(staged_tree, destination)
+        _harden_published_directories(destination)
         shutil.rmtree(source)
     finally:
         shutil.rmtree(staging_parent, ignore_errors=True)
@@ -260,6 +276,20 @@ def _trees_match(source: Path, copied: Path) -> bool:
         ):
             return False
     return True
+
+
+def _harden_published_directories(path: Path) -> None:
+    info = path.lstat()
+    if not stat.S_ISDIR(info.st_mode):
+        msg = f"Published zone path is not a directory: {path}"
+        raise ZoneConfigurationError(msg)
+    os.chmod(path, 0o700, follow_symlinks=False)
+    with os.scandir(path) as entries:
+        for entry in entries:
+            if entry.is_symlink():
+                continue
+            if entry.is_dir(follow_symlinks=False):
+                _harden_published_directories(Path(entry.path))
 
 
 def _timestamped_sibling(path: Path) -> Path:

--- a/src/djinn_in_a_box/core/zone_migration.py
+++ b/src/djinn_in_a_box/core/zone_migration.py
@@ -12,6 +12,7 @@ from collections.abc import Callable, Iterable
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
+from typing import cast
 
 from djinn_in_a_box.config.models import AppConfig
 from djinn_in_a_box.config.zones import (
@@ -72,13 +73,12 @@ def find_unmigrated_assignments(
     return tuple(
         assignment
         for assignment in _iter_assignments(assignments)
-        if path_has_content(roots.config_root / assignment.agent / assignment.relative_path)
-        or any(
-            path_has_content(aside)
-            for aside in _migration_asides(
-                roots, assignment, _zone_path(roots, assignment.zone, assignment)
-            )
+        if _migration_source(
+            roots,
+            assignment,
+            _zone_path(roots, assignment.zone, assignment),
         )
+        is not None
     )
 
 
@@ -295,7 +295,11 @@ def _remove_empty_source_directories(
             and not path.is_symlink()
             and not path_has_content(path)
         ):
-            path.rmdir()
+            try:
+                path.rmdir()
+            except OSError as error:
+                if error.errno not in {errno.EACCES, errno.EBUSY, errno.EPERM, None}:
+                    raise
 
 
 def _move_directory(source: Path, destination: Path, before_publish: BeforePublish | None) -> bool:
@@ -325,7 +329,16 @@ def _copy_then_publish(
     staging_parent = Path(tempfile.mkdtemp(prefix=".djinn-zone-migrate-", dir=destination.parent))
     staged_tree = staging_parent / "tree"
     try:
-        shutil.copytree(migrating_source, staged_tree, symlinks=True)
+        try:
+            shutil.copytree(migrating_source, staged_tree, symlinks=True)
+        except shutil.Error as error:
+            entry = _copy_error_entry(error, migrating_source)
+            msg = (
+                f"Zone migration could not copy {entry}; the source remains preserved at "
+                f"{migrating_source}. Remove or relocate the unsupported or unreadable "
+                "entry, then retry."
+            )
+            raise ZoneConfigurationError(msg) from error
         if not _trees_match(migrating_source, staged_tree):
             msg = f"Zone migration verification failed for {migrating_source}"
             raise ZoneConfigurationError(msg)
@@ -342,6 +355,19 @@ def _copy_then_publish(
         shutil.rmtree(migrating_source)
     finally:
         shutil.rmtree(staging_parent, ignore_errors=True)
+
+
+def _copy_error_entry(error: shutil.Error, migrating_source: Path) -> Path:
+    if not error.args:
+        return migrating_source
+    details = error.args[0]
+    if not isinstance(details, list) or not details:
+        return migrating_source
+    first = cast(object, details[0])
+    if not isinstance(first, tuple) or not first:
+        return migrating_source
+    source = cast(object, first[0])
+    return Path(source) if isinstance(source, str) else migrating_source
 
 
 def _rename_source_aside(source: Path) -> Path:

--- a/src/djinn_in_a_box/core/zone_migration.py
+++ b/src/djinn_in_a_box/core/zone_migration.py
@@ -14,7 +14,12 @@ from datetime import UTC, datetime
 from pathlib import Path
 
 from djinn_in_a_box.config.models import AppConfig
-from djinn_in_a_box.config.zones import ZoneAssignment, ZoneAssignments, load_zone_assignments
+from djinn_in_a_box.config.zones import (
+    MIGRATING_ZONE_PREFIX,
+    ZoneAssignment,
+    ZoneAssignments,
+    load_zone_assignments,
+)
 from djinn_in_a_box.core.docker import ZoneRoots, ensure_zone_roots, resolve_zone_roots
 from djinn_in_a_box.core.exceptions import ZoneConfigurationError
 
@@ -68,6 +73,12 @@ def find_unmigrated_assignments(
         assignment
         for assignment in _iter_assignments(assignments)
         if path_has_content(roots.config_root / assignment.agent / assignment.relative_path)
+        or any(
+            path_has_content(aside)
+            for aside in _migration_asides(
+                roots, assignment, _zone_path(roots, assignment.zone, assignment)
+            )
+        )
     )
 
 
@@ -78,8 +89,15 @@ def find_zone_collisions(
     for assignment in _iter_assignments(assignments):
         destination = _zone_path(roots, assignment.zone, assignment)
         populated_paths = tuple(
-            path for path in _assignment_paths(roots, assignment) if path_has_content(path)
+            path
+            for path in (
+                *_assignment_paths(roots, assignment),
+                *_migration_asides(roots, assignment, destination),
+            )
+            if path_has_content(path)
         )
+        if _is_recoverable_published_aside(populated_paths, destination):
+            continue
         if len(populated_paths) > 1:
             collisions.append(ZoneCollision(assignment, destination, populated_paths))
     return tuple(collisions)
@@ -104,18 +122,16 @@ def reconcile_zone_assignments(
             continue
         destination = _zone_path(roots, assignment.zone, assignment)
         _ensure_directory(_zone_root(roots, assignment.zone), destination)
-        source = next(
-            (
-                path
-                for path in _assignment_paths(roots, assignment)
-                if path != destination and path_has_content(path)
-            ),
-            None,
-        )
+        source = _migration_source(roots, assignment, destination)
         if source is None:
             if path_has_content(destination):
                 _harden_published_directories(destination)
             _remove_empty_source_directories(roots, assignment, destination)
+            continue
+        if _is_migration_aside(source) and path_has_content(destination):
+            _harden_published_directories(destination)
+            shutil.rmtree(source)
+            moves.append(ZoneMove(assignment, source, destination, True))
             continue
         moves.append(
             ZoneMove(
@@ -191,6 +207,50 @@ def _assignment_paths(roots: ZoneRoots, assignment: ZoneAssignment) -> tuple[Pat
     return paths
 
 
+def _migration_source(
+    roots: ZoneRoots, assignment: ZoneAssignment, destination: Path
+) -> Path | None:
+    source_paths = tuple(
+        path for path in _assignment_paths(roots, assignment) if path != destination
+    )
+    for path in (*source_paths, *(_migration_aside(path) for path in source_paths)):
+        if path_has_content(path):
+            return path
+    return None
+
+
+def _migration_asides(
+    roots: ZoneRoots, assignment: ZoneAssignment, destination: Path
+) -> tuple[Path, ...]:
+    return tuple(
+        _migration_aside(path)
+        for path in _assignment_paths(roots, assignment)
+        if path != destination
+    )
+
+
+def _migration_aside(source: Path) -> Path:
+    return source.with_name(f"{MIGRATING_ZONE_PREFIX}{source.name}")
+
+
+def _is_migration_aside(path: Path) -> bool:
+    return path.name.startswith(MIGRATING_ZONE_PREFIX)
+
+
+def _is_recoverable_published_aside(populated_paths: tuple[Path, ...], destination: Path) -> bool:
+    if len(populated_paths) != 2 or destination not in populated_paths:
+        return False
+    aside = next(path for path in populated_paths if path != destination)
+    return (
+        _is_migration_aside(aside)
+        and aside.is_dir()
+        and not aside.is_symlink()
+        and destination.is_dir()
+        and not destination.is_symlink()
+        and _trees_match(aside, destination)
+    )
+
+
 def _reject_symlinked_components(root: Path, path: Path) -> None:
     current = root
     if current.is_symlink():
@@ -261,23 +321,32 @@ def _move_directory(source: Path, destination: Path, before_publish: BeforePubli
 def _copy_then_publish(
     source: Path, destination: Path, before_publish: BeforePublish | None
 ) -> None:
+    migrating_source = _rename_source_aside(source)
     staging_parent = Path(tempfile.mkdtemp(prefix=".djinn-zone-migrate-", dir=destination.parent))
     staged_tree = staging_parent / "tree"
     try:
-        shutil.copytree(source, staged_tree, symlinks=True)
-        if not _trees_match(source, staged_tree):
-            msg = f"Zone migration verification failed for {source}"
+        shutil.copytree(migrating_source, staged_tree, symlinks=True)
+        if not _trees_match(migrating_source, staged_tree):
+            msg = f"Zone migration verification failed for {migrating_source}"
             raise ZoneConfigurationError(msg)
         if before_publish is not None:
             before_publish()
         os.replace(staged_tree, destination)
         _harden_published_directories(destination)
-        if not _trees_match(source, destination):
-            msg = f"Zone migration source changed during publish: {source}"
-            raise ZoneConfigurationError(msg)
-        shutil.rmtree(source)
+        shutil.rmtree(migrating_source)
     finally:
         shutil.rmtree(staging_parent, ignore_errors=True)
+
+
+def _rename_source_aside(source: Path) -> Path:
+    if _is_migration_aside(source):
+        return source
+    aside = _migration_aside(source)
+    if aside.exists() or aside.is_symlink():
+        msg = f"Zone migration reserved source already exists: {aside}"
+        raise ZoneConfigurationError(msg)
+    os.replace(source, aside)
+    return aside
 
 
 def _trees_match(source: Path, copied: Path) -> bool:

--- a/src/djinn_in_a_box/core/zone_migration.py
+++ b/src/djinn_in_a_box/core/zone_migration.py
@@ -333,6 +333,12 @@ def _copy_then_publish(
             before_publish()
         os.replace(staged_tree, destination)
         _harden_published_directories(destination)
+        if not _trees_match(migrating_source, destination):
+            msg = (
+                "Zone migration post-publish verification failed between "
+                f"{migrating_source} and {destination}"
+            )
+            raise ZoneConfigurationError(msg)
         shutil.rmtree(migrating_source)
     finally:
         shutil.rmtree(staging_parent, ignore_errors=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -49,6 +49,7 @@ def mock_app_config(tmp_path: Path) -> AppConfig:
     projects_dir.mkdir()
     return AppConfig(
         code_dir=projects_dir,
+        config_root=tmp_path / "config",
         resources=ResourceLimits(),
         shell=ShellConfig(),
     )

--- a/tests/test_cli_djinn.py
+++ b/tests/test_cli_djinn.py
@@ -117,6 +117,7 @@ class TestInitCommand:
         # when color output is forced (FORCE_COLOR) — never assert across them.
         assert "mcpgateway start" in combined
         assert "# MCP tools — not required" in combined
+        assert combined.index("djinn migrate-zones") < combined.index("djinn start")
 
     def test_init_force_overwrites(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         config_dir = tmp_path / ".config" / "djinn_in_a_box"

--- a/tests/test_commands/test_backup.py
+++ b/tests/test_commands/test_backup.py
@@ -56,6 +56,20 @@ class TestGuardNoContainersRunning:
         with patch("djinn_in_a_box.commands.backup.get_running_containers", return_value=[]):
             backup_module._guard_no_containers_running()
 
+    def test_refuses_an_unknown_container_state_from_the_docker_probe(self) -> None:
+        with (
+            patch(
+                "djinn_in_a_box.core.docker.subprocess.run",
+                return_value=subprocess.CompletedProcess(
+                    ["docker", "ps"], 1, stdout="", stderr="daemon unavailable"
+                ),
+            ),
+            pytest.raises(typer.Exit) as exc_info,
+        ):
+            backup_module._guard_no_containers_running()
+
+        assert exc_info.value.exit_code == 1
+
     def test_exits_when_containers_running(self) -> None:
         with patch("djinn_in_a_box.commands.backup.get_running_containers", return_value=["djinn"]):
             with pytest.raises(typer.Exit) as exc_info:
@@ -137,6 +151,24 @@ class TestCollectItems:
 
 class TestBackupCommand:
     """Tests for the backup command."""
+
+    def test_backup_refuses_unknown_container_state_from_the_docker_probe(self) -> None:
+        with (
+            patch(
+                "djinn_in_a_box.core.docker.subprocess.run",
+                return_value=subprocess.CompletedProcess(
+                    ["docker", "ps"], 1, stdout="", stderr="daemon unavailable"
+                ),
+            ),
+            patch(
+                "djinn_in_a_box.commands.backup._collect_items",
+                side_effect=AssertionError("backup proceeded after an unknown Docker state"),
+            ),
+            pytest.raises(typer.Exit) as exc_info,
+        ):
+            backup_module.backup()
+
+        assert exc_info.value.exit_code == 1
 
     def test_aborts_when_containers_running(self) -> None:
         with patch("djinn_in_a_box.commands.backup.get_running_containers", return_value=["djinn"]):
@@ -914,6 +946,24 @@ class TestBackupCommand:
 class TestRestoreCommand:
     """Tests for the restore command."""
 
+    def test_restore_refuses_unknown_container_state_from_the_docker_probe(self) -> None:
+        with (
+            patch(
+                "djinn_in_a_box.core.docker.subprocess.run",
+                return_value=subprocess.CompletedProcess(
+                    ["docker", "ps"], 1, stdout="", stderr="daemon unavailable"
+                ),
+            ),
+            patch(
+                "djinn_in_a_box.commands.backup._list_backups",
+                side_effect=AssertionError("restore proceeded after an unknown Docker state"),
+            ),
+            pytest.raises(typer.Exit) as exc_info,
+        ):
+            backup_module.restore()
+
+        assert exc_info.value.exit_code == 1
+
     def test_aborts_when_containers_running(self) -> None:
         with patch("djinn_in_a_box.commands.backup.get_running_containers", return_value=["djinn"]):
             with pytest.raises(typer.Exit) as exc_info:
@@ -1178,6 +1228,84 @@ class TestRestoreCommand:
             backup_module.restore()
 
         assert (configured_root / "claude" / "token.txt").read_text() == "secret\n"
+
+    def test_restore_rehardens_sync_target_after_extracting_legacy_archive(
+        self, tmp_path: Path
+    ) -> None:
+        code_dir = tmp_path / "code"
+        code_dir.mkdir()
+        config = AppConfig(code_dir=code_dir, config_root=tmp_path / "config")
+        backups_dir = tmp_path / "backups"
+        backups_dir.mkdir()
+        outside = tmp_path / "outside"
+        outside.mkdir(mode=0o755)
+        outside.chmod(0o755)
+        inner_archives: list[Path] = []
+        for name in ("claude", "codex"):
+            legacy_target = tmp_path / f"legacy-{name}"
+            legacy_target.mkdir(mode=0o755)
+            legacy_target.chmod(0o755)
+            (legacy_target / "credentials.json").write_text("secret\n")
+            nested = legacy_target / "nested"
+            nested.mkdir(mode=0o755)
+            nested.chmod(0o755)
+            (nested / "session.jsonl").write_text("history\n")
+            if name == "claude":
+                (legacy_target / "outside-link").symlink_to(outside, target_is_directory=True)
+            inner_archive = tmp_path / f"djinn-sync-{name}.tar.gz"
+            with tarfile.open(inner_archive, "w:gz") as inner:
+                inner.add(legacy_target, arcname=".")
+            inner_archives.append(inner_archive)
+        backup_file = backups_dir / "djinn-backup-2026-03-13.tar.gz"
+        with tarfile.open(backup_file, "w:gz") as outer:
+            for inner_archive in inner_archives:
+                outer.add(inner_archive, arcname=inner_archive.name)
+
+        with (
+            patch("djinn_in_a_box.commands.backup.load_config", return_value=config),
+            patch("djinn_in_a_box.commands.backup.get_running_containers", return_value=[]),
+            patch("djinn_in_a_box.commands.backup.BACKUPS_DIR", backups_dir),
+            patch("djinn_in_a_box.commands.backup.typer.confirm", return_value=True),
+        ):
+            backup_module.restore()
+
+        for name in ("claude", "codex"):
+            assert (config.config_root / name).stat().st_mode & 0o777 == 0o700
+            assert (config.config_root / name / "nested").stat().st_mode & 0o777 == 0o700
+        assert outside.stat().st_mode & 0o777 == 0o755
+
+    def test_restore_rehardens_a_partially_extracted_sync_target(self, tmp_path: Path) -> None:
+        code_dir = tmp_path / "code"
+        code_dir.mkdir()
+        config = AppConfig(code_dir=code_dir, config_root=tmp_path / "config")
+        backups_dir = tmp_path / "backups"
+        backups_dir.mkdir()
+        legacy_claude = tmp_path / "legacy-claude"
+        nested = legacy_claude / "nested"
+        nested.mkdir(parents=True, mode=0o755)
+        legacy_claude.chmod(0o755)
+        nested.chmod(0o755)
+        (nested / "session.jsonl").write_text("history\n")
+        inner_archive = tmp_path / "djinn-sync-claude.tar.gz"
+        with tarfile.open(inner_archive, "w:gz") as inner:
+            inner.add(legacy_claude, arcname=".")
+        inner_archive.write_bytes(inner_archive.read_bytes()[:-8])
+        backup_file = backups_dir / "djinn-backup-2026-03-13.tar.gz"
+        with tarfile.open(backup_file, "w:gz") as outer:
+            outer.add(inner_archive, arcname=inner_archive.name)
+
+        with (
+            patch("djinn_in_a_box.commands.backup.load_config", return_value=config),
+            patch("djinn_in_a_box.commands.backup.get_running_containers", return_value=[]),
+            patch("djinn_in_a_box.commands.backup.BACKUPS_DIR", backups_dir),
+            patch("djinn_in_a_box.commands.backup.typer.confirm", return_value=True),
+            pytest.raises(typer.Exit) as exc_info,
+        ):
+            backup_module.restore()
+
+        assert exc_info.value.exit_code == 1
+        assert (config.config_root / "claude").stat().st_mode & 0o777 == 0o700
+        assert (config.config_root / "claude" / "nested").stat().st_mode & 0o777 == 0o700
 
     def test_restore_decrypts_age_archive_before_restoring(self, tmp_path: Path) -> None:
         backups_dir = tmp_path / "backups"

--- a/tests/test_commands/test_container.py
+++ b/tests/test_commands/test_container.py
@@ -34,6 +34,8 @@ from djinn_in_a_box.core.exceptions import (
 )
 from djinn_in_a_box.core.theme import DJINN_THEME
 
+runner = CliRunner()
+
 
 class TestBuildCommand:
     """Tests for the build command."""
@@ -870,8 +872,19 @@ class TestCleanAllCommand:
 
     def test_clean_all_requires_confirmation(self) -> None:
         """Test clean all requires user confirmation."""
-        with patch("typer.confirm", return_value=False), pytest.raises(typer.Exit):
+        with (
+            patch("typer.confirm", return_value=False) as confirm,
+            pytest.raises(typer.Exit),
+        ):
             container.clean_all()
+        assert "Shared and local zone data are not removed" in confirm.call_args.args[0]
+
+    def test_clean_all_help_excludes_zone_data(self) -> None:
+        result = runner.invoke(app, ["clean", "all", "--help"])
+
+        assert result.exit_code == 0, result.output
+        assert "Shared and local" in result.output
+        assert "not removed" in result.output
 
     def test_clean_all_with_force_skips_confirmation(self, mock_app_config: AppConfig) -> None:
         """Test clean all --force skips confirmation and clears both volumes and sync paths."""

--- a/tests/test_commands/test_container.py
+++ b/tests/test_commands/test_container.py
@@ -2,6 +2,7 @@
 
 import io
 import re
+import subprocess
 from collections.abc import Generator
 from pathlib import Path
 from typing import Any
@@ -1159,6 +1160,26 @@ class TestEnterCommand:
                 container.enter()
 
             assert exc_info.value.exit_code == 1
+
+    def test_enter_refuses_an_unknown_container_state(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        with (
+            patch("djinn_in_a_box.commands.container.sys") as mock_sys,
+            patch(
+                "djinn_in_a_box.core.docker.subprocess.run",
+                return_value=subprocess.CompletedProcess(
+                    ["docker", "ps"], 1, stdout="", stderr="daemon unavailable"
+                ),
+            ),
+            pytest.raises(typer.Exit) as exc_info,
+        ):
+            mock_sys.stdin.isatty.return_value = True
+            container.enter()
+
+        assert exc_info.value.exit_code == 1
+        output = capsys.readouterr().err
+        assert "Could not determine whether a Djinn container is running." in output
 
     def test_enter_opens_shell(self) -> None:
         """Test enter opens zsh shell in running container."""

--- a/tests/test_commands/test_container.py
+++ b/tests/test_commands/test_container.py
@@ -596,9 +596,11 @@ class TestStatusCommand:
 class TestCleanDefaultCommand:
     """Tests for the clean default behavior."""
 
-    def test_clean_default_runs_compose_down(self) -> None:
+    def test_clean_default_runs_compose_down(self, mock_home: Path) -> None:
         """Test clean without subcommand runs compose down."""
         from typer import Context
+
+        assert mock_home.is_dir()
 
         with patch("djinn_in_a_box.commands.container.compose_down") as mock_down:
             mock_down.return_value = RunResult(returncode=0)

--- a/tests/test_commands/test_container.py
+++ b/tests/test_commands/test_container.py
@@ -616,6 +616,46 @@ class TestCleanDefaultCommand:
 
             mock_down.assert_called_once()
 
+    @pytest.mark.parametrize("entrypoint", ("default", "volumes", "all"))
+    def test_clean_entrypoints_render_invalid_zone_roots_as_cli_errors(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, entrypoint: str
+    ) -> None:
+        projects = tmp_path / "projects"
+        projects.mkdir()
+        config_root = tmp_path / "config"
+        config_root.write_text("not a directory")
+        config = AppConfig(code_dir=projects, config_root=config_root)
+        monkeypatch.setattr(container, "load_config", lambda: config)
+
+        with pytest.raises(typer.Exit) as exc_info:
+            if entrypoint == "default":
+                context = MagicMock()
+                context.invoked_subcommand = None
+                container.clean_default(context)
+            elif entrypoint == "volumes":
+                container.clean_volumes(force=True)
+            else:
+                container.clean_all(force=True)
+
+        assert exc_info.value.exit_code == 1
+
+
+class TestZoneRootErrors:
+    def test_start_renders_a_regular_file_zone_root_as_a_cli_error(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        projects = tmp_path / "projects"
+        projects.mkdir()
+        config_root = tmp_path / "config"
+        config_root.write_text("not a directory")
+        config = AppConfig(code_dir=projects, config_root=config_root)
+        monkeypatch.setattr(container, "load_config", lambda: config)
+
+        with pytest.raises(typer.Exit) as exc_info:
+            container.start()
+
+        assert exc_info.value.exit_code == 1
+
 
 class TestCleanVolumesCommand:
     """Tests for the clean volumes command."""

--- a/tests/test_commands/test_migrate_zones.py
+++ b/tests/test_commands/test_migrate_zones.py
@@ -74,6 +74,34 @@ def test_migrate_zones_rechecks_containers_before_publish(
     assert (source / "state.json").read_text() == "do not move"
 
 
+@pytest.mark.parametrize("probe_states", ((None,), ([], None)))
+def test_migrate_zones_refuses_an_unknown_container_state(
+    zone_config: AppConfig,
+    monkeypatch: pytest.MonkeyPatch,
+    probe_states: tuple[list[str] | None, ...],
+) -> None:
+    roots = resolve_zone_roots(zone_config)
+    source = roots.config_root / "claude" / "jobs"
+    source.mkdir(parents=True)
+    (source / "state.json").write_text("do not move")
+    probes = iter(probe_states)
+
+    def unknown_or_empty_containers() -> list[str] | None:
+        return next(probes, probe_states[-1])
+
+    monkeypatch.setattr(migration_command, "load_config", lambda: zone_config)
+    monkeypatch.setattr(migration_command, "get_running_containers", unknown_or_empty_containers)
+
+    with (
+        patch("djinn_in_a_box.commands.migrate_zones.typer.confirm", return_value=True),
+        pytest.raises(typer.Exit) as exc_info,
+    ):
+        migration_command.migrate_zones()
+
+    assert exc_info.value.exit_code == 1
+    assert (source / "state.json").read_text() == "do not move"
+
+
 def test_migrate_zones_collision_moves_nothing(
     zone_config: AppConfig, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/test_commands/test_migrate_zones.py
+++ b/tests/test_commands/test_migrate_zones.py
@@ -1,0 +1,173 @@
+from __future__ import annotations
+
+import tarfile
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+import typer
+
+from djinn_in_a_box.commands import backup as backup_command
+from djinn_in_a_box.commands import migrate_zones as migration_command
+from djinn_in_a_box.config import zones as zones_module
+from djinn_in_a_box.config.models import AppConfig
+from djinn_in_a_box.core.docker import RunResult, resolve_zone_roots
+
+
+@pytest.fixture
+def zone_config(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> AppConfig:
+    projects = tmp_path / "projects"
+    projects.mkdir()
+    monkeypatch.setattr(zones_module, "ZONES_FILE", tmp_path / "zones.toml")
+    return AppConfig(code_dir=projects, config_root=tmp_path / "config")
+
+
+def test_migrate_zones_confirms_unconditionally_and_is_idempotent(
+    zone_config: AppConfig, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    roots = resolve_zone_roots(zone_config)
+    source = roots.config_root / "claude" / "jobs"
+    source.mkdir(parents=True)
+    (source / "state.json").write_text("move")
+    target = roots.local_root / "claude" / "jobs"
+    monkeypatch.setattr(migration_command, "load_config", lambda: zone_config)
+
+    def no_containers() -> list[str]:
+        return []
+
+    monkeypatch.setattr(migration_command, "get_running_containers", no_containers)
+
+    with patch("djinn_in_a_box.commands.migrate_zones.typer.confirm", return_value=True) as confirm:
+        migration_command.migrate_zones()
+        migration_command.migrate_zones()
+
+    assert confirm.call_count == 2
+    assert "mirroring" in confirm.call_args.args[0]
+    assert not source.exists()
+    assert (target / "state.json").read_text() == "move"
+
+
+def test_migrate_zones_rechecks_containers_before_publish(
+    zone_config: AppConfig, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    roots = resolve_zone_roots(zone_config)
+    source = roots.config_root / "claude" / "jobs"
+    source.mkdir(parents=True)
+    (source / "state.json").write_text("do not move")
+    calls = 0
+
+    def containers() -> list[str]:
+        nonlocal calls
+        calls += 1
+        return [] if calls == 1 else ["djinn"]
+
+    monkeypatch.setattr(migration_command, "load_config", lambda: zone_config)
+    monkeypatch.setattr(migration_command, "get_running_containers", containers)
+
+    with (
+        patch("djinn_in_a_box.commands.migrate_zones.typer.confirm", return_value=True),
+        pytest.raises(typer.Exit) as exc_info,
+    ):
+        migration_command.migrate_zones()
+
+    assert exc_info.value.exit_code == 1
+    assert (source / "state.json").read_text() == "do not move"
+
+
+def test_migrate_zones_collision_moves_nothing(
+    zone_config: AppConfig, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    roots = resolve_zone_roots(zone_config)
+    source = roots.config_root / "claude" / "jobs"
+    target = roots.local_root / "claude" / "jobs"
+    source.mkdir(parents=True)
+    target.mkdir(parents=True)
+    (source / "config.json").write_text("config")
+    (target / "zone.json").write_text("zone")
+    monkeypatch.setattr(migration_command, "load_config", lambda: zone_config)
+
+    def no_containers() -> list[str]:
+        return []
+
+    monkeypatch.setattr(migration_command, "get_running_containers", no_containers)
+
+    with (
+        patch("djinn_in_a_box.commands.migrate_zones.typer.confirm", return_value=True),
+        pytest.raises(typer.Exit) as exc_info,
+    ):
+        migration_command.migrate_zones()
+
+    assert exc_info.value.exit_code == 1
+    assert (source / "config.json").read_text() == "config"
+    assert (target / "zone.json").read_text() == "zone"
+
+
+def test_restore_reconciles_under_its_shared_lock_without_reacquiring_it(
+    zone_config: AppConfig, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    backups = tmp_path / "backups"
+    backups.mkdir()
+    inner = tmp_path / "djinn-sync-claude.tar.gz"
+    inner.write_bytes(b"placeholder")
+    archive = backups / "djinn-backup-2026-01-01.tar.gz"
+    with tarfile.open(archive, "w:gz") as tar:
+        tar.add(inner, arcname=inner.name)
+
+    def restore_sync_path(_name: str, _staging: Path, config: AppConfig) -> RunResult:
+        source = resolve_zone_roots(config).config_root / "claude" / "jobs"
+        source.mkdir(parents=True)
+        (source / "state.json").write_text("restored")
+        return RunResult(0, "", "")
+
+    monkeypatch.setattr(backup_command, "BACKUPS_DIR", backups)
+    monkeypatch.setattr(backup_command, "load_config", lambda: zone_config)
+
+    def no_containers() -> list[str]:
+        return []
+
+    monkeypatch.setattr(backup_command, "get_running_containers", no_containers)
+    monkeypatch.setattr(backup_command, "restore_sync_path", restore_sync_path)
+
+    with patch("djinn_in_a_box.commands.backup.typer.confirm", return_value=True):
+        backup_command.restore()
+
+    target = resolve_zone_roots(zone_config).local_root / "claude" / "jobs"
+    assert (target / "state.json").read_text() == "restored"
+
+
+def test_restore_archive_adoption_moves_existing_zone_data_aside(
+    zone_config: AppConfig, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    backups = tmp_path / "backups"
+    backups.mkdir()
+    inner = tmp_path / "djinn-sync-claude.tar.gz"
+    inner.write_bytes(b"placeholder")
+    archive = backups / "djinn-backup-2026-01-01.tar.gz"
+    with tarfile.open(archive, "w:gz") as tar:
+        tar.add(inner, arcname=inner.name)
+
+    roots = resolve_zone_roots(zone_config)
+    live_zone = roots.shared_root / "claude" / "projects"
+    live_zone.mkdir(parents=True)
+    (live_zone / "live.jsonl").write_text("live")
+
+    def restore_sync_path(_name: str, _staging: Path, config: AppConfig) -> RunResult:
+        archive_copy = resolve_zone_roots(config).config_root / "claude" / "projects"
+        archive_copy.mkdir(parents=True)
+        (archive_copy / "archive.jsonl").write_text("archive")
+        return RunResult(0, "", "")
+
+    def no_containers() -> list[str]:
+        return []
+
+    monkeypatch.setattr(backup_command, "BACKUPS_DIR", backups)
+    monkeypatch.setattr(backup_command, "load_config", lambda: zone_config)
+    monkeypatch.setattr(backup_command, "get_running_containers", no_containers)
+    monkeypatch.setattr(backup_command, "restore_sync_path", restore_sync_path)
+
+    with patch("djinn_in_a_box.commands.backup.typer.confirm", side_effect=(True, True)):
+        backup_command.restore()
+
+    displaced = next(live_zone.parent.glob("projects.pre-restore-*"))
+    assert (displaced / "live.jsonl").read_text() == "live"
+    assert (live_zone / "archive.jsonl").read_text() == "archive"

--- a/tests/test_commands/test_migrate_zones.py
+++ b/tests/test_commands/test_migrate_zones.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import inspect
 import tarfile
 from pathlib import Path
 from unittest.mock import patch
@@ -11,6 +12,7 @@ from djinn_in_a_box.commands import backup as backup_command
 from djinn_in_a_box.commands import migrate_zones as migration_command
 from djinn_in_a_box.config import zones as zones_module
 from djinn_in_a_box.config.models import AppConfig
+from djinn_in_a_box.core.config_lock import config_directory_lock
 from djinn_in_a_box.core.docker import RunResult, resolve_zone_roots
 
 
@@ -72,6 +74,36 @@ def test_migrate_zones_rechecks_containers_before_publish(
 
     assert exc_info.value.exit_code == 1
     assert (source / "state.json").read_text() == "do not move"
+
+
+def test_migrate_zones_reports_running_containers_before_a_shared_gate_lock(
+    zone_config: AppConfig, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    roots = resolve_zone_roots(zone_config)
+    roots.local_root.mkdir(parents=True)
+    monkeypatch.setattr(migration_command, "load_config", lambda: zone_config)
+    monkeypatch.setattr(migration_command, "get_running_containers", lambda: ["djinn"])
+
+    with (
+        config_directory_lock(roots.local_root, exclusive=False),
+        pytest.raises(typer.Exit) as exc_info,
+    ):
+        migration_command.migrate_zones()
+
+    assert exc_info.value.exit_code == 1
+    assert "Containers are running: djinn" in capsys.readouterr().err
+
+
+def test_migrate_zones_pins_an_exclusive_lock_at_the_call_site() -> None:
+    source = inspect.getsource(migration_command.migrate_zones)
+
+    assert "config_directory_lock(roots.local_root, exclusive=True, blocking=False)" in source
+
+
+def test_restore_pins_an_exclusive_zone_gate_at_the_call_site() -> None:
+    source = inspect.getsource(backup_command.restore)
+
+    assert '_zone_gated("restore", exclusive=True)' in source
 
 
 @pytest.mark.parametrize("probe_states", ((None,), ([], None)))

--- a/tests/test_commands/test_zone_gate.py
+++ b/tests/test_commands/test_zone_gate.py
@@ -141,6 +141,31 @@ def test_command_passing_the_gate_holds_a_shared_lock_against_migration(
         pass
 
 
+def test_exclusive_restore_gate_blocks_clean_during_reconciliation(
+    zone_config: AppConfig,
+) -> None:
+    with (
+        zone_command_gate(zone_config, "restore", exclusive=True),
+        pytest.raises(typer.Exit) as exc_info,
+        zone_command_gate(zone_config, "clean"),
+    ):
+        pass
+
+    assert exc_info.value.exit_code == 1
+
+
+def test_launch_gate_refuses_data_left_in_a_previous_zone(zone_config: AppConfig) -> None:
+    roots = resolve_zone_roots(zone_config)
+    previous_zone = roots.local_root / "claude" / "projects"
+    previous_zone.mkdir(parents=True)
+    (previous_zone / "session.jsonl").write_text("move to shared")
+
+    with pytest.raises(typer.Exit) as exc_info, zone_command_gate(zone_config, "start"):
+        pass
+
+    assert exc_info.value.exit_code == 1
+
+
 def test_missing_local_root_is_treated_as_no_migration_in_progress(zone_config: AppConfig) -> None:
     roots = resolve_zone_roots(zone_config)
     assert not roots.local_root.exists()

--- a/tests/test_commands/test_zone_gate.py
+++ b/tests/test_commands/test_zone_gate.py
@@ -1,0 +1,198 @@
+from __future__ import annotations
+
+import inspect
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+import typer
+
+from djinn_in_a_box.commands import agent, backup, container, doctor
+from djinn_in_a_box.commands.zone_gate import GatedCommand, zone_command_gate
+from djinn_in_a_box.config import zones as zones_module
+from djinn_in_a_box.config.models import AppConfig
+from djinn_in_a_box.config.zones import load_zone_assignments
+from djinn_in_a_box.core.config_lock import (
+    ConfigDirectoryLockBusyError,
+    config_directory_lock,
+)
+from djinn_in_a_box.core.docker import ensure_zone_roots, resolve_zone_roots
+
+
+@pytest.fixture
+def zone_config(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> AppConfig:
+    projects = tmp_path / "projects"
+    projects.mkdir()
+    monkeypatch.setattr(zones_module, "ZONES_FILE", tmp_path / "zones.toml")
+    return AppConfig(code_dir=projects, config_root=tmp_path / "config")
+
+
+def _write_unmigrated_assignment(config: AppConfig) -> None:
+    roots = resolve_zone_roots(config)
+    source = roots.config_root / "claude" / "jobs"
+    source.mkdir(parents=True)
+    (source / "state.json").write_text("unmigrated")
+
+
+def _write_collision(config: AppConfig) -> None:
+    roots = ensure_zone_roots(config)
+    source = roots.config_root / "claude" / "jobs"
+    target = roots.local_root / "claude" / "jobs"
+    source.mkdir(parents=True)
+    target.mkdir(parents=True)
+    (source / "config.json").write_text("config")
+    (target / "zone.json").write_text("zone")
+
+
+@pytest.mark.parametrize(
+    ("command", "refused"),
+    [
+        ("start", True),
+        ("run", True),
+        ("backup", False),
+        ("restore", False),
+        ("clean", False),
+    ],
+)
+def test_unmigrated_gate_matrix_per_command(
+    zone_config: AppConfig, command: GatedCommand, refused: bool
+) -> None:
+    _write_unmigrated_assignment(zone_config)
+
+    if refused:
+        with pytest.raises(typer.Exit) as exc_info, zone_command_gate(zone_config, command):
+            pass
+        assert exc_info.value.exit_code == 1
+    else:
+        with zone_command_gate(zone_config, command):
+            pass
+
+
+@pytest.mark.parametrize("command", ("start", "run", "backup", "restore", "clean"))
+def test_collision_gates_every_command(zone_config: AppConfig, command: GatedCommand) -> None:
+    _write_collision(zone_config)
+
+    with pytest.raises(typer.Exit) as exc_info, zone_command_gate(zone_config, command):
+        pass
+
+    assert exc_info.value.exit_code == 1
+
+
+@pytest.mark.parametrize("command", ("start", "run", "backup", "restore", "clean"))
+def test_exclusive_migration_lock_gates_every_command(
+    zone_config: AppConfig, command: GatedCommand
+) -> None:
+    roots = ensure_zone_roots(zone_config)
+
+    with (
+        config_directory_lock(roots.local_root, exclusive=True),
+        pytest.raises(typer.Exit) as exc_info,
+        zone_command_gate(zone_config, command),
+    ):
+        pass
+
+    assert exc_info.value.exit_code == 1
+
+
+def test_each_gate_condition_prints_its_own_remedy(zone_config: AppConfig) -> None:
+    _write_unmigrated_assignment(zone_config)
+    with (
+        patch("djinn_in_a_box.commands.zone_gate.error") as report,
+        pytest.raises(typer.Exit),
+        zone_command_gate(zone_config, "start"),
+    ):
+        pass
+    assert "migrate-zones" in report.call_args.args[0]
+
+    roots = ensure_zone_roots(zone_config)
+    source = roots.config_root / "claude" / "jobs"
+    target = roots.local_root / "claude" / "jobs"
+    target.mkdir(parents=True)
+    (target / "zone.json").write_text("zone")
+    assert source.is_dir()
+    with (
+        patch("djinn_in_a_box.commands.zone_gate.error") as report,
+        pytest.raises(typer.Exit),
+        zone_command_gate(zone_config, "backup"),
+    ):
+        pass
+    assert "doctor" in report.call_args.args[0]
+
+    with (
+        config_directory_lock(roots.local_root, exclusive=True),
+        patch("djinn_in_a_box.commands.zone_gate.error") as report,
+        pytest.raises(typer.Exit),
+        zone_command_gate(zone_config, "clean"),
+    ):
+        pass
+    assert "migration is in progress" in report.call_args.args[0]
+
+
+def test_command_passing_the_gate_holds_a_shared_lock_against_migration(
+    zone_config: AppConfig,
+) -> None:
+    roots = ensure_zone_roots(zone_config)
+
+    with (
+        zone_command_gate(zone_config, "backup"),
+        pytest.raises(ConfigDirectoryLockBusyError),
+        config_directory_lock(roots.local_root, exclusive=True, blocking=False),
+    ):
+        pass
+
+
+def test_missing_local_root_is_treated_as_no_migration_in_progress(zone_config: AppConfig) -> None:
+    roots = resolve_zone_roots(zone_config)
+    assert not roots.local_root.exists()
+
+    with zone_command_gate(zone_config, "backup"):
+        pass
+
+    assert roots.local_root.is_dir()
+
+
+@pytest.mark.parametrize(
+    "entrypoint",
+    ("start", "run", "backup", "restore", "clean"),
+)
+def test_each_command_entrypoint_refuses_before_its_work(
+    zone_config: AppConfig, entrypoint: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _write_collision(zone_config)
+
+    if entrypoint == "start":
+        monkeypatch.setattr(container, "load_config", lambda: zone_config)
+        call = container.start
+    elif entrypoint == "run":
+        monkeypatch.setattr(agent, "load_config", lambda: zone_config)
+
+        def call() -> None:
+            agent.run("claude", "prompt")
+
+    elif entrypoint == "backup":
+        monkeypatch.setattr(backup, "load_config", lambda: zone_config)
+        call = backup.backup
+    elif entrypoint == "restore":
+        monkeypatch.setattr(backup, "load_config", lambda: zone_config)
+        call = backup.restore
+    else:
+        monkeypatch.setattr(container, "load_config", lambda: zone_config)
+
+        def call() -> None:
+            container.clean_all(force=True)
+
+    with pytest.raises(typer.Exit) as exc_info:
+        call()
+
+    assert exc_info.value.exit_code == 1
+
+
+def test_doctor_has_no_zone_gate() -> None:
+    assert "zone_command_gate" not in inspect.getsource(doctor)
+
+
+def test_assignment_loader_still_runs_under_a_shared_gate(zone_config: AppConfig) -> None:
+    with zone_command_gate(zone_config, "backup"):
+        assignments = load_zone_assignments(zone_config)
+
+    assert assignments.by_agent["claude"]["local"]

--- a/tests/test_commands/test_zone_gate.py
+++ b/tests/test_commands/test_zone_gate.py
@@ -181,6 +181,24 @@ def test_launch_gate_rejects_a_non_directory_zone_source(
         pass
 
 
+def test_launch_gate_refuses_an_unreadable_assigned_path(zone_config: AppConfig) -> None:
+    roots = resolve_zone_roots(zone_config)
+    source = roots.config_root / "claude" / "jobs"
+    source.mkdir(parents=True)
+    (source / "state.json").write_text("unreadable")
+    agent_root = source.parent
+    agent_root.chmod(0o000)
+
+    try:
+        with (
+            pytest.raises(ZoneConfigurationError, match="Cannot inspect zone path"),
+            zone_command_gate(zone_config, "start"),
+        ):
+            pass
+    finally:
+        agent_root.chmod(0o700)
+
+
 @pytest.mark.parametrize(
     "entrypoint",
     ("start", "run", "backup", "restore", "clean"),

--- a/tests/test_commands/test_zone_gate.py
+++ b/tests/test_commands/test_zone_gate.py
@@ -11,7 +11,7 @@ from djinn_in_a_box.commands import agent, backup, container, doctor
 from djinn_in_a_box.commands.zone_gate import GatedCommand, zone_command_gate
 from djinn_in_a_box.config import zones as zones_module
 from djinn_in_a_box.config.models import AppConfig
-from djinn_in_a_box.config.zones import load_zone_assignments
+from djinn_in_a_box.config.zones import ZoneConfigurationError, load_zone_assignments
 from djinn_in_a_box.core.config_lock import (
     ConfigDirectoryLockBusyError,
     config_directory_lock,
@@ -39,7 +39,7 @@ def _write_collision(config: AppConfig) -> None:
     source = roots.config_root / "claude" / "jobs"
     target = roots.local_root / "claude" / "jobs"
     source.mkdir(parents=True)
-    target.mkdir(parents=True)
+    target.mkdir(parents=True, exist_ok=True)
     (source / "config.json").write_text("config")
     (target / "zone.json").write_text("zone")
 
@@ -107,7 +107,7 @@ def test_each_gate_condition_prints_its_own_remedy(zone_config: AppConfig) -> No
     roots = ensure_zone_roots(zone_config)
     source = roots.config_root / "claude" / "jobs"
     target = roots.local_root / "claude" / "jobs"
-    target.mkdir(parents=True)
+    target.mkdir(parents=True, exist_ok=True)
     (target / "zone.json").write_text("zone")
     assert source.is_dir()
     with (
@@ -149,6 +149,36 @@ def test_missing_local_root_is_treated_as_no_migration_in_progress(zone_config: 
         pass
 
     assert roots.local_root.is_dir()
+
+
+def test_launch_gate_creates_every_missing_zone_target(zone_config: AppConfig) -> None:
+    roots = resolve_zone_roots(zone_config)
+
+    with zone_command_gate(zone_config, "start"):
+        assignments = load_zone_assignments(zone_config)
+        zone_roots = {"local": roots.local_root, "shared": roots.shared_root}
+        for agent, by_zone in assignments.by_agent.items():
+            for zone in ("local", "shared"):
+                for relative_path in by_zone[zone]:
+                    assert (zone_roots[zone] / agent / relative_path).is_dir()
+
+
+@pytest.mark.parametrize("source_kind", ("regular", "symlink"))
+def test_launch_gate_rejects_a_non_directory_zone_source(
+    zone_config: AppConfig, source_kind: str
+) -> None:
+    roots = resolve_zone_roots(zone_config)
+    source = roots.local_root / "claude" / "jobs"
+    source.parent.mkdir(parents=True)
+    if source_kind == "regular":
+        source.write_text("not a directory")
+    else:
+        outside = roots.local_root / "outside"
+        outside.mkdir()
+        source.symlink_to(outside, target_is_directory=True)
+
+    with pytest.raises(ZoneConfigurationError), zone_command_gate(zone_config, "start"):
+        pass
 
 
 @pytest.mark.parametrize(

--- a/tests/test_core/test_config_lock.py
+++ b/tests/test_core/test_config_lock.py
@@ -4,18 +4,28 @@ import errno
 import fcntl
 import multiprocessing
 import os
+import threading
 from multiprocessing.connection import Connection
 from pathlib import Path
 
 import pytest
 
 from djinn_in_a_box.core import config_lock
-from djinn_in_a_box.core.config_lock import ConfigDirectoryLockError, config_directory_lock
+from djinn_in_a_box.core.config_lock import (
+    ConfigDirectoryLockBusyError,
+    ConfigDirectoryLockError,
+    config_directory_lock,
+)
 
 
-def _probe_nonblocking_lock(
-    config_dir: Path, *, exclusive: bool, result: Connection
-) -> None:
+def _hold_lock_until_terminated(config_dir: Path, ready: Connection) -> None:
+    with config_directory_lock(config_dir, exclusive=True):
+        ready.send(None)
+        ready.close()
+        threading.Event().wait()
+
+
+def _probe_nonblocking_lock(config_dir: Path, *, exclusive: bool, result: Connection) -> None:
     """Report whether this process can acquire the directory lock immediately."""
     descriptor = os.open(config_dir, os.O_RDONLY | os.O_DIRECTORY)
     acquired = False
@@ -85,6 +95,45 @@ def test_config_directory_lock_allows_second_shared_holder(tmp_path: Path) -> No
         assert _can_acquire_nonblocking_lock(config_dir, exclusive=False)
 
 
+def test_nonblocking_lock_reports_a_held_lock_without_waiting(tmp_path: Path) -> None:
+    config_dir = tmp_path / "config"
+    config_dir.mkdir()
+
+    with (
+        config_directory_lock(config_dir, exclusive=True),
+        pytest.raises(ConfigDirectoryLockBusyError),
+        config_directory_lock(config_dir, exclusive=False, blocking=False),
+    ):
+        pass
+
+
+def test_killed_lock_holder_does_not_block_the_next_command(tmp_path: Path) -> None:
+    config_dir = tmp_path / "config"
+    config_dir.mkdir()
+    context = multiprocessing.get_context("spawn")
+    received, sent = context.Pipe(duplex=False)
+    holder = context.Process(
+        target=_hold_lock_until_terminated,
+        kwargs={"config_dir": config_dir, "ready": sent},
+    )
+    holder.start()
+    sent.close()
+    try:
+        assert received.poll(10)
+        received.recv()
+        holder.terminate()
+        holder.join(10)
+        assert holder.exitcode is not None
+        with config_directory_lock(config_dir, exclusive=True, blocking=False):
+            pass
+    finally:
+        received.close()
+        if holder.is_alive():
+            holder.terminate()
+        holder.join()
+        holder.close()
+
+
 def test_config_directory_lock_wraps_acquisition_failure(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -96,8 +145,9 @@ def test_config_directory_lock_wraps_acquisition_failure(
 
     monkeypatch.setattr(config_lock.fcntl, "flock", fail_acquisition)
 
-    with pytest.raises(ConfigDirectoryLockError) as exc_info, config_directory_lock(
-        config_dir, exclusive=True
+    with (
+        pytest.raises(ConfigDirectoryLockError) as exc_info,
+        config_directory_lock(config_dir, exclusive=True),
     ):
         pass
 
@@ -129,8 +179,9 @@ def test_config_directory_lock_wraps_unlock_failure_and_closes_descriptor(
     monkeypatch.setattr(config_lock.os, "open", record_descriptor)
     monkeypatch.setattr(config_lock.fcntl, "flock", fail_unlock)
 
-    with pytest.raises(ConfigDirectoryLockError) as exc_info, config_directory_lock(
-        config_dir, exclusive=True
+    with (
+        pytest.raises(ConfigDirectoryLockError) as exc_info,
+        config_directory_lock(config_dir, exclusive=True),
     ):
         pass
 

--- a/tests/test_core/test_config_lock.py
+++ b/tests/test_core/test_config_lock.py
@@ -17,6 +17,8 @@ from djinn_in_a_box.core.config_lock import (
     config_directory_lock,
 )
 
+_PROCESS_WAIT_SECONDS = 5
+
 
 def _hold_lock_until_terminated(config_dir: Path, ready: Connection) -> None:
     with config_directory_lock(config_dir, exclusive=True):
@@ -45,6 +47,16 @@ def _probe_nonblocking_lock(config_dir: Path, *, exclusive: bool, result: Connec
         result.close()
 
 
+def _attempt_nonblocking_config_lock(config_dir: Path, result: Connection) -> None:
+    try:
+        with config_directory_lock(config_dir, exclusive=False, blocking=False):
+            result.send("acquired")
+    except ConfigDirectoryLockBusyError:
+        result.send("busy")
+    finally:
+        result.close()
+
+
 def _can_acquire_nonblocking_lock(config_dir: Path, *, exclusive: bool) -> bool:
     context = multiprocessing.get_context("spawn")
     received, sent = context.Pipe(duplex=False)
@@ -55,14 +67,41 @@ def _can_acquire_nonblocking_lock(config_dir: Path, *, exclusive: bool) -> bool:
     probe.start()
     sent.close()
     try:
-        probe.join()
+        probe.join(_PROCESS_WAIT_SECONDS)
+        assert not probe.is_alive(), "non-blocking lock probe exceeded its wait bound"
         assert probe.exitcode == 0
         return received.recv()
     finally:
         received.close()
         if probe.is_alive():
             probe.terminate()
-        probe.join()
+        probe.join(_PROCESS_WAIT_SECONDS)
+        probe.close()
+
+
+def _nonblocking_config_lock_status(config_dir: Path) -> str:
+    context = multiprocessing.get_context("spawn")
+    received, sent = context.Pipe(duplex=False)
+    probe = context.Process(
+        target=_attempt_nonblocking_config_lock,
+        kwargs={"config_dir": config_dir, "result": sent},
+    )
+    probe.start()
+    sent.close()
+    try:
+        assert received.poll(_PROCESS_WAIT_SECONDS), (
+            "non-blocking lock acquisition exceeded its wait bound"
+        )
+        status = received.recv()
+        probe.join(_PROCESS_WAIT_SECONDS)
+        assert not probe.is_alive(), "non-blocking lock probe did not exit"
+        assert probe.exitcode == 0
+        return status
+    finally:
+        received.close()
+        if probe.is_alive():
+            probe.terminate()
+        probe.join(_PROCESS_WAIT_SECONDS)
         probe.close()
 
 
@@ -99,12 +138,8 @@ def test_nonblocking_lock_reports_a_held_lock_without_waiting(tmp_path: Path) ->
     config_dir = tmp_path / "config"
     config_dir.mkdir()
 
-    with (
-        config_directory_lock(config_dir, exclusive=True),
-        pytest.raises(ConfigDirectoryLockBusyError),
-        config_directory_lock(config_dir, exclusive=False, blocking=False),
-    ):
-        pass
+    with config_directory_lock(config_dir, exclusive=True):
+        assert _nonblocking_config_lock_status(config_dir) == "busy"
 
 
 def test_killed_lock_holder_does_not_block_the_next_command(tmp_path: Path) -> None:
@@ -119,10 +154,10 @@ def test_killed_lock_holder_does_not_block_the_next_command(tmp_path: Path) -> N
     holder.start()
     sent.close()
     try:
-        assert received.poll(10)
+        assert received.poll(_PROCESS_WAIT_SECONDS)
         received.recv()
         holder.terminate()
-        holder.join(10)
+        holder.join(_PROCESS_WAIT_SECONDS)
         assert holder.exitcode is not None
         with config_directory_lock(config_dir, exclusive=True, blocking=False):
             pass
@@ -130,7 +165,7 @@ def test_killed_lock_holder_does_not_block_the_next_command(tmp_path: Path) -> N
         received.close()
         if holder.is_alive():
             holder.terminate()
-        holder.join()
+        holder.join(_PROCESS_WAIT_SECONDS)
         holder.close()
 
 

--- a/tests/test_core/test_zone_migration.py
+++ b/tests/test_core/test_zone_migration.py
@@ -196,6 +196,25 @@ def test_migration_rejects_a_symlinked_destination_before_moving_data(
     assert not (outside / "jobs").exists()
 
 
+def test_reassignment_rejects_a_symlinked_previous_zone_source(
+    zone_config: AppConfig,
+) -> None:
+    zones_module.ZONES_FILE.write_text('[zones.claude]\nshared = ["newdir/cache"]\n')
+    roots = resolve_zone_roots(zone_config)
+    outside = roots.local_root / "outside"
+    previous_source = outside / "cache"
+    previous_source.mkdir(parents=True)
+    (previous_source / "state.json").write_text("must stay outside")
+    (roots.local_root / "claude").mkdir(parents=True)
+    (roots.local_root / "claude" / "newdir").symlink_to(outside, target_is_directory=True)
+
+    with pytest.raises(ZoneConfigurationError, match="symlinked"):
+        reconcile_zone_assignments(zone_config)
+
+    assert (previous_source / "state.json").read_text() == "must stay outside"
+    assert not (roots.shared_root / "claude" / "newdir" / "cache").exists()
+
+
 def test_reconciliation_moves_data_from_a_previous_zone_after_reassignment(
     zone_config: AppConfig,
 ) -> None:

--- a/tests/test_core/test_zone_migration.py
+++ b/tests/test_core/test_zone_migration.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import errno
+import os
 import stat
 from pathlib import Path
 
@@ -236,6 +237,71 @@ def test_cross_filesystem_migration_blocks_a_write_to_the_original_path_before_c
     assert not aside.exists()
     assert (target / "state.json").read_text() == "copied before publish"
     assert not (target / "written-during-publish.json").exists()
+
+
+def test_cross_filesystem_migration_preserves_a_preexisting_fd_write_after_publish(
+    zone_config: AppConfig, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    roots = resolve_zone_roots(zone_config)
+    source = roots.config_root / "claude" / "jobs"
+    state = source / "state.json"
+    state.parent.mkdir(parents=True)
+    state.write_text("verified before write\n")
+    target = roots.local_root / "claude" / "jobs"
+    aside = source.with_name(".djinn-migrating-jobs")
+    descriptor = os.open(state, os.O_WRONLY | os.O_APPEND)
+    original_replace = zone_migration.os.replace
+
+    def replace_with_exdev(source_path: str | Path, destination_path: str | Path) -> None:
+        if Path(source_path) == source and Path(destination_path) == target:
+            raise OSError(errno.EXDEV, "Cross-device link")
+        if Path(destination_path) == target:
+            assert Path(source_path).name == "tree"
+            os.write(descriptor, b"written through preexisting fd\n")
+            os.fsync(descriptor)
+        original_replace(source_path, destination_path)
+
+    monkeypatch.setattr(zone_migration.os, "replace", replace_with_exdev)
+
+    try:
+        with pytest.raises(ZoneConfigurationError) as error:
+            reconcile_zone_assignments(zone_config)
+    finally:
+        os.close(descriptor)
+
+    assert str(aside) in str(error.value)
+    assert str(target) in str(error.value)
+    assert (aside / "state.json").read_text() == (
+        "verified before write\nwritten through preexisting fd\n"
+    )
+    assert (target / "state.json").read_text() == "verified before write\n"
+
+    result = reconcile_zone_assignments(zone_config)
+
+    assert result.moves == ()
+    assert len(result.collisions) == 1
+    assert result.collisions[0].populated_paths == (target, aside)
+
+
+def test_published_aside_is_recovered_when_it_matches_the_destination(
+    zone_config: AppConfig,
+) -> None:
+    roots = resolve_zone_roots(zone_config)
+    source = roots.config_root / "claude" / "jobs"
+    aside = source.with_name(".djinn-migrating-jobs")
+    target = roots.local_root / "claude" / "jobs"
+    aside.mkdir(parents=True)
+    target.mkdir(parents=True)
+    (aside / "state.json").write_text("published before crash")
+    (target / "state.json").write_text("published before crash")
+
+    result = reconcile_zone_assignments(zone_config)
+
+    assert len(result.moves) == 1
+    assert result.moves[0].source == aside
+    assert result.collisions == ()
+    assert not aside.exists()
+    assert (target / "state.json").read_text() == "published before crash"
 
 
 def test_retry_rehardens_a_published_destination_after_hardening_failure(

--- a/tests/test_core/test_zone_migration.py
+++ b/tests/test_core/test_zone_migration.py
@@ -154,6 +154,81 @@ def test_cross_filesystem_copy_failure_retains_source_for_resume(
     assert not source.exists()
 
 
+def test_cross_filesystem_publish_change_preserves_both_trees(
+    zone_config: AppConfig, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    roots = resolve_zone_roots(zone_config)
+    source = roots.config_root / "claude" / "jobs"
+    source.mkdir(parents=True)
+    (source / "state.json").write_text("copied before publish")
+    target = roots.local_root / "claude" / "jobs"
+    original_replace = zone_migration.os.replace
+    before_publish_calls = 0
+
+    def replace_with_exdev(source_path: str | Path, destination_path: str | Path) -> None:
+        if Path(source_path) == source:
+            raise OSError(errno.EXDEV, "Cross-device link")
+        original_replace(source_path, destination_path)
+
+    def write_after_verification() -> None:
+        nonlocal before_publish_calls
+        before_publish_calls += 1
+        if before_publish_calls == 2:
+            (source / "written-during-publish.json").write_text("must not be deleted")
+
+    monkeypatch.setattr(zone_migration.os, "replace", replace_with_exdev)
+
+    with pytest.raises(ZoneConfigurationError, match="changed during publish"):
+        reconcile_zone_assignments(zone_config, before_publish=write_after_verification)
+
+    assert (source / "state.json").read_text() == "copied before publish"
+    assert (source / "written-during-publish.json").read_text() == "must not be deleted"
+    assert (target / "state.json").read_text() == "copied before publish"
+    assert not (target / "written-during-publish.json").exists()
+
+
+def test_retry_rehardens_a_published_destination_after_hardening_failure(
+    zone_config: AppConfig, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    roots = resolve_zone_roots(zone_config)
+    source = roots.config_root / "claude" / "jobs"
+    nested = source / "nested"
+    nested.mkdir(parents=True)
+    source.chmod(0o755)
+    nested.chmod(0o755)
+    (nested / "state.json").write_text("repair on retry")
+    target = roots.local_root / "claude" / "jobs"
+    original_chmod = zone_migration.os.chmod
+    target_chmod_calls = 0
+
+    def fail_post_publish_hardening(
+        path: Path,
+        mode: int,
+        *,
+        dir_fd: int | None = None,
+        follow_symlinks: bool = True,
+    ) -> None:
+        nonlocal target_chmod_calls
+        if path == target:
+            target_chmod_calls += 1
+            if target_chmod_calls == 2:
+                raise OSError("hardening interrupted")
+        original_chmod(path, mode, dir_fd=dir_fd, follow_symlinks=follow_symlinks)
+
+    monkeypatch.setattr(zone_migration.os, "chmod", fail_post_publish_hardening)
+
+    with pytest.raises(OSError, match="hardening interrupted"):
+        reconcile_zone_assignments(zone_config)
+
+    assert not source.exists()
+    assert (target / "nested").stat().st_mode & 0o777 == 0o755
+
+    resumed = reconcile_zone_assignments(zone_config)
+
+    assert resumed.moves == ()
+    assert stat.S_IMODE((target / "nested").stat().st_mode) == 0o700
+
+
 def test_collision_preserves_every_assigned_tree_without_moving_anything(
     zone_config: AppConfig,
 ) -> None:

--- a/tests/test_core/test_zone_migration.py
+++ b/tests/test_core/test_zone_migration.py
@@ -53,12 +53,13 @@ def test_cross_filesystem_migration_stages_on_destination_filesystem(
     source.mkdir(parents=True)
     (source / "state.json").write_text("copy me")
     target = roots.local_root / "claude" / "jobs"
+    aside = source.with_name(".djinn-migrating-jobs")
     original_replace = zone_migration.os.replace
     original_mkdtemp = zone_migration.tempfile.mkdtemp
     staging_dirs: list[Path] = []
 
     def replace_with_exdev(source_path: str | Path, destination_path: str | Path) -> None:
-        if Path(source_path) == source:
+        if Path(source_path) == source and Path(destination_path) == target:
             raise OSError(errno.EXDEV, "Cross-device link")
         original_replace(source_path, destination_path)
 
@@ -80,7 +81,47 @@ def test_cross_filesystem_migration_stages_on_destination_filesystem(
     assert result.moves[0].copied_across_filesystems
     assert staging_dirs == [target.parent]
     assert not source.exists()
+    assert not aside.exists()
     assert (target / "state.json").read_text() == "copy me"
+
+
+def test_cross_filesystem_migration_renames_source_aside_before_copy(
+    zone_config: AppConfig, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    roots = resolve_zone_roots(zone_config)
+    source = roots.config_root / "claude" / "jobs"
+    source.mkdir(parents=True)
+    (source / "state.json").write_text("move me")
+    target = roots.local_root / "claude" / "jobs"
+    aside = source.with_name(".djinn-migrating-jobs")
+    original_replace = zone_migration.os.replace
+    original_copytree = zone_migration.shutil.copytree
+    copied_sources: list[Path] = []
+
+    def replace_with_exdev(source_path: str | Path, destination_path: str | Path) -> None:
+        if Path(source_path) == source and Path(destination_path) == target:
+            raise OSError(errno.EXDEV, "Cross-device link")
+        original_replace(source_path, destination_path)
+
+    def observe_copytree(
+        source_path: str | Path,
+        destination_path: str | Path,
+        *,
+        symlinks: bool = False,
+    ) -> str | Path:
+        copied_sources.append(Path(source_path))
+        assert not source.exists()
+        return original_copytree(source_path, destination_path, symlinks=symlinks)
+
+    monkeypatch.setattr(zone_migration.os, "replace", replace_with_exdev)
+    monkeypatch.setattr(zone_migration.shutil, "copytree", observe_copytree)
+
+    reconcile_zone_assignments(zone_config)
+
+    assert copied_sources == [aside]
+    assert not source.exists()
+    assert not aside.exists()
+    assert (target / "state.json").read_text() == "move me"
 
 
 @pytest.mark.parametrize("cross_filesystem", (False, True))
@@ -103,7 +144,7 @@ def test_migration_hardens_every_published_directory_without_following_symlinks(
         original_replace = zone_migration.os.replace
 
         def replace_with_exdev(source_path: str | Path, destination_path: str | Path) -> None:
-            if Path(source_path) == source:
+            if Path(source_path) == source and Path(destination_path) == target:
                 raise OSError(errno.EXDEV, "Cross-device link")
             original_replace(source_path, destination_path)
 
@@ -117,7 +158,7 @@ def test_migration_hardens_every_published_directory_without_following_symlinks(
     assert stat.S_IMODE(outside.stat().st_mode) == 0o755
 
 
-def test_cross_filesystem_copy_failure_retains_source_for_resume(
+def test_cross_filesystem_copy_failure_resumes_from_the_renamed_aside(
     zone_config: AppConfig, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     roots = resolve_zone_roots(zone_config)
@@ -125,11 +166,12 @@ def test_cross_filesystem_copy_failure_retains_source_for_resume(
     source.mkdir(parents=True)
     (source / "state.json").write_text("still here")
     target = roots.local_root / "claude" / "jobs"
+    aside = source.with_name(".djinn-migrating-jobs")
     original_replace = zone_migration.os.replace
     original_copytree = zone_migration.shutil.copytree
 
     def replace_with_exdev(source_path: str | Path, destination_path: str | Path) -> None:
-        if Path(source_path) == source:
+        if Path(destination_path) == target and Path(source_path) in {source, aside}:
             raise OSError(errno.EXDEV, "Cross-device link")
         original_replace(source_path, destination_path)
 
@@ -142,7 +184,8 @@ def test_cross_filesystem_copy_failure_retains_source_for_resume(
     with pytest.raises(OSError, match="copy interrupted"):
         reconcile_zone_assignments(zone_config)
 
-    assert (source / "state.json").read_text() == "still here"
+    assert not source.exists()
+    assert (aside / "state.json").read_text() == "still here"
     assert target.is_dir()
     assert not any(target.iterdir())
 
@@ -150,11 +193,14 @@ def test_cross_filesystem_copy_failure_retains_source_for_resume(
     resumed = reconcile_zone_assignments(zone_config)
 
     assert len(resumed.moves) == 1
+    assert resumed.moves[0].source == aside
+    assert resumed.moves[0].copied_across_filesystems
     assert (target / "state.json").read_text() == "still here"
     assert not source.exists()
+    assert not aside.exists()
 
 
-def test_cross_filesystem_publish_change_preserves_both_trees(
+def test_cross_filesystem_migration_blocks_a_write_to_the_original_path_before_cleanup(
     zone_config: AppConfig, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     roots = resolve_zone_roots(zone_config)
@@ -162,27 +208,32 @@ def test_cross_filesystem_publish_change_preserves_both_trees(
     source.mkdir(parents=True)
     (source / "state.json").write_text("copied before publish")
     target = roots.local_root / "claude" / "jobs"
+    aside = source.with_name(".djinn-migrating-jobs")
     original_replace = zone_migration.os.replace
-    before_publish_calls = 0
+    original_rmtree = zone_migration.shutil.rmtree
+    cleanup_paths: list[Path] = []
 
     def replace_with_exdev(source_path: str | Path, destination_path: str | Path) -> None:
-        if Path(source_path) == source:
+        if Path(source_path) == source and Path(destination_path) == target:
             raise OSError(errno.EXDEV, "Cross-device link")
         original_replace(source_path, destination_path)
 
-    def write_after_verification() -> None:
-        nonlocal before_publish_calls
-        before_publish_calls += 1
-        if before_publish_calls == 2:
-            (source / "written-during-publish.json").write_text("must not be deleted")
+    def inject_write_before_cleanup(path: str | Path, ignore_errors: bool = False) -> None:
+        if Path(path) == aside:
+            cleanup_paths.append(Path(path))
+            with pytest.raises(FileNotFoundError):
+                (source / "written-during-publish.json").write_text("cannot reach source")
+        original_rmtree(path, ignore_errors=ignore_errors)
 
     monkeypatch.setattr(zone_migration.os, "replace", replace_with_exdev)
+    monkeypatch.setattr(zone_migration.shutil, "rmtree", inject_write_before_cleanup)
 
-    with pytest.raises(ZoneConfigurationError, match="changed during publish"):
-        reconcile_zone_assignments(zone_config, before_publish=write_after_verification)
+    result = reconcile_zone_assignments(zone_config)
 
-    assert (source / "state.json").read_text() == "copied before publish"
-    assert (source / "written-during-publish.json").read_text() == "must not be deleted"
+    assert len(result.moves) == 1
+    assert cleanup_paths == [aside]
+    assert not source.exists()
+    assert not aside.exists()
     assert (target / "state.json").read_text() == "copied before publish"
     assert not (target / "written-during-publish.json").exists()
 

--- a/tests/test_core/test_zone_migration.py
+++ b/tests/test_core/test_zone_migration.py
@@ -1,0 +1,193 @@
+from __future__ import annotations
+
+import errno
+from pathlib import Path
+
+import pytest
+
+from djinn_in_a_box.config import zones as zones_module
+from djinn_in_a_box.config.models import AppConfig
+from djinn_in_a_box.config.zones import load_zone_assignments
+from djinn_in_a_box.core import zone_migration
+from djinn_in_a_box.core.docker import resolve_zone_roots
+from djinn_in_a_box.core.zone_migration import (
+    adopt_archive_collision,
+    reconcile_zone_assignments,
+)
+
+
+@pytest.fixture
+def zone_config(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> AppConfig:
+    projects = tmp_path / "projects"
+    projects.mkdir()
+    monkeypatch.setattr(zones_module, "ZONES_FILE", tmp_path / "zones.toml")
+    return AppConfig(code_dir=projects, config_root=tmp_path / "config")
+
+
+def test_migration_renames_into_an_empty_target_and_is_idempotent(zone_config: AppConfig) -> None:
+    roots = resolve_zone_roots(zone_config)
+    source = roots.config_root / "claude" / "jobs"
+    source.mkdir(parents=True)
+    (source / "state.json").write_text("archive me")
+    target = roots.local_root / "claude" / "jobs"
+    target.mkdir(parents=True)
+
+    first = reconcile_zone_assignments(zone_config)
+    second = reconcile_zone_assignments(zone_config)
+
+    assert len(first.moves) == 1
+    assert not first.moves[0].copied_across_filesystems
+    assert not source.exists()
+    assert (target / "state.json").read_text() == "archive me"
+    assert second.moves == ()
+    assert second.collisions == ()
+
+
+def test_cross_filesystem_migration_stages_on_destination_filesystem(
+    zone_config: AppConfig, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    roots = resolve_zone_roots(zone_config)
+    source = roots.config_root / "claude" / "jobs"
+    source.mkdir(parents=True)
+    (source / "state.json").write_text("copy me")
+    target = roots.local_root / "claude" / "jobs"
+    original_replace = zone_migration.os.replace
+    original_mkdtemp = zone_migration.tempfile.mkdtemp
+    staging_dirs: list[Path] = []
+
+    def replace_with_exdev(source_path: str | Path, destination_path: str | Path) -> None:
+        if Path(source_path) == source:
+            raise OSError(errno.EXDEV, "Cross-device link")
+        original_replace(source_path, destination_path)
+
+    def record_staging_directory(
+        suffix: str | None = None,
+        prefix: str | None = None,
+        dir: str | Path | None = None,
+    ) -> str:
+        assert dir is not None
+        staging_dirs.append(Path(dir))
+        return original_mkdtemp(suffix=suffix, prefix=prefix, dir=dir)
+
+    monkeypatch.setattr(zone_migration.os, "replace", replace_with_exdev)
+    monkeypatch.setattr(zone_migration.tempfile, "mkdtemp", record_staging_directory)
+
+    result = reconcile_zone_assignments(zone_config)
+
+    assert len(result.moves) == 1
+    assert result.moves[0].copied_across_filesystems
+    assert staging_dirs == [target.parent]
+    assert not source.exists()
+    assert (target / "state.json").read_text() == "copy me"
+
+
+def test_cross_filesystem_copy_failure_retains_source_for_resume(
+    zone_config: AppConfig, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    roots = resolve_zone_roots(zone_config)
+    source = roots.config_root / "claude" / "jobs"
+    source.mkdir(parents=True)
+    (source / "state.json").write_text("still here")
+    target = roots.local_root / "claude" / "jobs"
+    original_replace = zone_migration.os.replace
+    original_copytree = zone_migration.shutil.copytree
+
+    def replace_with_exdev(source_path: str | Path, destination_path: str | Path) -> None:
+        if Path(source_path) == source:
+            raise OSError(errno.EXDEV, "Cross-device link")
+        original_replace(source_path, destination_path)
+
+    def fail_copy(*_args: object, **_kwargs: object) -> Path:
+        raise OSError("copy interrupted")
+
+    monkeypatch.setattr(zone_migration.os, "replace", replace_with_exdev)
+    monkeypatch.setattr(zone_migration.shutil, "copytree", fail_copy)
+
+    with pytest.raises(OSError, match="copy interrupted"):
+        reconcile_zone_assignments(zone_config)
+
+    assert (source / "state.json").read_text() == "still here"
+    assert target.is_dir()
+    assert not any(target.iterdir())
+
+    monkeypatch.setattr(zone_migration.shutil, "copytree", original_copytree)
+    resumed = reconcile_zone_assignments(zone_config)
+
+    assert len(resumed.moves) == 1
+    assert (target / "state.json").read_text() == "still here"
+    assert not source.exists()
+
+
+def test_collision_preserves_every_assigned_tree_without_moving_anything(
+    zone_config: AppConfig,
+) -> None:
+    roots = resolve_zone_roots(zone_config)
+    config_jobs = roots.config_root / "claude" / "jobs"
+    local_jobs = roots.local_root / "claude" / "jobs"
+    config_jobs.mkdir(parents=True)
+    local_jobs.mkdir(parents=True)
+    (config_jobs / "config.txt").write_text("config")
+    (local_jobs / "local.txt").write_text("local")
+    unrelated = roots.config_root / "gemini" / "tmp"
+    unrelated.mkdir(parents=True)
+    (unrelated / "would-have-moved.txt").write_text("keep")
+
+    result = reconcile_zone_assignments(zone_config)
+
+    assert result.moves == ()
+    assert len(result.collisions) == 1
+    assert (config_jobs / "config.txt").read_text() == "config"
+    assert (local_jobs / "local.txt").read_text() == "local"
+    assert (unrelated / "would-have-moved.txt").read_text() == "keep"
+
+
+def test_reconciliation_moves_data_from_a_previous_zone_after_reassignment(
+    zone_config: AppConfig,
+) -> None:
+    roots = resolve_zone_roots(zone_config)
+    previous_local = roots.local_root / "claude" / "projects"
+    previous_local.mkdir(parents=True)
+    (previous_local / "session.jsonl").write_text("shared now")
+    target = roots.shared_root / "claude" / "projects"
+
+    result = reconcile_zone_assignments(zone_config)
+
+    assert len(result.moves) == 1
+    assert result.moves[0].source == previous_local
+    assert not previous_local.exists()
+    assert (target / "session.jsonl").read_text() == "shared now"
+
+
+def test_empty_source_is_removed_while_populated_target_is_retained(zone_config: AppConfig) -> None:
+    roots = resolve_zone_roots(zone_config)
+    empty_source = roots.config_root / "claude" / "jobs"
+    populated_target = roots.local_root / "claude" / "jobs"
+    empty_source.mkdir(parents=True)
+    populated_target.mkdir(parents=True)
+    (populated_target / "state.json").write_text("already migrated")
+
+    result = reconcile_zone_assignments(zone_config)
+
+    assert result.moves == ()
+    assert not empty_source.exists()
+    assert (populated_target / "state.json").read_text() == "already migrated"
+
+
+def test_archive_adoption_moves_the_displaced_zone_tree_aside(zone_config: AppConfig) -> None:
+    roots = resolve_zone_roots(zone_config)
+    archive_copy = roots.config_root / "claude" / "projects"
+    zone_copy = roots.shared_root / "claude" / "projects"
+    archive_copy.mkdir(parents=True)
+    zone_copy.mkdir(parents=True)
+    (archive_copy / "archive.jsonl").write_text("archive")
+    (zone_copy / "live.jsonl").write_text("live")
+    assignments = load_zone_assignments(zone_config)
+    collision = reconcile_zone_assignments(zone_config, assignments=assignments).collisions[0]
+
+    displaced = adopt_archive_collision(collision, zone_config)
+
+    assert displaced.parent == zone_copy.parent
+    assert displaced.name.startswith("projects.pre-restore-")
+    assert (displaced / "live.jsonl").read_text() == "live"
+    assert (zone_copy / "archive.jsonl").read_text() == "archive"
+    assert not archive_copy.exists()

--- a/tests/test_core/test_zone_migration.py
+++ b/tests/test_core/test_zone_migration.py
@@ -439,6 +439,61 @@ def test_empty_source_is_removed_while_populated_target_is_retained(zone_config:
     assert (populated_target / "state.json").read_text() == "already migrated"
 
 
+def test_migration_keeps_an_empty_nonremovable_mount_placeholder(
+    zone_config: AppConfig, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    roots = resolve_zone_roots(zone_config)
+    placeholder = roots.config_root / "claude" / "plugins" / "marketplaces"
+    target = roots.local_root / "claude" / "plugins" / "marketplaces"
+    placeholder.mkdir(parents=True)
+    target.mkdir(parents=True)
+    original_rmdir = Path.rmdir
+
+    def deny_placeholder_removal(path: Path) -> None:
+        if path == placeholder:
+            raise PermissionError("Docker-owned mount placeholder")
+        original_rmdir(path)
+
+    monkeypatch.setattr(Path, "rmdir", deny_placeholder_removal)
+
+    result = reconcile_zone_assignments(zone_config)
+
+    assert result.moves == ()
+    assert placeholder.is_dir()
+    assert target.is_dir()
+
+
+@pytest.mark.skipif(not hasattr(os, "mkfifo"), reason="FIFOs are unavailable on this platform")
+def test_cross_filesystem_migration_names_an_unsupported_entry_and_preserves_the_aside(
+    zone_config: AppConfig, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    roots = resolve_zone_roots(zone_config)
+    source = roots.config_root / "claude" / "jobs"
+    source.mkdir(parents=True)
+    fifo = source / "agent.pipe"
+    os.mkfifo(fifo)
+    target = roots.local_root / "claude" / "jobs"
+    aside = source.with_name(".djinn-migrating-jobs")
+    original_replace = zone_migration.os.replace
+
+    def replace_with_exdev(source_path: str | Path, destination_path: str | Path) -> None:
+        if Path(source_path) == source and Path(destination_path) == target:
+            raise OSError(errno.EXDEV, "Cross-device link")
+        original_replace(source_path, destination_path)
+
+    monkeypatch.setattr(zone_migration.os, "replace", replace_with_exdev)
+
+    with pytest.raises(ZoneConfigurationError) as error:
+        reconcile_zone_assignments(zone_config)
+
+    assert str(aside / fifo.name) in str(error.value)
+    assert str(aside) in str(error.value)
+    assert not source.exists()
+    assert (aside / fifo.name).exists()
+    assert target.is_dir()
+    assert not any(target.iterdir())
+
+
 def test_archive_adoption_moves_the_displaced_zone_tree_aside(zone_config: AppConfig) -> None:
     roots = resolve_zone_roots(zone_config)
     archive_copy = roots.config_root / "claude" / "projects"

--- a/tests/test_core/test_zone_migration.py
+++ b/tests/test_core/test_zone_migration.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import errno
+import stat
 from pathlib import Path
 
 import pytest
@@ -10,6 +11,7 @@ from djinn_in_a_box.config.models import AppConfig
 from djinn_in_a_box.config.zones import load_zone_assignments
 from djinn_in_a_box.core import zone_migration
 from djinn_in_a_box.core.docker import resolve_zone_roots
+from djinn_in_a_box.core.exceptions import ZoneConfigurationError
 from djinn_in_a_box.core.zone_migration import (
     adopt_archive_collision,
     reconcile_zone_assignments,
@@ -81,6 +83,40 @@ def test_cross_filesystem_migration_stages_on_destination_filesystem(
     assert (target / "state.json").read_text() == "copy me"
 
 
+@pytest.mark.parametrize("cross_filesystem", (False, True))
+def test_migration_hardens_every_published_directory_without_following_symlinks(
+    zone_config: AppConfig, monkeypatch: pytest.MonkeyPatch, cross_filesystem: bool
+) -> None:
+    roots = resolve_zone_roots(zone_config)
+    source = roots.config_root / "claude" / "jobs"
+    nested = source / "nested"
+    nested.mkdir(parents=True)
+    source.chmod(0o755)
+    nested.chmod(0o755)
+    outside = source.parent / "outside"
+    outside.mkdir()
+    outside.chmod(0o755)
+    (source / "outside-link").symlink_to(outside, target_is_directory=True)
+    target = roots.local_root / "claude" / "jobs"
+
+    if cross_filesystem:
+        original_replace = zone_migration.os.replace
+
+        def replace_with_exdev(source_path: str | Path, destination_path: str | Path) -> None:
+            if Path(source_path) == source:
+                raise OSError(errno.EXDEV, "Cross-device link")
+            original_replace(source_path, destination_path)
+
+        monkeypatch.setattr(zone_migration.os, "replace", replace_with_exdev)
+
+    reconcile_zone_assignments(zone_config)
+
+    assert stat.S_IMODE(target.stat().st_mode) == 0o700
+    assert stat.S_IMODE((target / "nested").stat().st_mode) == 0o700
+    assert (target / "outside-link").is_symlink()
+    assert stat.S_IMODE(outside.stat().st_mode) == 0o755
+
+
 def test_cross_filesystem_copy_failure_retains_source_for_resume(
     zone_config: AppConfig, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -139,6 +175,25 @@ def test_collision_preserves_every_assigned_tree_without_moving_anything(
     assert (config_jobs / "config.txt").read_text() == "config"
     assert (local_jobs / "local.txt").read_text() == "local"
     assert (unrelated / "would-have-moved.txt").read_text() == "keep"
+
+
+def test_migration_rejects_a_symlinked_destination_before_moving_data(
+    zone_config: AppConfig,
+) -> None:
+    roots = resolve_zone_roots(zone_config)
+    source = roots.config_root / "claude" / "jobs"
+    source.mkdir(parents=True)
+    (source / "state.json").write_text("keep local")
+    outside = source.parent / "outside"
+    outside.mkdir()
+    roots.local_root.mkdir()
+    (roots.local_root / "claude").symlink_to(outside, target_is_directory=True)
+
+    with pytest.raises(ZoneConfigurationError, match="symlinked"):
+        reconcile_zone_assignments(zone_config)
+
+    assert (source / "state.json").read_text() == "keep local"
+    assert not (outside / "jobs").exists()
 
 
 def test_reconciliation_moves_data_from_a_previous_zone_after_reassignment(

--- a/tests/test_docker.py
+++ b/tests/test_docker.py
@@ -2312,3 +2312,40 @@ class TestComposeUpDetached:
         compose_up_detached(mock_app_config, ContainerOptions())
 
         assert mock_run.call_args.kwargs["env"]["DJINN_DETACHED"] == "true"
+class TestRunningContainerProbeFailure:
+    """A failed probe must stay distinguishable from 'no containers running'.
+
+    `_guard_no_containers_running` refuses on ``None`` and proceeds on ``[]``, so
+    collapsing the two here would let a migration rename a directory a live
+    container is using — with both commands reporting success.
+    """
+
+    def test_a_failed_docker_call_yields_none_not_an_empty_list(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        def failing_run(*_args: object, **_kwargs: object) -> subprocess.CompletedProcess[str]:
+            return subprocess.CompletedProcess(args=[], returncode=1, stdout="", stderr="boom")
+
+        monkeypatch.setattr(docker_mod.subprocess, "run", failing_run)
+
+        assert docker_mod.get_running_containers() is None
+
+    def test_a_missing_docker_binary_yields_none_not_an_empty_list(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        def missing_binary(*_args: object, **_kwargs: object) -> subprocess.CompletedProcess[str]:
+            raise FileNotFoundError
+
+        monkeypatch.setattr(docker_mod.subprocess, "run", missing_binary)
+
+        assert docker_mod.get_running_containers() is None
+
+    def test_a_successful_call_with_no_output_yields_an_empty_list(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        def empty_run(*_args: object, **_kwargs: object) -> subprocess.CompletedProcess[str]:
+            return subprocess.CompletedProcess(args=[], returncode=0, stdout="", stderr="")
+
+        monkeypatch.setattr(docker_mod.subprocess, "run", empty_run)
+
+        assert docker_mod.get_running_containers() == []

--- a/tests/test_docker.py
+++ b/tests/test_docker.py
@@ -15,6 +15,7 @@ import djinn_in_a_box.config.zones as zones_mod
 import djinn_in_a_box.core.docker as docker_mod
 from djinn_in_a_box.config.loader import load_config, save_config
 from djinn_in_a_box.config.models import AppConfig, ShellConfig
+from djinn_in_a_box.config.zones import ZoneAssignments, ZoneName
 from djinn_in_a_box.core.docker import (
     ContainerMount,
     ContainerOptions,
@@ -54,6 +55,7 @@ from djinn_in_a_box.core.docker import (
     validate_container_mounts,
     workflow_image_compatible,
 )
+from djinn_in_a_box.core.exceptions import ZoneConfigurationError
 
 
 def _empty_mount_args(_config: AppConfig | None = None) -> list[str]:
@@ -1100,15 +1102,16 @@ class TestGetRunningContainers:
             stdout="djinn\ndjinn-docker-proxy\n",
         )
         containers = get_running_containers()
+        assert containers is not None
         assert "djinn" in containers
         assert "djinn-docker-proxy" in containers
 
     @patch("djinn_in_a_box.core.docker.subprocess.run")
-    def test_returns_empty_list_on_error(self, mock_run: MagicMock) -> None:
-        """Test returns empty list on command failure."""
+    def test_returns_unknown_on_error(self, mock_run: MagicMock) -> None:
+        """A failed probe must stay distinct from an empty container list."""
         mock_run.return_value = MagicMock(returncode=1, stdout="")
         containers = get_running_containers()
-        assert containers == []
+        assert containers is None
 
 
 class TestDeleteVolumes:
@@ -1227,6 +1230,35 @@ class TestComposeRun:
         monkeypatch.setattr(zones_mod, "ZONES_FILE", tmp_path / "zones.toml")
 
         assert get_zone_overlay_mount_args(mock_app_config) == []
+
+    @pytest.mark.parametrize("source_kind", ("regular", "symlink"))
+    def test_rejects_non_directory_zone_source_after_assignment_resolution(
+        self,
+        mock_app_config: AppConfig,
+        monkeypatch: pytest.MonkeyPatch,
+        source_kind: str,
+    ) -> None:
+        source = Path(f"{mock_app_config.config_root}.local") / "claude" / "jobs"
+        source.parent.mkdir(parents=True)
+        if source_kind == "regular":
+            source.write_text("not a directory")
+        else:
+            outside = source.parent / "outside"
+            outside.mkdir()
+            source.symlink_to(outside, target_is_directory=True)
+        by_agent: dict[str, dict[ZoneName, tuple[Path, ...]]] = {
+            agent: {"local": (), "shared": ()} for agent in zones_mod.ZONE_CONTAINER_TARGETS
+        }
+        by_agent["claude"]["local"] = (Path("jobs"),)
+        assignments = ZoneAssignments(by_agent, ())
+
+        def load_assignments(_config: AppConfig | None = None) -> ZoneAssignments:
+            return assignments
+
+        monkeypatch.setattr(zones_mod, "load_zone_assignments", load_assignments)
+
+        with pytest.raises(ZoneConfigurationError, match="not a directory"):
+            get_zone_overlay_mount_args(mock_app_config)
 
     def test_rejects_mount_at_a_reserved_zone_overlay_target(
         self,

--- a/tests/test_docker.py
+++ b/tests/test_docker.py
@@ -5,6 +5,7 @@ import os
 import re
 import socket
 import subprocess
+import tarfile
 from collections.abc import Generator
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -60,6 +61,63 @@ from djinn_in_a_box.core.exceptions import ZoneConfigurationError
 
 def _empty_mount_args(_config: AppConfig | None = None) -> list[str]:
     return []
+
+
+def _deny_empty_placeholder_removal(
+    monkeypatch: pytest.MonkeyPatch, placeholder: Path
+) -> None:
+    original_rmdir = docker_mod.os.rmdir
+
+    def deny_placeholder_removal(path: str, *, dir_fd: int | None = None) -> None:
+        if Path(path).name == placeholder.name:
+            raise PermissionError("Docker-owned mount placeholder")
+        original_rmdir(path, dir_fd=dir_fd)
+
+    monkeypatch.setattr(docker_mod.os, "rmdir", deny_placeholder_removal)
+
+
+def test_clear_sync_path_preserves_an_empty_nonremovable_mount_placeholder(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    sync_path = tmp_path / "claude"
+    placeholder = sync_path / "plugins" / "marketplaces"
+    placeholder.mkdir(parents=True)
+    removable = sync_path / "credentials.json"
+    removable.write_text("remove me")
+    _deny_empty_placeholder_removal(monkeypatch, placeholder)
+
+    assert clear_sync_path(sync_path) is True
+    assert placeholder.is_dir()
+    assert not removable.exists()
+
+
+def test_restore_sync_path_preserves_an_empty_nonremovable_mount_placeholder(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    config_root = tmp_path / "config"
+    sync_path = config_root / "claude"
+    placeholder = sync_path / "plugins" / "marketplaces"
+    placeholder.mkdir(parents=True)
+    stale = sync_path / "stale.json"
+    stale.write_text("remove me")
+    staging = tmp_path / "staging"
+    staging.mkdir()
+    restored = tmp_path / "restored.json"
+    restored.write_text("restore me")
+    archive = staging / "djinn-sync-claude.tar.gz"
+    with tarfile.open(archive, "w:gz") as output:
+        output.add(restored, arcname=restored.name)
+    projects = tmp_path / "projects"
+    projects.mkdir()
+    config = AppConfig(code_dir=projects, config_root=config_root)
+    _deny_empty_placeholder_removal(monkeypatch, placeholder)
+
+    result = restore_sync_path("claude", staging, config)
+
+    assert result.success
+    assert placeholder.is_dir()
+    assert not stale.exists()
+    assert (sync_path / restored.name).read_text() == "restore me"
 
 
 def _parse_dockerfile_symlink_line(line: str) -> list[tuple[str, str]]:

--- a/tests/test_docker.py
+++ b/tests/test_docker.py
@@ -11,6 +11,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+import djinn_in_a_box.config.zones as zones_mod
 import djinn_in_a_box.core.docker as docker_mod
 from djinn_in_a_box.config.loader import load_config, save_config
 from djinn_in_a_box.config.models import AppConfig, ShellConfig
@@ -42,6 +43,7 @@ from djinn_in_a_box.core.docker import (
     get_existing_volumes_by_category,
     get_running_containers,
     get_shell_mount_args,
+    get_zone_overlay_mount_args,
     is_background_process_group,
     is_container_running,
     is_sync_archive,
@@ -444,9 +446,9 @@ class TestMountTargetCollisions:
         self, mock_app_config: AppConfig, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
     ) -> None:
         self._without_runtime_mounts(monkeypatch)
-        mounts = resolve_container_mounts((f"{tmp_path}:/home/dev/.config/claude/plugins",))
+        mounts = resolve_container_mounts((f"{tmp_path}:/home/dev/.config/claude/custom",))
 
-        assert mounts[0].target == Path("/home/dev/.claude/plugins")
+        assert mounts[0].target == Path("/home/dev/.claude/custom")
         validate_container_mounts(mounts, mock_app_config, DockerMode.NONE)
 
     @pytest.mark.parametrize(
@@ -1194,6 +1196,61 @@ class TestComposeRun:
 
     @patch("djinn_in_a_box.core.docker.get_project_root")
     @patch("djinn_in_a_box.core.docker.subprocess.run")
+    def test_emits_empty_zone_sources_without_using_them_as_workdir(
+        self,
+        mock_run: MagicMock,
+        mock_root: MagicMock,
+        mock_app_config: AppConfig,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """An empty source is a migrated overlay, not an omitted mount or workdir."""
+        self._without_runtime_mounts(monkeypatch)
+        zones_file = mock_app_config.config_root.parent / "zones.toml"
+        monkeypatch.setattr(zones_mod, "ZONES_FILE", zones_file)
+        mock_root.return_value = Path("/project")
+        mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+        empty_source = Path(f"{mock_app_config.config_root}.shared") / "claude" / "projects"
+        empty_source.mkdir(parents=True)
+
+        overlay_args = get_zone_overlay_mount_args(mock_app_config)
+        compose_run(mock_app_config, ContainerOptions(), command="echo", interactive=False)
+
+        expected = f"{empty_source}:/home/dev/.claude/projects"
+        assert expected in overlay_args
+        cmd = mock_run.call_args.args[0]
+        assert expected in cmd
+        assert "--workdir" not in cmd
+
+    def test_skips_zone_overlay_when_its_source_is_missing(
+        self, mock_app_config: AppConfig, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        monkeypatch.setattr(zones_mod, "ZONES_FILE", tmp_path / "zones.toml")
+
+        assert get_zone_overlay_mount_args(mock_app_config) == []
+
+    def test_rejects_mount_at_a_reserved_zone_overlay_target(
+        self,
+        mock_app_config: AppConfig,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+    ) -> None:
+        zones_file = tmp_path / "zones.toml"
+        monkeypatch.setattr(zones_mod, "ZONES_FILE", zones_file)
+
+        with pytest.raises(
+            MountCollisionError, match=r"reserved mount at /home/dev/\.claude/projects"
+        ):
+            validate_container_mounts(
+                (ContainerMount(tmp_path, Path("/home/dev/.claude/projects")),),
+                mock_app_config,
+                DockerMode.NONE,
+                shell_args=[],
+                audio_args=[],
+                dbus_args=[],
+            )
+
+    @patch("djinn_in_a_box.core.docker.get_project_root")
+    @patch("djinn_in_a_box.core.docker.subprocess.run")
     def test_emits_canonical_alias_target(
         self,
         mock_run: MagicMock,
@@ -1206,16 +1263,14 @@ class TestComposeRun:
         mock_root.return_value = Path("/project")
         mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
         options = ContainerOptions(
-            mounts=(
-                ContainerMount(tmp_path, Path("/home/dev/.config/claude/plugins")),
-            )
+            mounts=(ContainerMount(tmp_path, Path("/home/dev/.config/claude/custom")),)
         )
 
         compose_run(mock_app_config, options, command="echo", interactive=False)
 
         cmd = mock_run.call_args.args[0]
-        assert f"{tmp_path}:/home/dev/.claude/plugins" in cmd
-        assert cmd[cmd.index("--workdir") + 1] == "/home/dev/.claude/plugins"
+        assert f"{tmp_path}:/home/dev/.claude/custom" in cmd
+        assert cmd[cmd.index("--workdir") + 1] == "/home/dev/.claude/custom"
 
     @patch("djinn_in_a_box.core.docker.get_project_root")
     @patch("djinn_in_a_box.core.docker.subprocess.run")

--- a/tests/test_ws3_doctor_session.py
+++ b/tests/test_ws3_doctor_session.py
@@ -336,6 +336,7 @@ def _credential_root(tmp_path: Path) -> tuple[Path, AppConfig]:
     """A config root with one loose, one tight, and two decoys."""
     root = tmp_path / "config-root"
     root.mkdir()
+    root.chmod(0o700)
     # chmod after mkdir: mkdir's mode is masked by the umask, so 0o777 would
     # silently become 0o755 and the decoy would not be the wide-open case.
     (root / "claude").mkdir()
@@ -403,11 +404,15 @@ def test_doctor_warns_about_loose_credential_dirs_and_names_them(
 ) -> None:
     root, config = _credential_root(tmp_path)
     monkeypatch.setattr("djinn_in_a_box.config.loader.load_config", lambda: config)
-    monkeypatch.setattr(doctor_mod, "get_config_root", lambda _config=None: root)
+
+    def fixed_root(_config: AppConfig | None = None) -> Path:
+        return root
+
+    monkeypatch.setattr(doctor_mod, "get_config_root", fixed_root)
 
     checks = doctor_mod.run_checks(config, None)
 
-    row = next(check for check in checks if check.name == "Credential dir modes")
+    row = next(check for check in checks if check.name == "Credential and zone dir modes")
     assert row.status is doctor_mod.Status.WARN
     assert "claude" in row.detail
     assert "--fix" in row.remedy
@@ -421,7 +426,11 @@ def test_doctor_fix_tightens_loose_credential_dirs_and_is_idempotent(
     """
     root, config = _credential_root(tmp_path)
     monkeypatch.setattr("djinn_in_a_box.config.loader.load_config", lambda: config)
-    monkeypatch.setattr(doctor_mod, "get_config_root", lambda _config=None: root)
+
+    def fixed_root(_config: AppConfig | None = None) -> Path:
+        return root
+
+    monkeypatch.setattr(doctor_mod, "get_config_root", fixed_root)
     monkeypatch.setattr(doctor_mod, "run_checks", MagicMock(return_value=[]))
     monkeypatch.setattr(doctor_mod, "ensure_host_env", MagicMock())
     monkeypatch.setattr(doctor_mod, "seed_config", MagicMock(return_value=[]))

--- a/tests/test_zone_doctor.py
+++ b/tests/test_zone_doctor.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from djinn_in_a_box.commands import doctor as doctor_mod
+from djinn_in_a_box.config import zones as zones_mod
+from djinn_in_a_box.config.models import AppConfig
+from djinn_in_a_box.config.zones import load_zone_assignments
+from djinn_in_a_box.core.docker import ensure_zone_roots, resolve_zone_roots
+
+
+@pytest.fixture
+def zone_config(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> AppConfig:
+    projects = tmp_path / "projects"
+    projects.mkdir()
+    monkeypatch.setattr(zones_mod, "ZONES_FILE", tmp_path / "zones.toml")
+    return AppConfig(code_dir=projects, config_root=tmp_path / "config")
+
+
+def _check_named(checks: list[doctor_mod.Check], name: str) -> doctor_mod.Check:
+    return next(check for check in checks if check.name == name)
+
+
+def test_unmigrated_doctor_sizes_only_unmigrated_paths(
+    zone_config: AppConfig, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    roots = resolve_zone_roots(zone_config)
+    unmigrated = roots.config_root / "claude" / "jobs"
+    unmigrated.mkdir(parents=True)
+    (unmigrated / "state.json").write_text("unmigrated")
+    measured: list[Path] = []
+    def record_size(path: Path) -> int:
+        measured.append(path)
+        return 0
+
+    monkeypatch.setattr(doctor_mod, "_path_size_bytes", record_size)
+    checks = doctor_mod.run_checks(zone_config)
+
+    row = _check_named(checks, "Unmigrated zone assignments")
+    assert row.status is doctor_mod.Status.WARN
+    assert "claude/jobs" in row.detail
+    assert "migrate-zones" in row.remedy
+    assert measured
+    assert all(path == unmigrated or path.is_relative_to(unmigrated) for path in measured)
+
+
+def test_collision_doctor_names_both_copies_sizes_and_manual_options(
+    zone_config: AppConfig,
+) -> None:
+    roots = ensure_zone_roots(zone_config)
+    config_copy = roots.config_root / "claude" / "projects"
+    zone_copy = roots.shared_root / "claude" / "projects"
+    config_copy.mkdir(parents=True)
+    zone_copy.mkdir(parents=True)
+    (config_copy / "archive.jsonl").write_text("archive")
+    (zone_copy / "live.jsonl").write_text("live")
+
+    checks = doctor_mod.run_checks(zone_config)
+
+    row = _check_named(checks, "Unresolved zone collisions")
+    assert row.status is doctor_mod.Status.WARN
+    assert str(config_copy) in row.detail
+    assert str(zone_copy) in row.detail
+    assert "B" in row.detail
+    assert "keep the config-root copy" in row.remedy.lower()
+    assert "keep the zone copy" in row.remedy.lower()
+    assert "merge the trees by hand" in row.remedy.lower()
+
+
+def test_drift_accounts_for_intermediate_assignment_segments(zone_config: AppConfig) -> None:
+    roots = resolve_zone_roots(zone_config)
+    agent_root = roots.config_root / "claude"
+    (agent_root / "plugins").mkdir(parents=True)
+    unexpected = agent_root / "new-agent-directory"
+    unexpected.mkdir()
+
+    checks = doctor_mod.run_checks(zone_config)
+
+    row = _check_named(checks, "Zone drift")
+    assert row.status is doctor_mod.Status.WARN
+    assert str(unexpected) in row.detail
+    assert str(agent_root / "plugins") not in row.detail
+
+
+def test_doctor_reports_large_direct_files_and_loose_zone_permissions(
+    zone_config: AppConfig,
+) -> None:
+    roots = ensure_zone_roots(zone_config)
+    large_file = roots.config_root / "codex" / "logs.sqlite"
+    large_file.parent.mkdir(parents=True)
+    large_file.write_bytes(b"x" * doctor_mod.LARGE_NON_OVERLAYABLE_FILE_BYTES)
+    roots.shared_root.chmod(0o755)
+
+    assignments = load_zone_assignments(zone_config)
+    checks = doctor_mod.run_checks(zone_config)
+    loose = doctor_mod.loose_credential_dirs(zone_config, assignments)
+
+    large = _check_named(checks, "Large non-overlayable files")
+    assert large.status is doctor_mod.Status.WARN
+    assert str(large_file) in large.detail
+    assert roots.shared_root in loose

--- a/tests/test_zone_doctor.py
+++ b/tests/test_zone_doctor.py
@@ -151,3 +151,23 @@ def test_legacy_sync_root_is_not_reported_after_its_content_moves_to_a_zone(
     reconcile_zone_assignments(zone_config)
 
     assert doctor_mod._old_sync_root_present(zone_config) is False
+
+
+def test_doctor_warns_when_an_assigned_path_cannot_be_inspected(
+    zone_config: AppConfig,
+) -> None:
+    roots = resolve_zone_roots(zone_config)
+    source = roots.config_root / "claude" / "jobs"
+    source.mkdir(parents=True)
+    (source / "state.json").write_text("unreadable")
+    agent_root = source.parent
+    agent_root.chmod(0o000)
+
+    try:
+        checks = doctor_mod.run_checks(zone_config)
+    finally:
+        agent_root.chmod(0o700)
+
+    row = _check_named(checks, "Zone configuration")
+    assert row.status is doctor_mod.Status.WARN
+    assert "Cannot inspect zone path" in row.detail

--- a/tests/test_zone_doctor.py
+++ b/tests/test_zone_doctor.py
@@ -4,11 +4,13 @@ from pathlib import Path
 
 import pytest
 
+import djinn_in_a_box.core.docker as docker_mod
 from djinn_in_a_box.commands import doctor as doctor_mod
 from djinn_in_a_box.config import zones as zones_mod
 from djinn_in_a_box.config.models import AppConfig
 from djinn_in_a_box.config.zones import load_zone_assignments
 from djinn_in_a_box.core.docker import ensure_zone_roots, resolve_zone_roots
+from djinn_in_a_box.core.zone_migration import reconcile_zone_assignments
 
 
 @pytest.fixture
@@ -101,3 +103,51 @@ def test_doctor_reports_large_direct_files_and_loose_zone_permissions(
     assert large.status is doctor_mod.Status.WARN
     assert str(large_file) in large.detail
     assert roots.shared_root in loose
+
+
+def test_doctor_reports_skipped_shipped_default_and_names_conflicting_file(
+    zone_config: AppConfig,
+) -> None:
+    roots = resolve_zone_roots(zone_config)
+    conflict = roots.config_root / "claude" / "plugins"
+    conflict.parent.mkdir(parents=True)
+    conflict.write_text("not a directory")
+
+    checks = doctor_mod.run_checks(zone_config)
+
+    row = _check_named(checks, "Skipped shipped zone defaults")
+    assert row.status is doctor_mod.Status.WARN
+    assert "claude/plugins/cache" in row.detail
+    assert str(conflict) in row.detail
+    assert str(conflict) in row.remedy
+    assert "move or remove" in row.remedy.lower()
+
+
+def test_legacy_sync_root_is_detected_after_host_provisions_the_new_root(
+    zone_config: AppConfig, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(doctor_mod.Path, "home", lambda: zone_config.config_root.parent)
+    legacy_agent = zone_config.config_root.parent / ".djinn" / "sync" / "claude"
+    legacy_agent.mkdir(parents=True)
+    (legacy_agent / ".credentials.json").write_text("legacy credential")
+    monkeypatch.setattr(docker_mod, "get_project_root", lambda: zone_config.config_root.parent)
+
+    docker_mod.ensure_host_env(zone_config)
+
+    assert doctor_mod._old_sync_root_present(zone_config) is True
+
+
+def test_legacy_sync_root_is_not_reported_after_its_content_moves_to_a_zone(
+    zone_config: AppConfig, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(doctor_mod.Path, "home", lambda: zone_config.config_root.parent)
+    legacy_projects = zone_config.config_root.parent / ".djinn" / "sync" / "claude" / "projects"
+    legacy_projects.mkdir(parents=True)
+    (legacy_projects / "legacy.jsonl").write_text("legacy transcript")
+    current_projects = zone_config.config_root / "claude" / "projects"
+    current_projects.mkdir(parents=True)
+    (current_projects / "legacy.jsonl").write_text("legacy transcript")
+
+    reconcile_zone_assignments(zone_config)
+
+    assert doctor_mod._old_sync_root_present(zone_config) is False

--- a/tests/test_zone_doctor.py
+++ b/tests/test_zone_doctor.py
@@ -86,6 +86,22 @@ def test_drift_accounts_for_intermediate_assignment_segments(zone_config: AppCon
     assert str(agent_root / "plugins") not in row.detail
 
 
+def test_drift_ignores_a_reserved_migration_aside(zone_config: AppConfig) -> None:
+    roots = resolve_zone_roots(zone_config)
+    agent_root = roots.config_root / "claude"
+    aside = agent_root / ".djinn-migrating-jobs"
+    aside.mkdir(parents=True)
+    unexpected = agent_root / "new-agent-directory"
+    unexpected.mkdir()
+
+    checks = doctor_mod.run_checks(zone_config)
+
+    row = _check_named(checks, "Zone drift")
+    assert row.status is doctor_mod.Status.WARN
+    assert str(unexpected) in row.detail
+    assert str(aside) not in row.detail
+
+
 def test_doctor_reports_large_direct_files_and_loose_zone_permissions(
     zone_config: AppConfig,
 ) -> None:

--- a/tests/test_zone_overlays_live_docker.py
+++ b/tests/test_zone_overlays_live_docker.py
@@ -1,0 +1,228 @@
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from uuid import uuid4
+
+import pytest
+
+import djinn_in_a_box.config.zones as zones_mod
+import djinn_in_a_box.core.docker as docker_mod
+from djinn_in_a_box.config.models import AppConfig
+from djinn_in_a_box.core.docker import (
+    ContainerOptions,
+    DockerMode,
+    compose_run,
+    resolve_zone_roots,
+)
+
+
+def _docker_daemon_reachable() -> bool:
+    try:
+        result = subprocess.run(
+            ["docker", "info"],
+            capture_output=True,
+            check=False,
+            timeout=5,
+        )
+    except (FileNotFoundError, OSError, subprocess.TimeoutExpired):
+        return False
+    return result.returncode == 0
+
+
+pytestmark = pytest.mark.skipif(
+    not _docker_daemon_reachable(), reason="Docker daemon is not reachable"
+)
+
+
+def test_container_view_manifest_preserves_base_overlay_and_nested_overlay(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A live container proves the mounted paths retain the agent's expected layout."""
+    project = tmp_path / "project"
+    project.mkdir()
+    compose_file = project / "compose.yml"
+    project_name = f"djinn-zone-test-{uuid4().hex}"
+    service = f"zone-manifest-{uuid4().hex}"
+    volume_names = {
+        "config": f"djinn-zone-config-{uuid4().hex}",
+        "shared": f"djinn-zone-shared-{uuid4().hex}",
+        "local": f"djinn-zone-local-{uuid4().hex}",
+    }
+    created_volumes: list[str] = []
+    try:
+        mountpoints: dict[str, Path] = {}
+        for zone, name in volume_names.items():
+            created = subprocess.run(
+                ["docker", "volume", "create", name],
+                capture_output=True,
+                text=True,
+                check=False,
+                timeout=30,
+            )
+            assert created.returncode == 0, created.stderr
+            created_volumes.append(name)
+            inspected = subprocess.run(
+                ["docker", "volume", "inspect", name, "--format", "{{.Mountpoint}}"],
+                capture_output=True,
+                text=True,
+                check=False,
+                timeout=30,
+            )
+            assert inspected.returncode == 0, inspected.stderr
+            mountpoints[zone] = Path(inspected.stdout.strip())
+
+        helpers = {
+            "config": (
+                "mkdir -p /data/claude/base /data/claude/projects /data/claude/plugins/cache; "
+                "printf 'base\\n' > /data/claude/base/marker; "
+                "printf 'shared\\n' > /data/claude/projects/marker; "
+                "printf 'local\\n' > /data/claude/plugins/cache/marker"
+            ),
+            "shared": "mkdir -p /data/claude/projects; "
+            "printf 'shared\\n' > /data/claude/projects/marker",
+            "local": "mkdir -p /data/claude/plugins/cache; "
+            "printf 'local\\n' > /data/claude/plugins/cache/marker",
+        }
+        for zone, script in helpers.items():
+            populated = subprocess.run(
+                [
+                    "docker",
+                    "run",
+                    "--rm",
+                    "-v",
+                    f"{volume_names[zone]}:/data",
+                    "alpine:3.20",
+                    "/bin/sh",
+                    "-c",
+                    script,
+                ],
+                capture_output=True,
+                text=True,
+                check=False,
+                timeout=30,
+            )
+            assert populated.returncode == 0, populated.stderr
+
+        config = AppConfig(
+            code_dir=project,
+            config_root=mountpoints["config"],
+            shared_root=mountpoints["shared"],
+            local_root=mountpoints["local"],
+        )
+        roots = resolve_zone_roots(config)
+        compose_file.write_text(
+            f"""services:
+  {service}:
+    image: alpine:3.20
+    entrypoint: [\"/bin/sh\"]
+    volumes:
+      - {roots.config_root}/claude:/home/dev/.claude
+"""
+        )
+        command = "".join(
+            f"printf '{label}='; cat {path}; "
+            for label, path in (
+                ("base", "/home/dev/.claude/base/marker"),
+                ("overlay", "/home/dev/.claude/projects/marker"),
+                ("nested-overlay", "/home/dev/.claude/plugins/cache/marker"),
+            )
+        )
+        before = subprocess.run(
+            [
+                "docker",
+                "compose",
+                "--project-name",
+                project_name,
+                "-f",
+                str(compose_file),
+                "run",
+                "--rm",
+                "-T",
+                service,
+                "-c",
+                command,
+            ],
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=30,
+        )
+        assert before.returncode == 0, before.stderr
+        migrated = subprocess.run(
+            [
+                "docker",
+                "run",
+                "--rm",
+                "-v",
+                f"{volume_names['config']}:/data",
+                "alpine:3.20",
+                "/bin/sh",
+                "-c",
+                "rm -f /data/claude/projects/marker /data/claude/plugins/cache/marker",
+            ],
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=30,
+        )
+        assert migrated.returncode == 0, migrated.stderr
+        source_directories = {
+            roots.shared_root / "claude" / "projects",
+            roots.local_root / "claude" / "plugins" / "cache",
+        }
+        original_is_dir = Path.is_dir
+
+        def docker_host_directory(path: Path) -> bool:
+            return path in source_directories or original_is_dir(path)
+
+        monkeypatch.setattr(Path, "is_dir", docker_host_directory)
+        monkeypatch.setattr(zones_mod, "ZONES_FILE", tmp_path / "zones.toml")
+
+        def project_root() -> Path:
+            return project
+
+        def compose_files(_mode: DockerMode) -> list[str]:
+            return ["--project-name", project_name, "-f", str(compose_file)]
+
+        monkeypatch.setattr(docker_mod, "get_project_root", project_root)
+        monkeypatch.setattr(docker_mod, "get_compose_files", compose_files)
+        result = compose_run(
+            config,
+            ContainerOptions(),
+            command=command,
+            interactive=False,
+            shell_mount_args=[],
+            audio_mount_args=[],
+            dbus_mount_args=[],
+            service=service,
+            timeout=30,
+        )
+    finally:
+        subprocess.run(
+            [
+                "docker",
+                "compose",
+                "--project-name",
+                project_name,
+                "-f",
+                str(compose_file),
+                "down",
+                "--remove-orphans",
+            ],
+            capture_output=True,
+            check=False,
+            timeout=30,
+        )
+        for name in created_volumes:
+            subprocess.run(
+                ["docker", "volume", "rm", name],
+                capture_output=True,
+                check=False,
+                timeout=30,
+            )
+
+    expected = "base=base\noverlay=shared\nnested-overlay=local\n"
+    assert before.stdout == expected
+    assert result.success, result.stderr
+    assert result.stdout == before.stdout

--- a/tests/test_zone_resolution.py
+++ b/tests/test_zone_resolution.py
@@ -20,6 +20,7 @@ from djinn_in_a_box.config.zones import (
 from djinn_in_a_box.core.docker import (
     build_compose_env,
     ensure_host_env,
+    ensure_zone_roots,
     get_config_root,
     resolve_zone_roots,
 )
@@ -203,6 +204,31 @@ def test_host_provisioning_creates_zone_roots_and_agent_roots_with_0700_mode(
         assert stat.S_IMODE((roots.config_root / agent).stat().st_mode) == 0o700
 
 
+def test_ensure_zone_roots_rejects_a_derived_symlink_without_chmodding_its_target(
+    tmp_path: Path,
+) -> None:
+    config = _config(tmp_path)
+    shared_target = tmp_path / "large-disk"
+    shared_target.mkdir()
+    shared_target.chmod(0o755)
+    Path(f"{config.config_root}.shared").symlink_to(shared_target, target_is_directory=True)
+
+    with pytest.raises(ZoneRootValidationError, match="symlink"):
+        ensure_zone_roots(config)
+
+    assert stat.S_IMODE(shared_target.stat().st_mode) == 0o755
+
+
+def test_ensure_zone_roots_translates_a_regular_file_to_a_named_zone_error(
+    tmp_path: Path,
+) -> None:
+    config = _config(tmp_path)
+    config.config_root.write_text("not a directory")
+
+    with pytest.raises(ZoneRootValidationError, match="not a directory"):
+        ensure_zone_roots(config)
+
+
 def test_zone_assignments_merge_defaults_for_every_container_agent(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -318,6 +344,56 @@ def test_regular_file_at_a_default_assignment_is_skipped(tmp_path: Path) -> None
 
     assert Path("jobs") not in assignments.by_agent["claude"]["local"]
     assert assignments.skipped_defaults[0].relative_path == Path("jobs")
+
+
+def test_symlinked_component_at_a_default_assignment_is_skipped(tmp_path: Path) -> None:
+    config = _config(tmp_path)
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    plugins = config.config_root / "claude" / "plugins"
+    plugins.parent.mkdir(parents=True)
+    plugins.symlink_to(outside, target_is_directory=True)
+    zones_file = tmp_path / "zones.toml"
+    zones_file.touch()
+
+    assignments = load_zone_assignments(config, path=zones_file)
+
+    assert Path("plugins/marketplaces") not in assignments.by_agent["claude"]["local"]
+    assert any(
+        skipped.relative_path == Path("plugins/marketplaces")
+        for skipped in assignments.skipped_defaults
+    )
+
+
+@pytest.mark.parametrize("key", ("general.shared_root", "general.local_root"))
+def test_config_set_rejects_nested_zone_roots_before_saving(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, key: str
+) -> None:
+    config_file = tmp_path / "config.toml"
+    config = _config(tmp_path)
+    save_config(config, config_file)
+    monkeypatch.setattr("djinn_in_a_box.config.loader.CONFIG_FILE", config_file)
+
+    result = runner.invoke(app, ["config", "set", key, str(config.config_root / "nested")])
+
+    assert result.exit_code == 1
+    assert load_config(config_file).shared_root is None
+    assert load_config(config_file).local_root is None
+
+
+@pytest.mark.parametrize("key", ("general.shared_root", "general.local_root"))
+def test_config_set_warns_that_moved_zone_data_is_not_relocated(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, key: str
+) -> None:
+    config_file = tmp_path / "config.toml"
+    config = _config(tmp_path)
+    save_config(config, config_file)
+    monkeypatch.setattr("djinn_in_a_box.config.loader.CONFIG_FILE", config_file)
+
+    result = runner.invoke(app, ["config", "set", key, str(tmp_path / "moved-zone")])
+
+    assert result.exit_code == 0
+    assert "Zone data does not follow" in result.output
 
 
 @pytest.mark.parametrize(

--- a/tests/test_zone_resolution.py
+++ b/tests/test_zone_resolution.py
@@ -1,0 +1,335 @@
+from __future__ import annotations
+
+import stat
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+import djinn_in_a_box.config.zones as zones_mod
+import djinn_in_a_box.core.docker as docker_mod
+from djinn_in_a_box.cli.djinn import app
+from djinn_in_a_box.config.defaults import DEFAULT_ZONES, SYNC_PATHS
+from djinn_in_a_box.config.loader import load_config, save_config
+from djinn_in_a_box.config.models import AppConfig
+from djinn_in_a_box.config.zones import (
+    ZONE_CONTAINER_TARGETS,
+    ZoneConfigurationError,
+    load_zone_assignments,
+)
+from djinn_in_a_box.core.docker import (
+    build_compose_env,
+    ensure_host_env,
+    get_config_root,
+    resolve_zone_roots,
+)
+from djinn_in_a_box.core.exceptions import ZoneRootValidationError
+
+runner = CliRunner()
+
+
+def _config(
+    tmp_path: Path,
+    *,
+    shared_root: Path | None = None,
+    local_root: Path | None = None,
+) -> AppConfig:
+    projects = tmp_path / "projects"
+    projects.mkdir(exist_ok=True)
+    return AppConfig(
+        code_dir=projects,
+        config_root=tmp_path / "config",
+        shared_root=shared_root,
+        local_root=local_root,
+    )
+
+
+def _paths(values: list[str]) -> tuple[Path, ...]:
+    return tuple(Path(value) for value in values)
+
+
+def test_default_zones_match_the_frozen_assignment_table() -> None:
+    assert DEFAULT_ZONES == {
+        "claude": {
+            "local": [
+                "jobs",
+                "cache",
+                "file-history",
+                "ide",
+                "paste-cache",
+                "session-env",
+                "shell-snapshots",
+                "tasks",
+                "telemetry",
+                "work",
+                "sessions",
+                "daemon",
+                "plugins/marketplaces",
+                "plugins/cache",
+            ],
+            "shared": ["projects", "transcripts"],
+        },
+        "codex": {
+            "local": [
+                ".tmp",
+                "tmp",
+                "cache",
+                "log",
+                "mcp-oauth-locks",
+                "shell_snapshots",
+                "plugins/cache",
+            ],
+            "shared": ["sessions"],
+        },
+        "opencode": {"local": ["node_modules", "native"], "shared": []},
+        "gemini": {"local": ["tmp"], "shared": ["history"]},
+        "gh": {"local": [], "shared": []},
+        "age": {"local": [], "shared": []},
+    }
+
+
+@pytest.mark.parametrize("use_environment", [False, True])
+def test_zone_roots_follow_the_effective_config_root(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, use_environment: bool
+) -> None:
+    config = _config(tmp_path)
+    if use_environment:
+        effective_root = tmp_path / "from-environment"
+        monkeypatch.setenv("DJINN_CONFIG_ROOT", str(effective_root))
+    else:
+        effective_root = config.config_root
+        monkeypatch.delenv("DJINN_CONFIG_ROOT", raising=False)
+
+    roots = resolve_zone_roots(config)
+    compose_env = build_compose_env(config)
+
+    assert get_config_root(config) == effective_root
+    assert roots.config_root == effective_root
+    assert roots.shared_root == Path(f"{effective_root}.shared")
+    assert roots.local_root == Path(f"{effective_root}.local")
+    assert Path(compose_env["DJINN_CONFIG_ROOT"]) == roots.config_root
+
+
+def test_explicit_zone_roots_survive_an_unrelated_config_set(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    config = _config(
+        tmp_path,
+        shared_root=tmp_path / "shared-zone",
+        local_root=tmp_path / "local-zone",
+    )
+
+    config_file = tmp_path / "config.toml"
+    save_config(config, config_file)
+    monkeypatch.setattr("djinn_in_a_box.config.loader.CONFIG_FILE", config_file)
+
+    result = runner.invoke(app, ["config", "set", "general.timezone", "Europe/Berlin"])
+
+    assert result.exit_code == 0
+    persisted = load_config(config_file)
+
+    assert persisted.shared_root == (tmp_path / "shared-zone").resolve()
+    assert persisted.local_root == (tmp_path / "local-zone").resolve()
+
+
+def test_config_set_and_show_carry_explicit_zone_roots(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    config_file = tmp_path / "config.toml"
+    save_config(_config(tmp_path), config_file)
+    monkeypatch.setattr("djinn_in_a_box.config.loader.CONFIG_FILE", config_file)
+    shared_root = tmp_path / "shared-zone"
+    local_root = tmp_path / "local-zone"
+
+    shared_result = runner.invoke(app, ["config", "set", "general.shared_root", str(shared_root)])
+    local_result = runner.invoke(app, ["config", "set", "general.local_root", str(local_root)])
+    show_result = runner.invoke(app, ["config", "show"])
+
+    assert shared_result.exit_code == 0
+    assert local_result.exit_code == 0
+    assert show_result.exit_code == 0
+    persisted = load_config(config_file)
+    assert persisted.shared_root == shared_root.resolve()
+    assert persisted.local_root == local_root.resolve()
+    unwrapped = "".join(show_result.output.split())
+    assert str(shared_root) in unwrapped
+    assert str(local_root) in unwrapped
+
+
+@pytest.mark.parametrize(
+    "roots",
+    [
+        {"shared_root": Path("config")},
+        {"shared_root": Path("config/child")},
+        {"shared_root": Path("shared"), "local_root": Path("shared/child")},
+    ],
+)
+def test_zone_root_resolution_rejects_equal_and_nested_roots(
+    tmp_path: Path, roots: dict[str, Path]
+) -> None:
+    config_root = tmp_path / "config"
+    projects = tmp_path / "projects"
+    projects.mkdir()
+    config = AppConfig(
+        code_dir=projects,
+        config_root=config_root,
+        shared_root=tmp_path / roots["shared_root"] if "shared_root" in roots else None,
+        local_root=tmp_path / roots["local_root"] if "local_root" in roots else None,
+    )
+
+    assert config.config_root == config_root
+    with pytest.raises(ZoneRootValidationError):
+        resolve_zone_roots(config)
+
+
+def test_host_provisioning_creates_zone_roots_and_agent_roots_with_0700_mode(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    config = _config(tmp_path)
+    monkeypatch.setattr(docker_mod, "get_project_root", lambda: tmp_path / "project")
+    roots = resolve_zone_roots(config)
+    for root in (roots.config_root, roots.shared_root, roots.local_root):
+        root.mkdir(parents=True)
+        root.chmod(0o755)
+    agent_root = roots.config_root / "claude"
+    agent_root.mkdir()
+    agent_root.chmod(0o755)
+
+    ensure_host_env(config)
+
+    for root in (roots.config_root, roots.shared_root, roots.local_root):
+        assert stat.S_IMODE(root.stat().st_mode) == 0o700
+    for agent in SYNC_PATHS["credentials"]:
+        assert stat.S_IMODE((roots.config_root / agent).stat().st_mode) == 0o700
+
+
+def test_zone_assignments_merge_defaults_for_every_container_agent(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    zones_file = tmp_path / "zones.toml"
+    monkeypatch.setattr(zones_mod, "ZONES_FILE", zones_file)
+
+    assignments = load_zone_assignments(_config(tmp_path))
+
+    assert tuple(assignments.by_agent) == tuple(ZONE_CONTAINER_TARGETS)
+    assert assignments.skipped_defaults == ()
+    for agent in ZONE_CONTAINER_TARGETS:
+        assert assignments.by_agent[agent]["local"] == _paths(DEFAULT_ZONES[agent]["local"])
+        assert assignments.by_agent[agent]["shared"] == _paths(DEFAULT_ZONES[agent]["shared"])
+
+
+def test_zone_assignments_add_user_paths_without_replacing_defaults(tmp_path: Path) -> None:
+    zones_file = tmp_path / "zones.toml"
+    zones_file.write_text('[zones.claude]\nlocal = ["custom-cache"]\n')
+
+    assignments = load_zone_assignments(_config(tmp_path), path=zones_file)
+
+    assert assignments.by_agent["claude"]["local"] == (
+        *_paths(DEFAULT_ZONES["claude"]["local"]),
+        Path("custom-cache"),
+    )
+    assert assignments.by_agent["claude"]["shared"] == _paths(DEFAULT_ZONES["claude"]["shared"])
+
+
+@pytest.mark.parametrize(
+    ("contents", "expected"),
+    [
+        ('[zones.claude]\nlocal = ["projects"]\n', "both"),
+        ('[zones.claude]\nlocal = ["plugins"]\n', "overlap"),
+    ],
+)
+def test_zone_assignments_reject_cross_zone_and_nested_conflicts(
+    tmp_path: Path, contents: str, expected: str
+) -> None:
+    zones_file = tmp_path / "zones.toml"
+    zones_file.write_text(contents)
+
+    with pytest.raises(ZoneConfigurationError, match=expected):
+        load_zone_assignments(_config(tmp_path), path=zones_file)
+
+
+@pytest.mark.parametrize(
+    "path",
+    ["/absolute", ".", "..", "cache/../outside"],
+)
+def test_zone_assignments_reject_absolute_and_traversal_paths(tmp_path: Path, path: str) -> None:
+    zones_file = tmp_path / "zones.toml"
+    zones_file.write_text(f'[zones.gh]\nlocal = ["{path}"]\n')
+
+    with pytest.raises(ZoneConfigurationError):
+        load_zone_assignments(_config(tmp_path), path=zones_file)
+
+
+def test_zone_assignments_reject_symlinked_components(tmp_path: Path) -> None:
+    config = _config(tmp_path)
+    target = tmp_path / "outside"
+    target.mkdir()
+    agent_root = config.config_root / "claude"
+    agent_root.mkdir(parents=True)
+    (agent_root / "link").symlink_to(target)
+    zones_file = tmp_path / "zones.toml"
+    zones_file.write_text('[zones.claude]\nlocal = ["link/cache"]\n')
+
+    with pytest.raises(ZoneConfigurationError, match="symlinked"):
+        load_zone_assignments(config, path=zones_file)
+
+
+def test_zone_assignments_reject_a_user_path_that_is_a_regular_file(tmp_path: Path) -> None:
+    config = _config(tmp_path)
+    file_path = config.config_root / "gh" / "hosts.yml"
+    file_path.parent.mkdir(parents=True)
+    file_path.touch()
+    zones_file = tmp_path / "zones.toml"
+    zones_file.write_text('[zones.gh]\nlocal = ["hosts.yml"]\n')
+
+    with pytest.raises(ZoneConfigurationError, match="regular file"):
+        load_zone_assignments(config, path=zones_file)
+
+
+def test_regular_file_at_a_default_assignment_is_skipped(tmp_path: Path) -> None:
+    config = _config(tmp_path)
+    jobs = config.config_root / "claude" / "jobs"
+    jobs.parent.mkdir(parents=True)
+    jobs.touch()
+    zones_file = tmp_path / "zones.toml"
+    zones_file.touch()
+
+    assignments = load_zone_assignments(config, path=zones_file)
+
+    assert Path("jobs") not in assignments.by_agent["claude"]["local"]
+    assert assignments.skipped_defaults[0].relative_path == Path("jobs")
+
+
+@pytest.mark.parametrize(
+    ("agent", "path"),
+    [
+        ("repo-dotfiles", "cache"),
+        ("claude", "skills/cache"),
+        ("opencode", "seed"),
+    ],
+)
+def test_zone_assignments_reject_entries_without_a_safe_container_target(
+    tmp_path: Path, agent: str, path: str
+) -> None:
+    zones_file = tmp_path / "zones.toml"
+    zones_file.write_text(f'[zones.{agent}]\nlocal = ["{path}"]\n')
+
+    with pytest.raises(ZoneConfigurationError):
+        load_zone_assignments(_config(tmp_path), path=zones_file)
+
+
+@pytest.mark.parametrize(
+    "contents",
+    [
+        "[zones.claude\nlocal = [\"cache\"]\n",
+        '[zones.claude]\nunknown = ["cache"]\n',
+    ],
+)
+def test_malformed_or_schema_invalid_zones_file_raises_a_named_error(
+    tmp_path: Path, contents: str
+) -> None:
+    zones_file = tmp_path / "zones.toml"
+    zones_file.write_text(contents)
+
+    with pytest.raises(ZoneConfigurationError):
+        load_zone_assignments(_config(tmp_path), path=zones_file)

--- a/tests/test_zone_resolution.py
+++ b/tests/test_zone_resolution.py
@@ -260,6 +260,14 @@ def test_zone_assignments_reject_absolute_and_traversal_paths(tmp_path: Path, pa
         load_zone_assignments(_config(tmp_path), path=zones_file)
 
 
+def test_zone_assignments_reject_reserved_migration_paths(tmp_path: Path) -> None:
+    zones_file = tmp_path / "zones.toml"
+    zones_file.write_text('[zones.claude]\nlocal = [".djinn-migrating-jobs"]\n')
+
+    with pytest.raises(ZoneConfigurationError, match="reserved migration path"):
+        load_zone_assignments(_config(tmp_path), path=zones_file)
+
+
 def test_zone_assignments_reject_symlinked_components(tmp_path: Path) -> None:
     config = _config(tmp_path)
     target = tmp_path / "outside"

--- a/tests/test_zone_resolution.py
+++ b/tests/test_zone_resolution.py
@@ -274,6 +274,18 @@ def test_zone_assignments_reject_symlinked_components(tmp_path: Path) -> None:
         load_zone_assignments(config, path=zones_file)
 
 
+def test_zone_assignments_reject_symlinked_destination_components(tmp_path: Path) -> None:
+    config = _config(tmp_path)
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    roots = resolve_zone_roots(config)
+    roots.local_root.mkdir()
+    (roots.local_root / "claude").symlink_to(outside, target_is_directory=True)
+
+    with pytest.raises(ZoneConfigurationError, match="symlinked"):
+        load_zone_assignments(config)
+
+
 def test_zone_assignments_reject_a_user_path_that_is_a_regular_file(tmp_path: Path) -> None:
     config = _config(tmp_path)
     file_path = config.config_root / "gh" / "hosts.yml"


### PR DESCRIPTION
Closes #8.

## The problem

The config root held three unrelated data classes in one directory per agent:
credentials, conversation transcripts, and rebuildable scratch. All three inherited
the properties meant for credentials — encrypted backup, cross-machine mirroring,
bind-mount into every container. Measured on a real host: **8.6 GB across 117,430
files to protect under 1 MB of secrets**, a ratio of roughly 1 : 10,000.

It was never a Claude-specific problem. `codex` carried the same disease
(`sessions/` 1.8 GB, `logs_2.sqlite` 205 MB), and two of the largest items —
`.pnpm-store/` at 835 MB and `bin-shellcheck` — were not named in the issue at all.

## The approach

Each agent subpath is assigned to one of three zones, realised by **mount overlay**
rather than by filtering the backup:

| Zone | Backed up | Mirrorable |
|---|---|---|
| `config` (the resolved config root) | yes | yes |
| `<config_root>.shared` | no | yes |
| `<config_root>.local` | no | no |

Overlaying rather than filtering is what keeps `backup_sync_path` and
`restore_sync_path` untouched: `restore_sync_path` clears its target before
extracting, so a filtered backup would have deleted on first restore exactly the
data this issue protects.

Roots derive at runtime from `get_config_root()`, so `DJINN_CONFIG_ROOT` and a
`config set` move all three together. `DEFAULT_ZONES` ships host-neutral defaults;
`~/.config/djinn_in_a_box/zones.toml` extends them additively, so OSS users never
edit the repo.

## What's included

- `djinn migrate-zones` — idempotent, container-guarded, kernel-locked, mirroring-aware
- A zone gate over three unsafe conditions, each with its own remedy; `doctor` and
  `migrate-zones` are never gated
- New `doctor` rows: unmigrated assignments, unresolved collisions, drift below the
  agent roots, zone-root permissions, large non-overlayable files
- README, IMPLEMENTATION and the sync guide updated; `clean`'s help text corrected;
  agent-native retention documented (acceptance criteria 2-4)

## Result

The backed-up and mirrored surface drops from **8.6 GB to ~340 MB**, the container's
view is unchanged, and for a fresh installation the defaults apply from day one — so
the problem never arises rather than being cleaned up later.

## Notable design points

**Occupancy is decided by content on the config-root side and by existence on the
zone side.** Docker materialises a missing nested bind-mount destination inside the
parent's bind source, so every assigned path reappears as an empty root-owned
directory after each container start. An existence test there would read as
"unmigrated" forever; a non-emptiness test on the zone side would emit no overlays
at all on a fresh install.

**Cross-filesystem migration renames the source aside atomically before copying,
and re-verifies it immediately before deletion.** The rename locks out processes
that would newly open the path; the comparison catches writers holding a descriptor
from before it. Both are needed — a rename removes a pathname, it does not
invalidate open descriptors — and without them a mirroring daemon mid-write loses
data while the migration reports success.

**Guards fail closed on unknown state.** A failed `docker ps` yields `None`, distinct
from "no containers", and every consumer refuses it.

## Deliberately out of scope

`include_shared` and a zone-qualified archive identity (all four acceptance criteria
are met without them, and they would force a zone dimension onto the two helpers that
clear a directory before extracting into it); Djinn-implemented retention; per-project
transcript isolation, which the issue lists as a proposal option and which this change
does not alter — documented in the README as a stated limit.

## Verification

952 tests, Ruff clean, Pyright 119 against a 122 baseline on master (three
pre-existing errors incidentally fixed, none added).

Planned with a convergence Plan-Loop run to its stop conditions (Codex 5 iterations,
87 findings; Opus 2 rounds, 63 findings) and built under a Code-Loop of 3 iterations
plus 4 fix rounds. Every load-bearing rule was mutation-tested: the guard was broken
deliberately and the suite had to fail. That caught, among others, a test that mocked
the very function it was meant to pin — the whole fix could be reverted with the suite
staying green.
