### PR TITLE
fix(start): stop the container dying on backgrounded starts, add --detach

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,18 @@ Versioning before and after the first stable release.
 
 ### Fixed
 
+- Captured Docker output is no longer mangled by Rich. Every command that echoes
+  a subprocess's stdout/stderr now routes through `print_captured()`, which
+  disables markup, highlighting and re-wrapping. Previously Rich consumed
+  anything shaped like a tag, so `djinn build`'s BuildKit log lost exactly the
+  `[internal]` / `[dev 3/25]` stage markers that locate a failing step, and long
+  paths were hard-wrapped mid-token.
+- `djinn start --detach` no longer implies a readiness it cannot verify. `up -d`
+  returns as soon as the container is created, while seeding runs for roughly
+  another 30 seconds, so the check confirms only that the container did not die
+  immediately; the message now says "started", points at `docker logs -f djinn`
+  for the initialization, and reports an unverified container as "not running"
+  rather than asserting it exited.
 - Settings are no longer lost when the container is stopped rather than exited.
   `entrypoint.sh` ran its reverse-sync only after the interactive shell returned,
   so `docker stop` — the only shutdown a detached container ever gets — killed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,13 @@ Versioning before and after the first stable release.
 
 ### Fixed
 
+- Settings are no longer lost when the container is stopped rather than exited.
+  `entrypoint.sh` ran its reverse-sync only after the interactive shell returned,
+  so `docker stop` — the only shutdown a detached container ever gets — killed
+  PID 1 with every in-session settings change unpersisted. The sync now lives in
+  an idempotent `persist_session_state()` reached from both the normal exit and a
+  TERM/INT trap, and the shell runs as a waited-on background job so the trap can
+  fire at all. Interactive behaviour (job control, Ctrl+C) is unchanged.
 - `djinn clean` now removes the containers it reports as removed. Compose treats
   containers created by `compose run` as one-off and skips them on a plain
   `down`, which is how `djinn start` and `djinn run` create the dev container —

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,15 @@ Versioning before and after the first stable release.
 - `djinn start --detach` starts the container with `docker compose up -d` and
   returns, leaving no Compose client attached; attach afterwards with
   `djinn enter`. The detached path keeps the `--docker` proxy running, refuses to
-  start when a Djinn container already exists, and passes the dynamic mounts to
-  Compose through a generated override file.
+  start when a Djinn container is already running, and passes the dynamic mounts
+  to Compose through a generated override file — including the `-e` half of the
+  audio/D-Bus pairs, without which the sockets are mounted but `PULSE_SERVER`
+  and `DBUS_SESSION_BUS_ADDRESS` are unset and every client fails to find them.
+  Because `up -d` exits 0 as soon as the container is created and says nothing
+  about what the entrypoint did next, the command verifies the container is
+  actually running before reporting success, and points at `docker logs djinn`
+  when it is not. Captured Docker output is printed verbatim rather than through
+  Rich markup, which would silently delete the bracketed BuildKit stage tags.
 - Guard against starting an interactive container from a background process
   group. `djinn start ... &` left a TTY-attached Compose client in the
   background, where every `tcsetattr()` raises SIGTTOU; Compose forwarded the
@@ -61,7 +68,12 @@ Versioning before and after the first stable release.
   PID 1 with every in-session settings change unpersisted. The sync now lives in
   an idempotent `persist_session_state()` reached from both the normal exit and a
   TERM/INT trap, and the shell runs as a waited-on background job so the trap can
-  fire at all. Interactive behaviour (job control, Ctrl+C) is unchanged.
+  fire at all — a foreground command defers every trap until it returns, which
+  under `docker stop` never happens. Backgrounding would also reassign the
+  shell's stdin to `/dev/null` (job control is off, and that reassignment happens
+  before explicit redirections), leaving zsh non-interactive so it reads EOF and
+  exits at once; the entrypoint therefore duplicates fd 0 beforehand and hands it
+  back explicitly. Interactive behaviour (job control, Ctrl+C) is unchanged.
 - `djinn clean` now removes the containers it reports as removed. Compose treats
   containers created by `compose run` as one-off and skips them on a plain
   `down`, which is how `djinn start` and `djinn run` create the dev container —

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,8 +26,15 @@ Versioning before and after the first stable release.
   background, where every `tcsetattr()` raises SIGTTOU; Compose forwarded the
   signal into the container, producing tens of events per second and flooding
   Docker's event ring buffer. `djinn start` now fails with an explanation and
-  points at `--detach`, a foreground start, or `setsid`. Non-TTY stdin, absent
-  controlling terminals, and headless `-T` runs are unaffected.
+  points at `--detach` or a foreground start. Non-TTY stdin, absent controlling
+  terminals, and headless `-T` runs are unaffected.
+- The entrypoint no longer exits when it has no terminal. An interactive shell
+  cannot run without one — zsh reads EOF and returns immediately, which used to
+  take the container down with exit code 0 and an empty log. Since
+  `docker compose run` picks `-T` from the *client's stdout*, redirecting output
+  was enough to trigger that, whatever stdin did. The container now stays up and
+  says why, so `djinn enter` (which brings its own TTY) still works, and a later
+  `docker stop` still reaches the reverse-sync.
 - Persistent `age` encryption identity store: `${DJINN_CONFIG_ROOT}/age` is
   provisioned as a credential directory and bind-mounted at `~/.config/age`, so
   `age` keys survive container restarts and are captured by `djinn backup`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,9 @@ Versioning before and after the first stable release.
   `Seed & Config`, `MCP`, `Tools`, and `Security` sections.
 - Propagated `NO_COLOR` and terminal width into Compose startup so container
   shell output follows host plain-output and wrapping behavior.
+- The startup banner leads with a blank line, so the djinn's top row no longer
+  reads as clipped against the shell prompt. Plain mode (NO_COLOR, dumb, or
+  non-UTF-8 terminals) still renders exactly one line.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,8 +27,11 @@ Versioning before and after the first stable release.
   background, where every `tcsetattr()` raises SIGTTOU; Compose forwarded the
   signal into the container, producing tens of events per second and flooding
   Docker's event ring buffer. `djinn start` now fails with an explanation and
-  points at `--detach` or a foreground start. Non-TTY stdin, absent controlling
-  terminals, and headless `-T` runs are unaffected.
+  points at `--detach` or a foreground start. The check keys on stdout, which is
+  what Compose derives TTY allocation from, so `djinn start > log &` stays allowed
+  (no TTY is allocated, so nothing can storm) while `djinn start < /dev/null &` is
+  refused. Absent controlling terminals (`setsid`) and headless `-T` runs are
+  unaffected.
 - The entrypoint no longer exits when it has no terminal. An interactive shell
   cannot run without one — zsh reads EOF and returns immediately, which used to
   take the container down with exit code 0 and an empty log. Since

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ Versioning before and after the first stable release.
 
 ### Added
 
+- `djinn start --detach` starts the container with `docker compose up -d` and
+  returns, leaving no Compose client attached; attach afterwards with
+  `djinn enter`. The detached path keeps the `--docker` proxy running, refuses to
+  start when a Djinn container already exists, and passes the dynamic mounts to
+  Compose through a generated override file.
+- Guard against starting an interactive container from a background process
+  group. `djinn start ... &` left a TTY-attached Compose client in the
+  background, where every `tcsetattr()` raises SIGTTOU; Compose forwarded the
+  signal into the container, producing tens of events per second and flooding
+  Docker's event ring buffer. `djinn start` now fails with an explanation and
+  points at `--detach`, a foreground start, or `setsid`. Non-TTY stdin, absent
+  controlling terminals, and headless `-T` runs are unaffected.
 - Persistent `age` encryption identity store: `${DJINN_CONFIG_ROOT}/age` is
   provisioned as a credential directory and bind-mounted at `~/.config/age`, so
   `age` keys survive container restarts and are captured by `djinn backup`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,8 +19,9 @@ Versioning before and after the first stable release.
   Because `up -d` exits 0 as soon as the container is created and says nothing
   about what the entrypoint did next, the command verifies the container is
   actually running before reporting success, and points at `docker logs djinn`
-  when it is not. Captured Docker output is printed verbatim rather than through
-  Rich markup, which would silently delete the bracketed BuildKit stage tags.
+  when it is not. Captured Docker output is printed without markup interpretation
+  rather than through Rich's parser, which would silently delete the bracketed
+  BuildKit stage tags.
 - Guard against starting an interactive container from a background process
   group. `djinn start ... &` left a TTY-attached Compose client in the
   background, where every `tcsetattr()` raises SIGTTOU; Compose forwarded the
@@ -70,11 +71,16 @@ Versioning before and after the first stable release.
 ### Fixed
 
 - Captured Docker output is no longer mangled by Rich. Every command that echoes
-  a subprocess's stdout/stderr now routes through `print_captured()`, which
-  disables markup, highlighting and re-wrapping. Previously Rich consumed
-  anything shaped like a tag, so `djinn build`'s BuildKit log lost exactly the
-  `[internal]` / `[dev 3/25]` stage markers that locate a failing step, and long
-  paths were hard-wrapped mid-token.
+  a subprocess's stdout/stderr as its own output — `build`, `start`, `clean`,
+  `run`, `session`, `mcp` — now routes through `print_captured()`, which disables
+  markup, highlighting and re-wrapping. Previously Rich consumed anything shaped
+  like a tag, so `djinn build`'s BuildKit log lost exactly the `[internal]` /
+  `[dev 3/25]` stage markers that locate a failing step, and long paths were
+  hard-wrapped mid-token. Note two limits: `backup`/`restore` still embed Docker's
+  stderr inside a formatted `error(...)` line, where it stays subject to markup;
+  and `print_captured` is not byte-verbatim — Rich still strips control characters
+  (including the `\r` that redraw-in-place progress output relies on) and expands
+  tabs.
 - `djinn start --detach` no longer implies a readiness it cannot verify. `up -d`
   returns as soon as the container is created, while seeding runs for roughly
   another 30 seconds, so the check confirms only that the container did not die

--- a/Dockerfile
+++ b/Dockerfile
@@ -83,7 +83,7 @@ RUN eval "$(fnm env)" && fnm install --lts && fnm default lts-latest
 ARG CLAUDE_CODE_VERSION=2.1.226
 ARG GEMINI_CLI_VERSION=0.54.4
 ARG CODEX_VERSION=0.147.0
-ARG OPENCODE_VERSION=1.18.15
+ARG OPENCODE_VERSION=1.18.16
 
 # Claude Code via native installer (no npm/Node.js dependency)
 # Installs to ~/.local/bin/claude (already in PATH via .zshrc)

--- a/Dockerfile
+++ b/Dockerfile
@@ -80,10 +80,10 @@ ENV PATH="/home/${USERNAME}/.local/bin:/home/${USERNAME}/.local/share/fnm:$PATH"
 RUN eval "$(fnm env)" && fnm install --lts && fnm default lts-latest
 
 # CLI Agent versions - update with: ./scripts/update-agents.sh
-ARG CLAUDE_CODE_VERSION=2.1.220
-ARG GEMINI_CLI_VERSION=0.53.1
-ARG CODEX_VERSION=0.146.0
-ARG OPENCODE_VERSION=1.18.11
+ARG CLAUDE_CODE_VERSION=2.1.226
+ARG GEMINI_CLI_VERSION=0.54.4
+ARG CODEX_VERSION=0.147.0
+ARG OPENCODE_VERSION=1.18.15
 
 # Claude Code via native installer (no npm/Node.js dependency)
 # Installs to ~/.local/bin/claude (already in PATH via .zshrc)

--- a/IMPLEMENTATION.md
+++ b/IMPLEMENTATION.md
@@ -513,10 +513,21 @@ SIGTERM to PID 1 and that is its only shutdown. `entrypoint.sh` therefore:
   is nothing to flush first;
 - runs the shell as a background job and `wait`s on it. As a foreground command
   it would defer every trap until it returned, which under `docker stop` never
-  happens — the traps would be dead code. Job control is off in this
-  non-interactive script, so the shell starts inside PID 1's process group and
-  keeps the terminal's foreground group until it claims the terminal itself;
-  interactive behaviour (job control, Ctrl+C) is unchanged.
+  happens — the traps would be dead code. Backgrounding costs the shell its
+  stdin, and that is the subtle part: with job control off, a background job's
+  fd 0 is reassigned to `/dev/null` *before* any explicit redirection is applied.
+  zsh would then not be interactive at all — it reads EOF and exits within
+  milliseconds, taking the container with it. The entrypoint therefore duplicates
+  fd 0 first (`exec 3<&0`) and hands it back explicitly (`<&3`, plus `3<&-` to
+  keep the spare descriptor out of the child). `<&0` cannot do this: by the time
+  it is evaluated, fd 0 is already `/dev/null`. With stdin restored, the shell
+  claims its own process group and the terminal as usual, and interactive
+  behaviour (job control, Ctrl+C) is unchanged.
+
+  The container passes no arguments (`ENTRYPOINT` with no `CMD`, no compose
+  `command:`), so `tests/test_entrypoint_shutdown.py` covers that exact shape on
+  a real pty: a shell launched with `-c <cmd>` never needs a terminal and would
+  hide the regression entirely.
 
 Shell-side startup output is sectioned through `scripts/output-lib.sh`:
 `Seed & Config`, `MCP`, `Tools`, and `Security`. `mcp-register.sh` captures

--- a/IMPLEMENTATION.md
+++ b/IMPLEMENTATION.md
@@ -647,7 +647,22 @@ backed by named volumes.
   which use `/home/dev/mount/<basename>` with parent and numeric collision
   fallbacks. The command rejects source errors and mount collisions before
   calling `compose_run()`, then prints one source-to-target mode line per mount
-  in the `Environment`/`Container` output.
+  in the `Environment`/`Container` output. With `--detach` it calls
+  `compose_up_detached()` instead, skips `cleanup_docker_proxy()` (the container
+  outlives the process, so its proxy has to stay up), and refuses up front when a
+  Djinn container is already running, because `up` collides with the fixed
+  `container_name`.
+- Background-start guard: `compose_run()` refuses an interactive start from a
+  background process group. `docker compose run` allocates a TTY and calls
+  `tcsetattr()` on it; from the background that raises SIGTTOU unconditionally
+  (the `tostop` flag gates background *writes*, not attribute changes), Compose
+  forwards the signal into the container, and container PID 1 installs no SIGTTOU
+  handler. `djinn start ... &` is exactly that shape and produces a signal storm
+  of tens of events per second, which also floods Docker's event ring buffer.
+  `is_background_process_group()` compares `os.tcgetpgrp(stdin)` against
+  `os.getpgrp()` and returns False when stdin is not a TTY or there is no
+  controlling terminal, so `< /dev/null`, pipes, and `setsid` stay allowed.
+  Headless runs pass `-T`, allocate no TTY, and are never blocked.
 - `status()`: reports config, containers, known volumes, config-root paths,
   networks, Docker proxy, and MCP Gateway status.
 - `clean_default()`: `djinn clean` stops and removes containers with

--- a/IMPLEMENTATION.md
+++ b/IMPLEMENTATION.md
@@ -698,9 +698,12 @@ backed by named volumes.
   background process group. `docker compose run` allocates a TTY and calls
   `tcsetattr()` on it; from the background that raises SIGTTOU unconditionally
   (the `tostop` flag gates background *writes*, not attribute changes), Compose
-  forwards the signal into the container, and container PID 1 installs no SIGTTOU
-  handler. `djinn start ... &` is exactly that shape and produces a signal storm
-  of tens of events per second, which also floods Docker's event ring buffer.
+  forwards the signals into the container. `djinn start ... &` is exactly that
+  shape and produces tens of events per second. Container PID 1 is not what dies —
+  namespace init discards a signal it has no handler for, and a container was
+  observed surviving 45+ minutes under continuous SIGTTOU. What the storm does is
+  flood Docker's event ring buffer (hence the missing logs) and stop the host-side
+  compose client, after which `--rm` reaps the container.
   `is_background_process_group()` compares `os.tcgetpgrp(stdin)` against
   `os.getpgrp()` and returns False when stdin is not a TTY or there is no
   controlling terminal, so `< /dev/null`, pipes, and `setsid` are not blocked.

--- a/IMPLEMENTATION.md
+++ b/IMPLEMENTATION.md
@@ -472,7 +472,7 @@ publication.
   baseline wins for the owned `SessionStart`, `PreToolUse`, and `Stop` hook
   fragments; neighboring settings remain overlay-controlled.
 - `reverse_sync_file(volume_file, seed_file)`: best-effort copy from container
-  state back to writable seed mounts on shell exit.
+  state back to writable seed mounts at shutdown (shell exit or SIGTERM).
 - `reverse_sync_claude_settings(volume_file, seed_file)`: persists the personal
   Claude overlay after removing only those three managed hook fragments.
 
@@ -494,9 +494,29 @@ container start
   +-- source mcp-register.sh and register MCP servers
   +-- install optional cached tools
   +-- print security summary, including firewall, Docker access, and MCP state
-  +-- run interactive zsh
-  +-- reverse-sync selected settings files on exit
+  +-- run interactive zsh as a background job, waited on by PID 1
+  +-- reverse-sync selected settings files on shell exit OR on SIGTERM
 ```
+
+Both shutdown paths reach the reverse-sync, which matters because a detached
+container (`djinn start --detach`) never exits its shell — `docker stop` sends
+SIGTERM to PID 1 and that is its only shutdown. `entrypoint.sh` therefore:
+
+- collects the reverse-sync calls in `persist_session_state()`, guarded by
+  `_DJINN_STATE_PERSISTED` so the signal path and the normal path cannot both
+  run it;
+- traps TERM and INT into `_djinn_on_termination_signal`, which persists
+  immediately and exits `128 + signal`. It deliberately does not signal the
+  shell and wait for it: an interactive zsh ignores SIGTERM, so waiting would
+  burn the whole `docker stop` grace period and end in SIGKILL having persisted
+  nothing. The agent CLIs write settings as they change, not on exit, so there
+  is nothing to flush first;
+- runs the shell as a background job and `wait`s on it. As a foreground command
+  it would defer every trap until it returned, which under `docker stop` never
+  happens — the traps would be dead code. Job control is off in this
+  non-interactive script, so the shell starts inside PID 1's process group and
+  keeps the terminal's foreground group until it claims the terminal itself;
+  interactive behaviour (job control, Ctrl+C) is unchanged.
 
 Shell-side startup output is sectioned through `scripts/output-lib.sh`:
 `Seed & Config`, `MCP`, `Tools`, and `Security`. `mcp-register.sh` captures
@@ -884,8 +904,8 @@ entrypoint.sh
   +-- MCP: register MCP servers and box third-party CLI output
   +-- Tools: install optional tools
   +-- Security: summarize firewall, Docker access, and MCP gateway state
-  +-- run interactive shell
-  +-- reverse-sync selected settings on exit
+  +-- run interactive shell as a background job
+  +-- reverse-sync selected settings on shell exit or on SIGTERM
 ```
 
 Backup:

--- a/IMPLEMENTATION.md
+++ b/IMPLEMENTATION.md
@@ -529,6 +529,17 @@ SIGTERM to PID 1 and that is its only shutdown. `entrypoint.sh` therefore:
   a real pty: a shell launched with `-c <cmd>` never needs a terminal and would
   hide the regression entirely.
 
+- refuses to start an interactive shell when there is no terminal at all, and
+  keeps the container alive instead. This closes a whole class rather than one
+  instance: an interactive zsh without a TTY reads EOF and returns immediately,
+  so PID 1 exits 0 and the container disappears with an empty log — the very
+  signature this work started from. The class has several entrances, and the
+  background-start guard cannot see them all, because it keys on stdin while
+  `docker compose run` selects `-T` from the client's *stdout*. Since nobody can
+  use PID 1's shell without a terminal anyway, while `djinn enter` brings its own
+  TTY through `docker exec`, staying up is strictly better than dying silently.
+  The reverse-sync on `docker stop` works unchanged in that state.
+
 Shell-side startup output is sectioned through `scripts/output-lib.sh`:
 `Seed & Config`, `MCP`, `Tools`, and `Security`. `mcp-register.sh` captures
 third-party CLI output from MCP add/remove commands and passes non-empty output
@@ -692,8 +703,16 @@ backed by named volumes.
   of tens of events per second, which also floods Docker's event ring buffer.
   `is_background_process_group()` compares `os.tcgetpgrp(stdin)` against
   `os.getpgrp()` and returns False when stdin is not a TTY or there is no
-  controlling terminal, so `< /dev/null`, pipes, and `setsid` stay allowed.
+  controlling terminal, so `< /dev/null`, pipes, and `setsid` are not blocked.
   Headless runs pass `-T`, allocate no TTY, and are never blocked.
+
+  Not blocked is not the same as recommended, and the guard is deliberately not
+  the only defence. It keys on **stdin**, while Compose decides TTY allocation
+  from the **client's stdout** — so `setsid djinn start … > log 2>&1 &` slips
+  past it and yields a container with no TTY at all. That is why the entrypoint
+  closes the class on its own side (see *Container-Side Seed and Merge*): with no
+  terminal it keeps the container up instead of exiting. `--detach` remains the
+  supported way to background a session.
 - `status()`: reports config, containers, known volumes, config-root paths,
   networks, Docker proxy, and MCP Gateway status.
 - `clean_default()`: `djinn clean` stops and removes containers with

--- a/IMPLEMENTATION.md
+++ b/IMPLEMENTATION.md
@@ -704,17 +704,21 @@ backed by named volumes.
   observed surviving 45+ minutes under continuous SIGTTOU. What the storm does is
   flood Docker's event ring buffer (hence the missing logs) and stop the host-side
   compose client, after which `--rm` reaps the container.
-  `is_background_process_group()` compares `os.tcgetpgrp(stdin)` against
-  `os.getpgrp()` and returns False when stdin is not a TTY or there is no
-  controlling terminal, so `< /dev/null`, pipes, and `setsid` are not blocked.
-  Headless runs pass `-T`, allocate no TTY, and are never blocked.
+  `is_background_process_group()` compares `os.tcgetpgrp(fd)` against
+  `os.getpgrp()` for **each of stdin, stdout and stderr**, and returns True as
+  soon as any of them is a terminal whose foreground group is not ours. Checking
+  stdout is not optional: Compose picks TTY allocation from the *client's stdout*,
+  so `djinn start < /dev/null &` still gets a terminal and still storms, while a
+  stdin-only test would wave it through. Redirecting every stream
+  (`< /dev/null > log 2>&1`) is genuinely safe, because Compose then allocates no
+  TTY. `setsid` is likewise not blocked — with no controlling terminal the kernel
+  raises no SIGTTOU. Headless runs pass `-T`, allocate no TTY, and are never
+  blocked.
 
-  Not blocked is not the same as recommended, and the guard is deliberately not
-  the only defence. It keys on **stdin**, while Compose decides TTY allocation
-  from the **client's stdout** — so `setsid djinn start … > log 2>&1 &` slips
-  past it and yields a container with no TTY at all. That is why the entrypoint
-  closes the class on its own side (see *Container-Side Seed and Merge*): with no
-  terminal it keeps the container up instead of exiting. `--detach` remains the
+  Not blocked is not the same as supported, and the guard is deliberately not the
+  only defence: any shape that ends with no TTY inside the container is handled on
+  the container side instead (see *Container-Side Seed and Merge*), where the
+  entrypoint keeps the container up rather than exiting. `--detach` remains the
   supported way to background a session.
 - `status()`: reports config, containers, known volumes, config-root paths,
   networks, Docker proxy, and MCP Gateway status.

--- a/IMPLEMENTATION.md
+++ b/IMPLEMENTATION.md
@@ -534,8 +534,9 @@ SIGTERM to PID 1 and that is its only shutdown. `entrypoint.sh` therefore:
   instance: an interactive zsh without a TTY reads EOF and returns immediately,
   so PID 1 exits 0 and the container disappears with an empty log — the very
   signature this work started from. The class has several entrances, and the
-  background-start guard cannot see them all, because it keys on stdin while
-  `docker compose run` selects `-T` from the client's *stdout*. Since nobody can
+  background-start guard deliberately does not cover them all: it refuses only
+  the shapes that can actually storm (stdout on a background terminal), leaving
+  the genuinely TTY-less ones to be handled here. Since nobody can
   use PID 1's shell without a terminal anyway, while `djinn enter` brings its own
   TTY through `docker exec`, staying up is strictly better than dying silently.
   The reverse-sync on `docker stop` works unchanged in that state.
@@ -704,16 +705,16 @@ backed by named volumes.
   observed surviving 45+ minutes under continuous SIGTTOU. What the storm does is
   flood Docker's event ring buffer (hence the missing logs) and stop the host-side
   compose client, after which `--rm` reaps the container.
-  `is_background_process_group()` compares `os.tcgetpgrp(fd)` against
-  `os.getpgrp()` for **each of stdin, stdout and stderr**, and returns True as
-  soon as any of them is a terminal whose foreground group is not ours. Checking
-  stdout is not optional: Compose picks TTY allocation from the *client's stdout*,
-  so `djinn start < /dev/null &` still gets a terminal and still storms, while a
-  stdin-only test would wave it through. Redirecting every stream
-  (`< /dev/null > log 2>&1`) is genuinely safe, because Compose then allocates no
-  TTY. `setsid` is likewise not blocked — with no controlling terminal the kernel
-  raises no SIGTTOU. Headless runs pass `-T`, allocate no TTY, and are never
-  blocked.
+  `is_background_process_group()` compares `os.tcgetpgrp(stdout)` against
+  `os.getpgrp()` — **stdout, and only stdout**, because that is what Compose keys
+  on: it derives `noTty` from `!dockerCli.Out().IsTerminal()` and allocates a TTY
+  only when stdout is a terminal. Consequently `djinn start < /dev/null &` is
+  refused (stdout is still the terminal, so a TTY is allocated and the storm is
+  possible), while `djinn start > log &` is allowed (no TTY, nothing calls
+  `tcsetattr`, nothing to storm). Checking stdin or stderr as well would refuse
+  that second, safe shape. `setsid` is likewise not blocked — with no controlling
+  terminal the kernel raises no SIGTTOU. Headless runs pass `-T`, allocate no TTY,
+  and are never blocked.
 
   Not blocked is not the same as supported, and the guard is deliberately not the
   only defence: any shape that ends with no TTY inside the container is handled on

--- a/README.md
+++ b/README.md
@@ -27,7 +27,8 @@ Djinn gives you one repeatable container image and several ways to use it:
   the background with `djinn start --detach` and attach to it later with
   `djinn enter`. Do not background the interactive form with `&`: that leaves a
   TTY-attached Compose client in a background process group, which storms the
-  container with SIGTTOU until it dies. `djinn start` refuses that shape.
+  container with SIGTTOU until its host-side client is stopped and `--rm` reaps
+  it. `djinn start` refuses that shape.
 - Run a one-shot agent prompt with `djinn run`.
 - Attach another shell to a running container with `djinn enter`.
 - Keep reusable session workspaces under `~/.djinn/sessions/` with

--- a/README.md
+++ b/README.md
@@ -23,7 +23,11 @@ They stay local unless you choose to back them up or mirror them.
 
 Djinn gives you one repeatable container image and several ways to use it:
 
-- Open an interactive shell with `djinn start`.
+- Open an interactive shell with `djinn start`, or leave the container running in
+  the background with `djinn start --detach` and attach to it later with
+  `djinn enter`. Do not background the interactive form with `&`: that leaves a
+  TTY-attached Compose client in a background process group, which storms the
+  container with SIGTTOU until it dies. `djinn start` refuses that shape.
 - Run a one-shot agent prompt with `djinn run`.
 - Attach another shell to a running container with `djinn enter`.
 - Keep reusable session workspaces under `~/.djinn/sessions/` with
@@ -393,7 +397,7 @@ value overrides `default_model` for that invocation.
 
 | Command | Container behavior | Workspace behavior | Main use |
 | --- | --- | --- | --- |
-| `djinn start` | Runs the `dev` service interactively with `docker compose run --rm`; removed after exit | Starts in `/home/dev/projects` without an extra mount; `--here` mounts `/home/dev/workspace`; repeatable `--mount` values add directories at chosen or derived targets | Daily interactive shell |
+| `djinn start` | Runs the `dev` service interactively with `docker compose run --rm`; removed after exit. `--detach` uses `docker compose up -d` instead and leaves no client attached | Starts in `/home/dev/projects` without an extra mount; `--here` mounts `/home/dev/workspace`; repeatable `--mount` values add directories at chosen or derived targets | Daily interactive shell; `--detach` for a long-lived container |
 | `djinn enter` | Uses `docker exec -it <running-container> zsh` | Enters an already running Djinn container | Open a second shell while `djinn start` is still running |
 | `djinn run AGENT PROMPT` | Runs the `dev` service headlessly with `docker compose run --rm -T`; removed after exit | Without `--mount` and without `--here`, mounts the current directory at `/home/dev/workspace`; `--here` keeps that mount when combined with repeatable `--mount` values | One-shot agent prompts |
 | `djinn session` | Uses `docker exec` into a running `djinn` container when available; otherwise host fallback preflight checks the selected agent binary on `PATH`. Claude, Codex, and OpenCode host fallback receives that agent's canonical workflow at its native host root. Running-container OpenCode sessions refresh the live runtime through the shared publisher before invocation. | Uses `~/.djinn/sessions/<project>` on the host and `/home/dev/sessions/<project>` in the container; `--create` creates the host workspace | Reusable session workspaces |

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -266,12 +266,29 @@ trap '_djinn_on_termination_signal 2' INT
 # Fence set -e around the interactive shell: a non-zero shell exit must NOT abort
 # the script before EXIT_CODE capture + reverse-sync (else settings persistence is silently skipped).
 set +e
-exec 3<&0
-/bin/zsh "$@" <&3 3<&- &
-DJINN_SHELL_PID=$!
+if [[ $# -eq 0 && ! -t 0 ]]; then
+    # An interactive shell was requested but there is no terminal to drive it, so
+    # zsh would read EOF and exit within milliseconds — PID 1 would follow and the
+    # container would vanish with exit code 0 and nothing in its log. That is the
+    # whole failure class this guard closes, and it has more entrances than it
+    # looks: `docker compose run` picks `-T` from the *client's stdout*, so merely
+    # redirecting output is enough to land here, no matter what stdin does.
+    #
+    # Staying alive is strictly better than dying silently: nobody can use PID 1's
+    # shell without a terminal anyway, while `djinn enter` (docker exec, which
+    # brings its own TTY) works perfectly against a live container.
+    ui_warn "No TTY available — not starting an interactive shell."
+    ui_item "The container stays up; attach with: djinn enter"
+    sleep infinity &
+    DJINN_SHELL_PID=$!
+else
+    exec 3<&0
+    /bin/zsh "$@" <&3 3<&- &
+    DJINN_SHELL_PID=$!
+    exec 3<&-
+fi
 wait "$DJINN_SHELL_PID"
 EXIT_CODE=$?
-exec 3<&-
 set -e
 
 persist_session_state

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -252,18 +252,26 @@ trap '_djinn_on_termination_signal 2' INT
 
 # The shell runs as a background job so that `wait` stays interruptible. As a
 # foreground command it would defer every trap until it returned — which under
-# `docker stop` never happens, so the traps above would be dead code. Job
-# control is off in this non-interactive script, so the shell starts in PID 1's
-# process group and keeps the terminal's foreground group until it claims the
-# terminal itself.
+# `docker stop` never happens, so the traps above would be dead code.
+#
+# stdin must be handed over explicitly. With job control off (the default for a
+# non-interactive script) a background job's stdin is reassigned to /dev/null
+# BEFORE any explicit redirection is applied. zsh would then not be a terminal,
+# would not be interactive, would read EOF immediately and exit 0 — killing the
+# container milliseconds after start. `<&3` from a descriptor duplicated
+# beforehand is what restores it; `<&0` cannot, because by the time it is
+# evaluated fd 0 is already /dev/null. `3<&-` keeps the spare descriptor out of
+# the child.
 #
 # Fence set -e around the interactive shell: a non-zero shell exit must NOT abort
 # the script before EXIT_CODE capture + reverse-sync (else settings persistence is silently skipped).
 set +e
-/bin/zsh "$@" &
+exec 3<&0
+/bin/zsh "$@" <&3 3<&- &
 DJINN_SHELL_PID=$!
 wait "$DJINN_SHELL_PID"
 EXIT_CODE=$?
+exec 3<&-
 set -e
 
 persist_session_state

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -213,22 +213,58 @@ echo "" >&2
 # =============================================================================
 # Interactive Shell (reverse-sync settings on exit)
 # =============================================================================
+# Settings persistence has to survive BOTH ways this container ends: the
+# interactive shell exiting normally, and SIGTERM from `docker stop` — the only
+# way a detached container (`djinn start --detach`) is ever shut down. Without
+# the signal path, every detached session would silently lose its settings.
+
+_DJINN_STATE_PERSISTED=0
+
+persist_session_state() {
+    # Idempotent: the signal path and the normal path must never both run this.
+    [[ "$_DJINN_STATE_PERSISTED" == "1" ]] && return 0
+    _DJINN_STATE_PERSISTED=1
+
+    # Persist claude.json state into volume for next container start
+    reverse_sync_file "$HOME/.claude.json"                    "$HOME/.claude/claude.json"
+    # → settings.local.json (personal overlay, git-ignored): in-session changes persist there, NOT the tracked baseline
+    reverse_sync_claude_settings "$HOME/.claude/settings.json" "$HOME/.claude_seed/settings.local.json"
+    reverse_sync_file "$HOME/.gemini/settings.json"          "$HOME/.gemini_seed/settings.json"
+    if ! python3 "$SETTINGS_COPY_HELPER" \
+        --copy-settings "$OPENCODE_RUNTIME_SETTINGS" "$OPENCODE_PERSISTENT_SETTINGS" \
+        --missing-ok >&2; then
+        ui_warn "could not persist OpenCode personal settings"
+    fi
+}
+
+_djinn_on_termination_signal() {
+    # Persist right away rather than signalling the shell and waiting for it: an
+    # interactive zsh ignores SIGTERM, so waiting would burn the entire
+    # `docker stop` grace period and end in SIGKILL with nothing persisted. The
+    # agent CLIs write their settings as they change, not on exit, so there is
+    # nothing to flush first.
+    persist_session_state
+    exit $((128 + $1))
+}
+
+trap '_djinn_on_termination_signal 15' TERM
+trap '_djinn_on_termination_signal 2' INT
+
+# The shell runs as a background job so that `wait` stays interruptible. As a
+# foreground command it would defer every trap until it returned — which under
+# `docker stop` never happens, so the traps above would be dead code. Job
+# control is off in this non-interactive script, so the shell starts in PID 1's
+# process group and keeps the terminal's foreground group until it claims the
+# terminal itself.
+#
 # Fence set -e around the interactive shell: a non-zero shell exit must NOT abort
 # the script before EXIT_CODE capture + reverse-sync (else settings persistence is silently skipped).
 set +e
-/bin/zsh "$@"
+/bin/zsh "$@" &
+DJINN_SHELL_PID=$!
+wait "$DJINN_SHELL_PID"
 EXIT_CODE=$?
 set -e
 
-# Persist claude.json state into volume for next container start
-reverse_sync_file "$HOME/.claude.json"                    "$HOME/.claude/claude.json"
-# → settings.local.json (personal overlay, git-ignored): in-session changes persist there, NOT the tracked baseline
-reverse_sync_claude_settings "$HOME/.claude/settings.json" "$HOME/.claude_seed/settings.local.json"
-reverse_sync_file "$HOME/.gemini/settings.json"          "$HOME/.gemini_seed/settings.json"
-if ! python3 "$SETTINGS_COPY_HELPER" \
-    --copy-settings "$OPENCODE_RUNTIME_SETTINGS" "$OPENCODE_PERSISTENT_SETTINGS" \
-    --missing-ok >&2; then
-    ui_warn "could not persist OpenCode personal settings"
-fi
-
+persist_session_state
 exit $EXIT_CODE

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -278,7 +278,7 @@ if [[ $# -eq 0 && ! -t 0 ]]; then
     # shell without a terminal anyway, while `djinn enter` (docker exec, which
     # brings its own TTY) works perfectly against a live container.
     ui_warn "No TTY available — not starting an interactive shell."
-    ui_item "The container stays up; attach with: djinn enter"
+    ui_info "The container stays up; attach with: djinn enter"
     sleep infinity &
     DJINN_SHELL_PID=$!
 else

--- a/src/djinn_in_a_box/commands/agent.py
+++ b/src/djinn_in_a_box/commands/agent.py
@@ -26,6 +26,7 @@ from djinn_in_a_box.core.console import (
     err_console,
     error,
     info,
+    print_captured,
     rule,
     status_line,
     warning,
@@ -262,10 +263,10 @@ def run(
         raise typer.Exit(1) from None
 
     if result.stdout:
-        console.print(result.stdout, end="")
+        print_captured(result.stdout, err=False)
 
     if result.stderr:
-        err_console.print(result.stderr, end="")
+        print_captured(result.stderr)
 
     raise typer.Exit(result.returncode)
 

--- a/src/djinn_in_a_box/commands/container.py
+++ b/src/djinn_in_a_box/commands/container.py
@@ -25,6 +25,7 @@ from djinn_in_a_box.core.console import (
     err_console,
     error,
     info,
+    print_captured,
     rule,
     status_line,
     success,
@@ -114,7 +115,7 @@ def build(
     else:
         error(f"Build failed with exit code {result.returncode}")
         if result.stderr:
-            err_console.print(result.stderr)
+            print_captured(result.stderr)
         raise typer.Exit(result.returncode)
 
 
@@ -309,19 +310,21 @@ def start(
         # Captured Docker output is data, not markup. Rich would silently delete
         # every bracketed token — `[internal]`, `[auth]`, `[dev 3/25]` — which is
         # exactly the part that locates a failing build step.
-        err_console.print(result.stderr, end="", markup=False, highlight=False)
+        print_captured(result.stderr)
 
     if detach and result.success:
-        # `up -d` exits 0 once the container is created; it observes nothing that
-        # happens afterwards, and the dev service has no healthcheck. Without this
-        # an entrypoint abort still prints a green checkmark and the user is sent
-        # to `djinn enter`, which then reports no container and no reason.
+        # `up -d` exits 0 the moment the container is created and observes nothing
+        # afterwards; the dev service has no healthcheck. This catches a container
+        # that is already gone, and nothing more — seeding runs for ~30s after
+        # this point, so an abort in that window is invisible from here. Hence
+        # "started", never "ready", and a pointer at the log rather than a claim.
         if not is_container_running("djinn"):
-            error("Container exited immediately after starting.")
+            error("Container is not running after start.")
             err_console.print("Inspect the cause with: docker logs djinn")
             raise typer.Exit(1)
         blank()
         success("Container started in the background.")
+        info("Initialization runs for ~30s; follow it with: docker logs -f djinn")
         info("Attach with: djinn enter")
         info("Stop with:   djinn clean")
 
@@ -534,7 +537,7 @@ def clean_default(ctx: typer.Context) -> None:
         else:
             error(f"Failed to remove containers (exit code: {result.returncode})")
             if result.stderr:
-                err_console.print(result.stderr)
+                print_captured(result.stderr)
             raise typer.Exit(result.returncode)
 
 

--- a/src/djinn_in_a_box/commands/container.py
+++ b/src/djinn_in_a_box/commands/container.py
@@ -40,6 +40,7 @@ from djinn_in_a_box.core.docker import (
     compose_build,
     compose_down,
     compose_run,
+    compose_up_detached,
     delete_network,
     delete_volume,
     delete_volumes,
@@ -143,6 +144,13 @@ def start(
             help="Host directory to mount; repeatable: SRC[:DST[:ro|rw]]",
         ),
     ] = None,
+    detach: Annotated[
+        bool,
+        typer.Option(
+            "--detach",
+            help="Start in the background and return; attach later with `djinn enter`",
+        ),
+    ] = False,
 ) -> None:
     """Start interactive development shell.
 
@@ -150,11 +158,19 @@ def start(
     The container has access to the configured projects directory
     and optionally Docker socket access and firewall restrictions.
 
+    Use --detach to leave the container running in the background. Do NOT
+    background the foreground form with `&`: that keeps a TTY-attached Compose
+    client in a background process group, which storms the container with
+    SIGTTOU until it dies. `djinn start` refuses that shape rather than let it
+    happen. A detached container still persists its settings: the entrypoint
+    traps the SIGTERM from `docker stop` and reverse-syncs before exiting.
+
     Examples:
         djinn start                         # Basic interactive shell
         djinn start --docker                # With Docker access (proxy)
         djinn start --docker-direct         # With Docker access (direct)
         djinn start --here                  # Mount cwd as workspace
+        djinn start --detach --docker-direct  # Background; then `djinn enter`
         djinn start -d -f --here            # Full options
     """
     try:
@@ -162,6 +178,12 @@ def start(
     except ValueError as e:
         error(str(e))
         raise typer.Exit(1) from None
+
+    # `up -d` collides with the fixed container_name; say so before doing work.
+    if detach and is_container_running("djinn"):
+        error("A Djinn container is already running.")
+        err_console.print("Attach to it with: djinn enter")
+        raise typer.Exit(1)
 
     config = load_config()
     preflight(config, provision_host=False)
@@ -254,14 +276,23 @@ def start(
     )
 
     try:
-        result = compose_run(
-            config,
-            options,
-            interactive=True,
-            shell_mount_args=shell_args,
-            audio_mount_args=audio_args,
-            dbus_mount_args=dbus_args,
-        )
+        if detach:
+            result = compose_up_detached(
+                config,
+                options,
+                shell_mount_args=shell_args,
+                audio_mount_args=audio_args,
+                dbus_mount_args=dbus_args,
+            )
+        else:
+            result = compose_run(
+                config,
+                options,
+                interactive=True,
+                shell_mount_args=shell_args,
+                audio_mount_args=audio_args,
+                dbus_mount_args=dbus_args,
+            )
     except (MountCollisionError, MountSpecificationError) as e:
         error(str(e))
         raise typer.Exit(1) from None
@@ -269,10 +300,19 @@ def start(
         error(f"Internal runtime mount construction failed: {e}")
         raise typer.Exit(1) from None
     finally:
-        cleanup_docker_proxy(docker_mode, config)
+        # A detached container outlives this process, so the proxy it talks to has
+        # to stay up. Only the foreground path owns the proxy's lifetime.
+        if not detach:
+            cleanup_docker_proxy(docker_mode, config)
 
     if result.stderr:
         err_console.print(result.stderr, end="")
+
+    if detach and result.success:
+        blank()
+        success("Container started in the background.")
+        info("Attach with: djinn enter")
+        info("Stop with:   djinn clean")
 
     raise typer.Exit(result.returncode)
 

--- a/src/djinn_in_a_box/commands/container.py
+++ b/src/djinn_in_a_box/commands/container.py
@@ -162,7 +162,8 @@ def start(
     Use --detach to leave the container running in the background. Do NOT
     background the foreground form with `&`: that keeps a TTY-attached Compose
     client in a background process group, which storms the container with
-    SIGTTOU until it dies. `djinn start` refuses that shape rather than let it
+    SIGTTOU until its host-side client is stopped and `--rm` reaps it. `djinn start`
+    refuses that shape rather than let it
     happen. A detached container still persists its settings: the entrypoint
     traps the SIGTERM from `docker stop` and reverse-syncs before exiting.
 

--- a/src/djinn_in_a_box/commands/container.py
+++ b/src/djinn_in_a_box/commands/container.py
@@ -306,9 +306,20 @@ def start(
             cleanup_docker_proxy(docker_mode, config)
 
     if result.stderr:
-        err_console.print(result.stderr, end="")
+        # Captured Docker output is data, not markup. Rich would silently delete
+        # every bracketed token — `[internal]`, `[auth]`, `[dev 3/25]` — which is
+        # exactly the part that locates a failing build step.
+        err_console.print(result.stderr, end="", markup=False, highlight=False)
 
     if detach and result.success:
+        # `up -d` exits 0 once the container is created; it observes nothing that
+        # happens afterwards, and the dev service has no healthcheck. Without this
+        # an entrypoint abort still prints a green checkmark and the user is sent
+        # to `djinn enter`, which then reports no container and no reason.
+        if not is_container_running("djinn"):
+            error("Container exited immediately after starting.")
+            err_console.print("Inspect the cause with: docker logs djinn")
+            raise typer.Exit(1)
         blank()
         success("Container started in the background.")
         info("Attach with: djinn enter")

--- a/src/djinn_in_a_box/commands/mcp.py
+++ b/src/djinn_in_a_box/commands/mcp.py
@@ -11,10 +11,10 @@ from typing import Annotated
 import typer
 
 from djinn_in_a_box.core.console import (
-    console,
     err_console,
     error,
     info,
+    print_captured,
     rule,
     status_line,
     success,
@@ -151,7 +151,7 @@ def status() -> None:
             check=False,
         )
         if result.stdout.strip():
-            err_console.print(result.stdout.strip())
+            print_captured(result.stdout.strip(), end="\n")
 
         rule("Enabled Servers")
         result = subprocess.run(
@@ -161,7 +161,7 @@ def status() -> None:
             check=False,
         )
         if result.returncode == 0 and result.stdout.strip():
-            err_console.print(result.stdout.strip())
+            print_captured(result.stdout.strip(), end="\n")
         else:
             err_console.print("  (none)")
 
@@ -264,7 +264,7 @@ def servers() -> None:
     )
 
     if result.returncode == 0 and result.stdout.strip():
-        console.print(result.stdout.strip())
+        print_captured(result.stdout.strip(), err=False, end="\n")
     else:
         err_console.print("No servers enabled or gateway not running")
 
@@ -287,7 +287,7 @@ def catalog() -> None:
         err_console.print("Initialize catalog first: docker mcp catalog init")
         err_console.print("Or browse online: https://hub.docker.com/search?q=mcp%2F")
     else:
-        console.print(result.stdout.strip())
+        print_captured(result.stdout.strip(), err=False, end="\n")
 
 
 def test() -> None:

--- a/src/djinn_in_a_box/commands/session.py
+++ b/src/djinn_in_a_box/commands/session.py
@@ -14,7 +14,7 @@ from djinn_in_a_box.core.config_workflow import (
     WorkflowDeliveryTarget,
     prepare_config_workflow,
 )
-from djinn_in_a_box.core.console import console, err_console, error, warning
+from djinn_in_a_box.core.console import err_console, error, print_captured, warning
 from djinn_in_a_box.core.decorators import handle_config_errors
 from djinn_in_a_box.core.docker import WorkflowImageCompatibility, get_config_root
 from djinn_in_a_box.core.paths import get_project_root
@@ -178,9 +178,9 @@ def session(
                 target=target,
             )
             if result.stdout:
-                console.print(result.stdout, end="")
+                print_captured(result.stdout, err=False)
             if result.stderr:
-                err_console.print(result.stderr, end="")
+                print_captured(result.stderr)
         else:
             # Interactive mode
             if not sys.stdin.isatty():
@@ -193,7 +193,7 @@ def session(
                 target=target,
             )
             if result.stderr:
-                err_console.print(result.stderr, end="")
+                print_captured(result.stderr)
     except ValueError as e:
         error(str(e))
         raise typer.Exit(1) from None

--- a/src/djinn_in_a_box/core/banner.py
+++ b/src/djinn_in_a_box/core/banner.py
@@ -60,12 +60,19 @@ def banner() -> None:
 
 def _render_banner(console: Console) -> None:
     mode = _mode_for_console(console)
+    if mode is _BannerMode.PLAIN:
+        _render_plain(console)
+        return
+
+    # The graphical modes lead with a blank line, the same spacing convention
+    # rule() follows: flush against the shell prompt, the logo's top row reads
+    # as clipped. Plain mode stays exactly one line — it exists for NO_COLOR,
+    # dumb, and non-UTF-8 terminals, where extra whitespace is noise.
+    console.print()
     if mode is _BannerMode.FULL:
         _render_full(console)
-    elif mode is _BannerMode.WORDMARK:
-        _render_wordmark(console)
     else:
-        _render_plain(console)
+        _render_wordmark(console)
 
 
 def _mode_for_console(console: Console) -> _BannerMode:

--- a/src/djinn_in_a_box/core/console.py
+++ b/src/djinn_in_a_box/core/console.py
@@ -48,6 +48,19 @@ def warning(message: str) -> None:
     err_console.print(f"[warning]{ICONS['warning']} Warning: {message}[/warning]")
 
 
+def print_captured(text: str, *, err: bool = True, end: str = "") -> None:
+    """Print captured subprocess output as data, never as markup.
+
+    Rich consumes anything shaped like a tag, and Docker's `[internal]`, `[auth]`
+    and `[dev 3/25]` stage markers are exactly that — the part that locates a
+    failing build step, deleted without a trace. ``soft_wrap`` additionally stops
+    long paths from being hard-wrapped mid-token, so what is printed is what the
+    subprocess wrote.
+    """
+    target = err_console if err else console
+    target.print(text, end=end, markup=False, highlight=False, soft_wrap=True)
+
+
 def blank() -> None:
     err_console.print()
 

--- a/src/djinn_in_a_box/core/console.py
+++ b/src/djinn_in_a_box/core/console.py
@@ -54,8 +54,12 @@ def print_captured(text: str, *, err: bool = True, end: str = "") -> None:
     Rich consumes anything shaped like a tag, and Docker's `[internal]`, `[auth]`
     and `[dev 3/25]` stage markers are exactly that — the part that locates a
     failing build step, deleted without a trace. ``soft_wrap`` additionally stops
-    long paths from being hard-wrapped mid-token, so what is printed is what the
-    subprocess wrote.
+    long paths from being hard-wrapped mid-token.
+
+    Not byte-exact, and deliberately not claimed to be: Rich still strips control
+    characters — including the ``\\r`` that redraw-in-place progress output relies
+    on — and expands tabs. Writing to ``target.file`` would be the fix if verbatim
+    ever becomes the requirement.
     """
     target = err_console if err else console
     target.print(text, end=end, markup=False, highlight=False, soft_wrap=True)

--- a/src/djinn_in_a_box/core/docker.py
+++ b/src/djinn_in_a_box/core/docker.py
@@ -2,11 +2,13 @@
 
 from __future__ import annotations
 
+import json
 import os
 import re
 import shutil
 import subprocess
 import sys
+import tempfile
 from dataclasses import dataclass
 from enum import Enum
 from pathlib import Path
@@ -427,14 +429,27 @@ def _compose_host_env(config: AppConfig | None) -> dict[str, str]:
     return {**os.environ, **build_compose_env(config)}
 
 
-def _run_compose(args: list[str], *, config: AppConfig | None, cwd: Path) -> RunResult:
+def _run_compose(
+    args: list[str],
+    *,
+    config: AppConfig | None,
+    cwd: Path,
+    extra_env: dict[str, str] | None = None,
+) -> RunResult:
     """Single choke-point for *captured* ``docker compose`` calls.
 
     Every captured compose invocation routes through here so the host
     interpolation env is always injected. (The interactive/headless path in
     ``compose_run`` is the only other sanctioned compose site.)
+
+    ``extra_env`` carries values a subcommand cannot pass as a flag — ``up`` has
+    no per-invocation ``-e`` — and is layered on top of the host bridge, never
+    replacing it.
     """
-    return _run_captured(["docker", "compose", *args], cwd=cwd, env=_compose_host_env(config))
+    env = _compose_host_env(config)
+    if extra_env:
+        env.update(extra_env)
+    return _run_captured(["docker", "compose", *args], cwd=cwd, env=env)
 
 
 def get_shell_mount_args(config: AppConfig) -> list[str]:
@@ -670,6 +685,48 @@ def compose_build(config: AppConfig | None = None, *, no_cache: bool = False) ->
     return _run_compose(args, config=config, cwd=project_root)
 
 
+BACKGROUND_START_ERROR = (
+    "Refusing to start an interactive container from a background process group.\n"
+    "\n"
+    "`docker compose run` allocates a TTY, and every terminal-attribute call from the\n"
+    "background raises SIGTTOU. Compose forwards that signal to the container, and PID 1\n"
+    "installs no SIGTTOU handler, so its default action (stop) takes the container down —\n"
+    "no exit code, no log, while the retry loop emits tens of signals per second.\n"
+    "\n"
+    "`djinn start ... &` is exactly this shape. Use one of:\n"
+    "  djinn start --detach ...        (no TTY client at all; then `djinn enter`)\n"
+    "  djinn start ...                 (foreground, e.g. in its own tmux window)\n"
+    "  setsid djinn start ... < /dev/null > ~/djinn.log 2>&1 &\n"
+)
+
+
+def is_background_process_group() -> bool:
+    """True when this process is not in the terminal's foreground process group.
+
+    Load-bearing for interactive ``compose run``, and the reason is easy to miss:
+    Compose allocates a TTY and calls ``tcsetattr()`` on it. From a *background*
+    process group that raises SIGTTOU unconditionally — the ``tostop`` terminal
+    flag gates background *writes*, not terminal-attribute changes — and Compose
+    forwards the signal into the container. Container PID 1 installs no SIGTTOU
+    handler, so the default action (stop) applies and the container dies silently.
+
+    ``djinn start ... &`` is precisely that shape: ``&`` puts the process group in
+    the background while stdin stays attached to the terminal.
+
+    Returns False when stdin is not a TTY (``< /dev/null``, a pipe, pytest's
+    capture): with no terminal there is no foreground group to be outside of, and
+    no SIGTTOU can be raised.
+    """
+    try:
+        fd = sys.stdin.fileno()
+        if not os.isatty(fd):
+            return False
+        return os.tcgetpgrp(fd) != os.getpgrp()
+    except (AttributeError, ValueError, OSError):
+        # No usable stdin (closed, replaced, or no controlling terminal).
+        return False
+
+
 def compose_run(
     config: AppConfig,
     options: ContainerOptions,
@@ -694,6 +751,12 @@ def compose_run(
         service: Compose service name (default: dev).
         timeout: Timeout in seconds (headless only). Returns exit code 124 on timeout.
     """
+    # Fail before allocating a TTY: a background start would otherwise degenerate
+    # into a SIGTTOU storm that kills the container. Headless runs pass -T and are
+    # unaffected.
+    if interactive and is_background_process_group():
+        return RunResult(returncode=1, stderr=BACKGROUND_START_ERROR)
+
     project_root = get_project_root()
 
     # Build compose command
@@ -815,6 +878,112 @@ def compose_run(
             stdout="",
             stderr=f"Permission denied: {e}",
         )
+
+
+def _volume_specs_from_mount_args(args: list[str]) -> list[str]:
+    """Pull the ``src:dst[:mode]`` specs out of a ``["-v", spec, ...]`` list."""
+    specs: list[str] = []
+    expecting_spec = False
+    for arg in args:
+        if expecting_spec:
+            specs.append(arg)
+            expecting_spec = False
+        elif arg == "-v":
+            expecting_spec = True
+    return specs
+
+
+def compose_up_detached(
+    config: AppConfig,
+    options: ContainerOptions,
+    *,
+    env: dict[str, str] | None = None,
+    service: str = "dev",
+    shell_mount_args: list[str] | None = None,
+    audio_mount_args: list[str] | None = None,
+    dbus_mount_args: list[str] | None = None,
+) -> RunResult:
+    """Start the container in the background via ``docker compose up -d``.
+
+    This path exists because ``compose run`` keeps a host-side foreground client
+    attached to a TTY for as long as the container lives. Backgrounding that
+    client (``djinn start ... &``) turns every terminal-attribute call into a
+    SIGTTOU that Compose forwards into the container, stopping PID 1 — see
+    ``is_background_process_group``. ``up -d`` leaves no client behind at all.
+
+    ``run`` accepts per-invocation ``-v``/``--workdir``/``-e`` flags; ``up`` does
+    not, so the same dynamic mounts reach Compose as a generated override file.
+    It is written as JSON — valid YAML, so this needs no YAML dependency — and
+    carries only absolute paths, which keeps it independent of Compose's
+    project-directory resolution.
+
+    The container keeps the TTY declared by ``tty``/``stdin_open`` in the compose
+    file, so the interactive zsh ending the entrypoint stays alive with nothing
+    attached. Attach afterwards with ``djinn enter``.
+    """
+    project_root = get_project_root()
+    compose_files = get_compose_files(options.docker_mode)
+
+    mounts = tuple(
+        ContainerMount(mount.source, _normalize_mount_target(mount.target), mount.read_only)
+        for mount in options.mounts
+    )
+    shell_args = _canonicalize_runtime_mount_args(
+        get_shell_mount_args(config) if shell_mount_args is None else shell_mount_args
+    )
+    audio_args = _canonicalize_runtime_mount_args(
+        get_audio_mount_args() if audio_mount_args is None else audio_mount_args
+    )
+    dbus_args = _canonicalize_runtime_mount_args(
+        get_dbus_mount_args() if dbus_mount_args is None else dbus_mount_args
+    )
+    validate_container_mounts(
+        mounts,
+        config,
+        options.docker_mode,
+        shell_args=shell_args,
+        audio_args=audio_args,
+        dbus_args=dbus_args,
+    )
+
+    volume_specs: list[str] = []
+    for mount in mounts:
+        mount_target = _resolve_image_aliases(mount.target)
+        spec = f"{mount.source}:{mount_target}"
+        if mount.read_only:
+            spec += ":ro"
+        volume_specs.append(spec)
+    volume_specs.extend(_volume_specs_from_mount_args([*shell_args, *audio_args, *dbus_args]))
+
+    service_override: dict[str, object] = {}
+    if volume_specs:
+        service_override["volumes"] = volume_specs
+    if mounts:
+        service_override["working_dir"] = str(mounts[0].target)
+    if env:
+        service_override["environment"] = dict(env)
+
+    override_path: Path | None = None
+    try:
+        args = [*compose_files]
+        if service_override:
+            handle_fd, override_name = tempfile.mkstemp(prefix="djinn-detach-", suffix=".yml")
+            override_path = Path(override_name)
+            with os.fdopen(handle_fd, "w") as handle:
+                json.dump({"services": {service: service_override}}, handle)
+            args.extend(["-f", str(override_path)])
+        args.extend(["up", "-d", service])
+        # ENABLE_FIREWALL rides the compose file's ${ENABLE_FIREWALL:-false}
+        # interpolation, because `up` has no per-invocation `-e` flag to carry it.
+        return _run_compose(
+            args,
+            config=config,
+            cwd=project_root,
+            extra_env={"ENABLE_FIREWALL": str(options.firewall_enabled).lower()},
+        )
+    finally:
+        if override_path is not None:
+            override_path.unlink(missing_ok=True)
 
 
 def compose_down(config: AppConfig | None = None) -> RunResult:

--- a/src/djinn_in_a_box/core/docker.py
+++ b/src/djinn_in_a_box/core/docker.py
@@ -715,28 +715,26 @@ def is_background_process_group() -> bool:
     ``djinn start ... &`` is precisely that shape: ``&`` puts the process group in
     the background while a standard stream stays attached to the terminal.
 
-    All three standard streams are checked, and stdout is not optional: Compose
-    decides TTY allocation from the *client's stdout*, so
-    ``djinn start < /dev/null &`` keeps a terminal on stdout, gets a TTY, and
-    storms — while a stdin-only test would call it safe. Redirecting *every*
-    stream (``> log 2>&1 < /dev/null``) genuinely cannot storm, because Compose
-    then allocates no TTY at all.
+    Keyed on **stdout**, and neither stdin nor stderr, because that is exactly what
+    Compose keys on: it derives ``noTty`` from ``!dockerCli.Out().IsTerminal()``
+    and allocates a TTY only when stdout is a terminal. So
+    ``djinn start < /dev/null &`` still storms (stdout is the terminal), while
+    ``djinn start > log &`` cannot (no TTY is allocated, nothing calls
+    ``tcsetattr``) — and refusing the latter would block a safe shape that the
+    entrypoint's no-TTY branch handles perfectly well.
 
-    Returns False when no standard stream is a TTY (pipes, ``< /dev/null`` with
-    output redirected, pytest's capture) or when there is no controlling terminal
-    (``setsid``): with no terminal there is no foreground group to be outside of,
-    and no SIGTTOU can be raised.
+    Returns False when stdout is not a TTY (redirected, a pipe, pytest's capture)
+    or when there is no controlling terminal (``setsid``): with no allocated TTY
+    there is nothing to raise SIGTTOU.
     """
-    for stream in (sys.stdin, sys.stdout, sys.stderr):
-        try:
-            fd = stream.fileno()
-            if os.isatty(fd) and os.tcgetpgrp(fd) != os.getpgrp():
-                return True
-        except (AttributeError, ValueError, OSError):
-            # This stream is unusable (closed, replaced, or no controlling
-            # terminal). It cannot raise SIGTTOU, so it cannot decide the answer.
-            continue
-    return False
+    try:
+        fd = sys.stdout.fileno()
+        if not os.isatty(fd):
+            return False
+        return os.tcgetpgrp(fd) != os.getpgrp()
+    except (AttributeError, ValueError, OSError):
+        # No usable stdout (closed, replaced, or no controlling terminal).
+        return False
 
 
 def compose_run(

--- a/src/djinn_in_a_box/core/docker.py
+++ b/src/djinn_in_a_box/core/docker.py
@@ -707,8 +707,10 @@ def is_background_process_group() -> bool:
     Compose allocates a TTY and calls ``tcsetattr()`` on it. From a *background*
     process group that raises SIGTTOU unconditionally — the ``tostop`` terminal
     flag gates background *writes*, not terminal-attribute changes — and Compose
-    forwards the signal into the container. Container PID 1 installs no SIGTTOU
-    handler, so the default action (stop) applies and the container dies silently.
+    forwards the signals into the container by the tens per second. Container PID 1
+    survives them — namespace init discards a signal it has no handler for — but the
+    storm floods Docker's event ring buffer and stops the *host-side* compose client,
+    and once that client is gone ``--rm`` reaps the container: no exit code, no log.
 
     ``djinn start ... &`` is precisely that shape: ``&`` puts the process group in
     the background while stdin stays attached to the terminal.
@@ -929,7 +931,8 @@ def compose_up_detached(
     This path exists because ``compose run`` keeps a host-side foreground client
     attached to a TTY for as long as the container lives. Backgrounding that
     client (``djinn start ... &``) turns every terminal-attribute call into a
-    SIGTTOU that Compose forwards into the container, stopping PID 1 — see
+    SIGTTOU storm that ends with the host-side client stopped and ``--rm`` reaping
+    the container — see
     ``is_background_process_group``. ``up -d`` leaves no client behind at all.
 
     ``run`` accepts per-invocation ``-v``/``--workdir``/``-e`` flags; ``up`` does

--- a/src/djinn_in_a_box/core/docker.py
+++ b/src/djinn_in_a_box/core/docker.py
@@ -713,20 +713,30 @@ def is_background_process_group() -> bool:
     and once that client is gone ``--rm`` reaps the container: no exit code, no log.
 
     ``djinn start ... &`` is precisely that shape: ``&`` puts the process group in
-    the background while stdin stays attached to the terminal.
+    the background while a standard stream stays attached to the terminal.
 
-    Returns False when stdin is not a TTY (``< /dev/null``, a pipe, pytest's
-    capture): with no terminal there is no foreground group to be outside of, and
-    no SIGTTOU can be raised.
+    All three standard streams are checked, and stdout is not optional: Compose
+    decides TTY allocation from the *client's stdout*, so
+    ``djinn start < /dev/null &`` keeps a terminal on stdout, gets a TTY, and
+    storms — while a stdin-only test would call it safe. Redirecting *every*
+    stream (``> log 2>&1 < /dev/null``) genuinely cannot storm, because Compose
+    then allocates no TTY at all.
+
+    Returns False when no standard stream is a TTY (pipes, ``< /dev/null`` with
+    output redirected, pytest's capture) or when there is no controlling terminal
+    (``setsid``): with no terminal there is no foreground group to be outside of,
+    and no SIGTTOU can be raised.
     """
-    try:
-        fd = sys.stdin.fileno()
-        if not os.isatty(fd):
-            return False
-        return os.tcgetpgrp(fd) != os.getpgrp()
-    except (AttributeError, ValueError, OSError):
-        # No usable stdin (closed, replaced, or no controlling terminal).
-        return False
+    for stream in (sys.stdin, sys.stdout, sys.stderr):
+        try:
+            fd = stream.fileno()
+            if os.isatty(fd) and os.tcgetpgrp(fd) != os.getpgrp():
+                return True
+        except (AttributeError, ValueError, OSError):
+            # This stream is unusable (closed, replaced, or no controlling
+            # terminal). It cannot raise SIGTTOU, so it cannot decide the answer.
+            continue
+    return False
 
 
 def compose_run(

--- a/src/djinn_in_a_box/core/docker.py
+++ b/src/djinn_in_a_box/core/docker.py
@@ -689,14 +689,14 @@ BACKGROUND_START_ERROR = (
     "Refusing to start an interactive container from a background process group.\n"
     "\n"
     "`docker compose run` allocates a TTY, and every terminal-attribute call from the\n"
-    "background raises SIGTTOU. Compose forwards that signal to the container, and PID 1\n"
-    "installs no SIGTTOU handler, so its default action (stop) takes the container down —\n"
-    "no exit code, no log, while the retry loop emits tens of signals per second.\n"
+    "background raises SIGTTOU. Compose forwards those signals into the container by the\n"
+    "tens per second, which floods Docker's event ring buffer and stops the host-side\n"
+    "compose client — and once that client is gone, `--rm` reaps the container. No exit\n"
+    "code, no log.\n"
     "\n"
     "`djinn start ... &` is exactly this shape. Use one of:\n"
     "  djinn start --detach ...        (no TTY client at all; then `djinn enter`)\n"
     "  djinn start ...                 (foreground, e.g. in its own tmux window)\n"
-    "  setsid djinn start ... < /dev/null > ~/djinn.log 2>&1 &\n"
 )
 
 

--- a/src/djinn_in_a_box/core/docker.py
+++ b/src/djinn_in_a_box/core/docker.py
@@ -893,6 +893,27 @@ def _volume_specs_from_mount_args(args: list[str]) -> list[str]:
     return specs
 
 
+def _env_pairs_from_mount_args(args: list[str]) -> dict[str, str]:
+    """Pull the ``KEY=VALUE`` pairs out of a ``["-e", pair, ...]`` list.
+
+    The runtime mount builders emit a socket *and* the variable that points at
+    it — ``get_audio_mount_args`` pairs its bind with ``PULSE_SERVER``, and
+    ``get_dbus_mount_args`` with ``DBUS_SESSION_BUS_ADDRESS``. Keeping only the
+    ``-v`` half mounts the socket and leaves every client unable to find it, so
+    the detached path has to carry these across too.
+    """
+    pairs: dict[str, str] = {}
+    expecting_pair = False
+    for arg in args:
+        if expecting_pair:
+            key, _, value = arg.partition("=")
+            pairs[key] = value
+            expecting_pair = False
+        elif arg == "-e":
+            expecting_pair = True
+    return pairs
+
+
 def compose_up_detached(
     config: AppConfig,
     options: ContainerOptions,
@@ -953,15 +974,19 @@ def compose_up_detached(
         if mount.read_only:
             spec += ":ro"
         volume_specs.append(spec)
-    volume_specs.extend(_volume_specs_from_mount_args([*shell_args, *audio_args, *dbus_args]))
+    runtime_args = [*shell_args, *audio_args, *dbus_args]
+    volume_specs.extend(_volume_specs_from_mount_args(runtime_args))
+    # The `-e` half of those same pairs has to ride along, or the sockets are
+    # mounted but unreachable. Explicit `env` wins over the derived values.
+    environment = {**_env_pairs_from_mount_args(runtime_args), **(env or {})}
 
     service_override: dict[str, object] = {}
     if volume_specs:
         service_override["volumes"] = volume_specs
     if mounts:
         service_override["working_dir"] = str(mounts[0].target)
-    if env:
-        service_override["environment"] = dict(env)
+    if environment:
+        service_override["environment"] = environment
 
     override_path: Path | None = None
     try:

--- a/tests/test_commands/test_container.py
+++ b/tests/test_commands/test_container.py
@@ -313,7 +313,7 @@ class TestStartCommand:
         assert "not running after start" in start_mocks["err_output"].getvalue()
         assert "docker logs djinn" in capsys.readouterr().err
 
-    def test_start_prints_captured_docker_output_verbatim(
+    def test_start_keeps_bracketed_docker_tokens(
         self, start_mocks: dict[str, Any]
     ) -> None:
         """Rich markup would eat the bracketed BuildKit tags that locate a failure."""

--- a/tests/test_commands/test_container.py
+++ b/tests/test_commands/test_container.py
@@ -53,6 +53,32 @@ class TestBuildCommand:
 
             assert exc_info.value.exit_code == 1
 
+    def test_build_failure_keeps_the_buildkit_stage_tags(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """`djinn build` is the command that emits bracketed BuildKit tags.
+
+        Rich reads them as markup and deletes them, taking with it the one token
+        that says which stage failed.
+        """
+        with (
+            patch("djinn_in_a_box.commands.container.load_config"),
+            patch("djinn_in_a_box.commands.container.preflight"),
+            patch("djinn_in_a_box.commands.container._sync_build_files"),
+            patch("djinn_in_a_box.commands.container.compose_build") as mock_build,
+        ):
+            mock_build.return_value = RunResult(
+                returncode=1,
+                stderr="#8 [dev 3/25] RUN apt-get update\n#1 [internal] load metadata\n",
+            )
+
+            with pytest.raises(typer.Exit):
+                container.build()
+
+        captured = capsys.readouterr().err
+        assert "[dev 3/25]" in captured
+        assert "[internal]" in captured
+
     def test_sync_build_files_uses_config_root_from_config_file(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:

--- a/tests/test_commands/test_container.py
+++ b/tests/test_commands/test_container.py
@@ -124,6 +124,16 @@ class TestStartCommand:
             mock_load.return_value = mock_config
             mock_run.return_value = RunResult(returncode=0)
             mock_detached.return_value = RunResult(returncode=0)
+            # `is_container_running` is consulted twice on the detached path: the
+            # collision guard before starting (nothing there yet) and the liveness
+            # check afterwards (the container is up).
+            running_calls = {"count": 0}
+
+            def _running(_name: str) -> bool:
+                running_calls["count"] += 1
+                return running_calls["count"] > 1
+
+            mock_running.side_effect = _running
             yield {
                 "load": mock_load,
                 "run": mock_run,
@@ -207,6 +217,7 @@ class TestStartCommand:
     def test_start_detached_refuses_when_a_container_already_runs(
         self, start_mocks: dict[str, Any]
     ) -> None:
+        start_mocks["running"].side_effect = None
         start_mocks["running"].return_value = True
 
         with pytest.raises(typer.Exit) as exc_info:
@@ -215,6 +226,37 @@ class TestStartCommand:
         assert exc_info.value.exit_code == 1
         start_mocks["detached"].assert_not_called()
         start_mocks["run"].assert_not_called()
+
+    def test_start_detached_reports_a_container_that_died_on_startup(
+        self, start_mocks: dict[str, Any], capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """`up -d` exits 0 once the container is created — it observes nothing after."""
+        start_mocks["running"].side_effect = None
+        start_mocks["running"].return_value = False
+
+        with pytest.raises(typer.Exit) as exc_info:
+            container.start(detach=True)
+
+        assert exc_info.value.exit_code == 1
+        # Both reach stderr in production; the fixture patches console.err_console,
+        # so error() lands in err_output while the direct err_console.print does not.
+        assert "exited immediately" in start_mocks["err_output"].getvalue()
+        assert "docker logs djinn" in capsys.readouterr().err
+
+    def test_start_prints_captured_docker_output_verbatim(
+        self, start_mocks: dict[str, Any], capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """Rich markup would eat the bracketed BuildKit tags that locate a failure."""
+        start_mocks["detached"].return_value = RunResult(
+            returncode=1, stderr="#8 [dev 3/25] RUN apt-get update\n#1 [internal] load metadata\n"
+        )
+
+        with pytest.raises(typer.Exit):
+            container.start(detach=True)
+
+        captured = capsys.readouterr().err
+        assert "[dev 3/25]" in captured
+        assert "[internal]" in captured
 
     def test_start_detached_says_how_to_attach(self, start_mocks: dict[str, Any]) -> None:
         with pytest.raises(typer.Exit):

--- a/tests/test_commands/test_container.py
+++ b/tests/test_commands/test_container.py
@@ -98,6 +98,10 @@ class TestStartCommand:
                 "djinn_in_a_box.commands.container.ensure_network", return_value=True
             ) as mock_network,
             patch("djinn_in_a_box.commands.container.compose_run") as mock_run,
+            patch("djinn_in_a_box.commands.container.compose_up_detached") as mock_detached,
+            patch(
+                "djinn_in_a_box.commands.container.is_container_running", return_value=False
+            ) as mock_running,
             patch("djinn_in_a_box.commands.container.cleanup_docker_proxy") as mock_cleanup,
             patch("djinn_in_a_box.commands.container.get_shell_mount_args", return_value=[]),
             patch("djinn_in_a_box.commands.container.get_audio_mount_args", return_value=[]),
@@ -119,9 +123,12 @@ class TestStartCommand:
             mock_config.shell.skip_mounts = False
             mock_load.return_value = mock_config
             mock_run.return_value = RunResult(returncode=0)
+            mock_detached.return_value = RunResult(returncode=0)
             yield {
                 "load": mock_load,
                 "run": mock_run,
+                "detached": mock_detached,
+                "running": mock_running,
                 "cleanup": mock_cleanup,
                 "config": mock_config,
                 "banner": mock_banner,
@@ -176,6 +183,44 @@ class TestStartCommand:
             container.start(firewall=True)
         options = start_mocks["run"].call_args[0][1]
         assert options.firewall_enabled is True
+
+    def test_start_detached_uses_up_instead_of_a_foreground_client(
+        self, start_mocks: dict[str, Any]
+    ) -> None:
+        """The point of --detach: no compose client is left attached to a TTY."""
+        with pytest.raises(typer.Exit) as exc_info:
+            container.start(detach=True)
+
+        assert exc_info.value.exit_code == 0
+        start_mocks["detached"].assert_called_once()
+        start_mocks["run"].assert_not_called()
+
+    def test_start_detached_keeps_the_docker_proxy_alive(
+        self, start_mocks: dict[str, Any]
+    ) -> None:
+        """A detached container outlives this process, so its proxy must survive too."""
+        with pytest.raises(typer.Exit):
+            container.start(docker=True, detach=True)
+
+        start_mocks["cleanup"].assert_not_called()
+
+    def test_start_detached_refuses_when_a_container_already_runs(
+        self, start_mocks: dict[str, Any]
+    ) -> None:
+        start_mocks["running"].return_value = True
+
+        with pytest.raises(typer.Exit) as exc_info:
+            container.start(detach=True)
+
+        assert exc_info.value.exit_code == 1
+        start_mocks["detached"].assert_not_called()
+        start_mocks["run"].assert_not_called()
+
+    def test_start_detached_says_how_to_attach(self, start_mocks: dict[str, Any]) -> None:
+        with pytest.raises(typer.Exit):
+            container.start(detach=True)
+
+        assert "djinn enter" in start_mocks["err_output"].getvalue()
 
     def test_start_passes_each_precomputed_runtime_mount_list(
         self, start_mocks: dict[str, Any]

--- a/tests/test_commands/test_container.py
+++ b/tests/test_commands/test_container.py
@@ -205,6 +205,50 @@ class TestStartCommand:
         start_mocks["detached"].assert_called_once()
         start_mocks["run"].assert_not_called()
 
+    def test_start_detached_forwards_every_argument(self, start_mocks: dict[str, Any]) -> None:
+        """`assert_called_once` alone lets --here/--firewall/mounts be dropped silently.
+
+        That is how the audio regression reached production: the override handling
+        was pinned, the delivery of the arguments to it was not.
+        """
+        shell_args = ["-v", "/host/.zshrc:/home/dev/.zshrc.local:ro"]
+        audio_args = ["-v", "/host/pulse:/run/pulse", "-e", "PULSE_SERVER=unix:/run/pulse"]
+        dbus_args = ["-v", "/host/bus:/run/bus:ro"]
+        with (
+            patch(
+                "djinn_in_a_box.commands.container.get_shell_mount_args", return_value=shell_args
+            ),
+            patch(
+                "djinn_in_a_box.commands.container.get_audio_mount_args", return_value=audio_args
+            ),
+            patch("djinn_in_a_box.commands.container.get_dbus_mount_args", return_value=dbus_args),
+            patch(
+                "djinn_in_a_box.commands.container.resolve_container_mounts",
+                return_value=(ContainerMount(Path("/host/here"), Path("/home/dev/workspace")),),
+            ),
+            pytest.raises(typer.Exit),
+        ):
+            container.start(detach=True, firewall=True, here=True)
+
+        options = start_mocks["detached"].call_args[0][1]
+        kwargs = start_mocks["detached"].call_args.kwargs
+        assert options.firewall_enabled is True
+        assert options.mounts[0].target == Path("/home/dev/workspace")
+        assert kwargs["shell_mount_args"] == shell_args
+        assert kwargs["audio_mount_args"] == audio_args
+        assert kwargs["dbus_mount_args"] == dbus_args
+
+    def test_start_detached_stays_silent_when_up_failed(
+        self, start_mocks: dict[str, Any]
+    ) -> None:
+        start_mocks["detached"].return_value = RunResult(returncode=1, stderr="boom\n")
+
+        with pytest.raises(typer.Exit) as exc_info:
+            container.start(detach=True)
+
+        assert exc_info.value.exit_code == 1
+        assert "started in the background" not in start_mocks["err_output"].getvalue()
+
     def test_start_detached_keeps_the_docker_proxy_alive(
         self, start_mocks: dict[str, Any]
     ) -> None:
@@ -240,11 +284,11 @@ class TestStartCommand:
         assert exc_info.value.exit_code == 1
         # Both reach stderr in production; the fixture patches console.err_console,
         # so error() lands in err_output while the direct err_console.print does not.
-        assert "exited immediately" in start_mocks["err_output"].getvalue()
+        assert "not running after start" in start_mocks["err_output"].getvalue()
         assert "docker logs djinn" in capsys.readouterr().err
 
     def test_start_prints_captured_docker_output_verbatim(
-        self, start_mocks: dict[str, Any], capsys: pytest.CaptureFixture[str]
+        self, start_mocks: dict[str, Any]
     ) -> None:
         """Rich markup would eat the bracketed BuildKit tags that locate a failure."""
         start_mocks["detached"].return_value = RunResult(
@@ -254,7 +298,7 @@ class TestStartCommand:
         with pytest.raises(typer.Exit):
             container.start(detach=True)
 
-        captured = capsys.readouterr().err
+        captured = start_mocks["err_output"].getvalue()
         assert "[dev 3/25]" in captured
         assert "[internal]" in captured
 
@@ -407,16 +451,14 @@ class TestStartCommand:
         assert exc_info.value.exit_code == 1
         assert "Internal runtime mount construction failed" in start_mocks["err_output"].getvalue()
 
-    def test_start_prints_compose_stderr(
-        self, start_mocks: dict[str, Any], capsys: pytest.CaptureFixture[str]
-    ) -> None:
+    def test_start_prints_compose_stderr(self, start_mocks: dict[str, Any]) -> None:
         start_mocks["run"].return_value = RunResult(returncode=127, stderr="docker missing\n")
 
         with pytest.raises(typer.Exit) as exc_info:
             container.start()
 
         assert exc_info.value.exit_code == 127
-        assert "docker missing" in capsys.readouterr().err
+        assert "docker missing" in start_mocks["err_output"].getvalue()
 
     def test_start_uses_the_common_mount_path_validation(
         self, start_mocks: dict[str, Any], tmp_path: Path

--- a/tests/test_core/test_banner.py
+++ b/tests/test_core/test_banner.py
@@ -51,6 +51,22 @@ def _has_braille(value: str) -> bool:
     return any("\u2800" <= char <= "\u28ff" for char in value)
 
 
+@pytest.mark.parametrize("width", [80, 40])
+def test_graphical_banner_leads_with_a_blank_line(
+    monkeypatch: pytest.MonkeyPatch, width: int
+) -> None:
+    """Flush against the shell prompt, the logo's top row reads as a clipped turban.
+
+    Both graphical modes need it (80 renders full, 40 degrades to wordmark);
+    plain mode stays one line, which the plain-mode tests below pin down.
+    """
+    console, output = _recording_console(width=width)
+
+    rendered = _render(monkeypatch, console, output)
+
+    assert rendered.startswith("\n")
+
+
 def test_full_banner_contains_braille_and_wordmark(monkeypatch: pytest.MonkeyPatch) -> None:
     console, output = _recording_console(width=80)
 

--- a/tests/test_core/test_console.py
+++ b/tests/test_core/test_console.py
@@ -26,3 +26,44 @@ def test_rule_renders_title_to_err_console(monkeypatch) -> None:
     assert lines[0] == ""
     assert lines[1].startswith("─ Environment ─")
     assert len(lines[1]) == 40
+
+
+def _recording(width: int = 40) -> tuple[Console, StringIO]:
+    output = StringIO()
+    return (
+        Console(file=output, force_terminal=True, no_color=True, theme=DJINN_THEME, width=width),
+        output,
+    )
+
+
+def test_print_captured_does_not_rewrap_long_lines(monkeypatch) -> None:
+    """soft_wrap is what keeps a long path from being broken mid-token."""
+    test_console, output = _recording(width=40)
+    monkeypatch.setattr(console_mod, "err_console", test_console)
+
+    long_path = "/home/dev/" + "a" * 80 + "/file.txt"
+    console_mod.print_captured(long_path + "\n")
+
+    assert long_path in output.getvalue()
+
+
+def test_print_captured_keeps_bracketed_tokens(monkeypatch) -> None:
+    test_console, output = _recording()
+    monkeypatch.setattr(console_mod, "err_console", test_console)
+
+    console_mod.print_captured("#8 [dev 3/25] RUN apt-get update\n")
+
+    assert "[dev 3/25]" in output.getvalue()
+
+
+def test_print_captured_routes_to_stdout_when_asked(monkeypatch) -> None:
+    """`err=False` must reach stdout — otherwise `djinn mcp servers | grep` breaks."""
+    out_console, out_buf = _recording()
+    err_console_, err_buf = _recording()
+    monkeypatch.setattr(console_mod, "console", out_console)
+    monkeypatch.setattr(console_mod, "err_console", err_console_)
+
+    console_mod.print_captured("payload\n", err=False)
+
+    assert "payload" in out_buf.getvalue()
+    assert "payload" not in err_buf.getvalue()

--- a/tests/test_docker.py
+++ b/tests/test_docker.py
@@ -1909,6 +1909,14 @@ class TestVolumeSpecsFromMountArgs:
     def test_ignores_volume_flag_without_specification(self) -> None:
         assert docker_mod._volume_specs_from_mount_args(["-v"]) == []
 
+    def test_extracts_env_pairs(self) -> None:
+        assert docker_mod._env_pairs_from_mount_args(
+            ["-v", "/a:/b", "-e", "PULSE_SERVER=unix:/run/pulse", "-e", "EMPTY="]
+        ) == {"PULSE_SERVER": "unix:/run/pulse", "EMPTY": ""}
+
+    def test_env_pairs_ignore_unrelated_arguments(self) -> None:
+        assert docker_mod._env_pairs_from_mount_args(["-v", "/a:/b", "--rm"]) == {}
+
 
 class TestComposeUpDetached:
     """Detached start uses ``up -d``, leaving no TTY client to be backgrounded."""
@@ -1989,6 +1997,82 @@ class TestComposeUpDetached:
 
         cmd = mock_run.call_args.args[0]
         assert not any("djinn-detach-" in arg for arg in cmd)
+
+    @patch("djinn_in_a_box.core.docker.get_project_root")
+    @patch("djinn_in_a_box.core.docker.subprocess.run")
+    def test_carries_the_env_half_of_the_runtime_mount_pairs(
+        self,
+        mock_run: MagicMock,
+        mock_root: MagicMock,
+        mock_app_config: AppConfig,
+    ) -> None:
+        """A mounted socket is useless without the variable that points at it.
+
+        Deliberately does not stub the runtime mount builders: passing real
+        `-v`/`-e` pairs is the input class that exposes a dropped `-e` half.
+        """
+        mock_root.return_value = Path("/project")
+        payload: dict[str, object] = {}
+
+        def _read_override(cmd: list[str], **_kwargs: object) -> MagicMock:
+            override = Path(next(arg for arg in cmd if "djinn-detach-" in arg))
+            payload.update(json.loads(override.read_text()))
+            return MagicMock(returncode=0, stdout="", stderr="")
+
+        mock_run.side_effect = _read_override
+
+        compose_up_detached(
+            mock_app_config,
+            ContainerOptions(),
+            shell_mount_args=[],
+            audio_mount_args=[
+                "-v", "/run/user/1000/pulse/native:/run/user/1000/pulse/native",
+                "-e", "PULSE_SERVER=unix:/run/user/1000/pulse/native",
+            ],
+            dbus_mount_args=[
+                "-v", "/run/user/1000/bus:/run/user/1000/bus:ro",
+                "-e", "DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/1000/bus",
+            ],
+        )
+
+        service = payload["services"]["dev"]  # type: ignore[index]
+        assert service["environment"] == {
+            "PULSE_SERVER": "unix:/run/user/1000/pulse/native",
+            "DBUS_SESSION_BUS_ADDRESS": "unix:path=/run/user/1000/bus",
+        }
+        assert "/run/user/1000/pulse/native:/run/user/1000/pulse/native" in service["volumes"]
+
+    @patch("djinn_in_a_box.core.docker.get_project_root")
+    @patch("djinn_in_a_box.core.docker.subprocess.run")
+    def test_explicit_env_overrides_the_derived_pairs(
+        self,
+        mock_run: MagicMock,
+        mock_root: MagicMock,
+        mock_app_config: AppConfig,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        self._without_runtime_mounts(monkeypatch)
+        mock_root.return_value = Path("/project")
+        payload: dict[str, object] = {}
+
+        def _read_override(cmd: list[str], **_kwargs: object) -> MagicMock:
+            override = Path(next(arg for arg in cmd if "djinn-detach-" in arg))
+            payload.update(json.loads(override.read_text()))
+            return MagicMock(returncode=0, stdout="", stderr="")
+
+        mock_run.side_effect = _read_override
+
+        compose_up_detached(
+            mock_app_config,
+            ContainerOptions(),
+            env={"PULSE_SERVER": "explicit"},
+            audio_mount_args=["-v", "/host:/sock", "-e", "PULSE_SERVER=derived"],
+            shell_mount_args=[],
+            dbus_mount_args=[],
+        )
+
+        service = payload["services"]["dev"]  # type: ignore[index]
+        assert service["environment"]["PULSE_SERVER"] == "explicit"
 
     @patch("djinn_in_a_box.core.docker.get_project_root")
     @patch("djinn_in_a_box.core.docker.subprocess.run")

--- a/tests/test_docker.py
+++ b/tests/test_docker.py
@@ -1878,6 +1878,19 @@ class TestBackgroundProcessGroupGuard:
         self._stdin_state(monkeypatch, isatty=True, foreground=False, tty_fds=frozenset({1, 2}))
         assert is_background_process_group()
 
+    def test_allows_a_background_start_with_stdout_redirected(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """`djinn start > log &` is safe and must not be refused.
+
+        Compose derives `noTty` from stdout alone, so a redirected stdout means no
+        TTY is allocated and nothing calls tcsetattr — whatever stdin and stderr
+        are attached to. Refusing this would block a working shape, and the
+        entrypoint's no-TTY branch already covers the container side of it.
+        """
+        self._stdin_state(monkeypatch, isatty=True, foreground=False, tty_fds=frozenset({0, 2}))
+        assert not is_background_process_group()
+
     def test_ignores_non_tty_streams(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """`< /dev/null > log 2>&1` leaves no terminal at all, so nothing can storm."""
         self._stdin_state(monkeypatch, isatty=False, foreground=False)

--- a/tests/test_docker.py
+++ b/tests/test_docker.py
@@ -1802,7 +1802,8 @@ class TestBackgroundProcessGroupGuard:
 
     A backgrounded TTY-attached compose client turns every terminal-attribute
     call into SIGTTOU, which Compose forwards into the container until PID 1 —
-    which installs no handler for it — stops. The guard refuses that shape.
+    which floods Docker's event ring buffer and stops the host-side compose client,
+    after which `--rm` reaps the container. The guard refuses that shape.
     """
 
     @staticmethod

--- a/tests/test_docker.py
+++ b/tests/test_docker.py
@@ -2001,6 +2001,31 @@ class TestComposeUpDetached:
 
     @patch("djinn_in_a_box.core.docker.get_project_root")
     @patch("djinn_in_a_box.core.docker.subprocess.run")
+    def test_rejects_a_colliding_mount_like_the_foreground_path(
+        self,
+        mock_run: MagicMock,
+        mock_root: MagicMock,
+        mock_app_config: AppConfig,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Both paths must refuse the same mounts — a divergence is silent damage.
+
+        Without this the detached path would happily bind over `/home/dev/.claude`
+        (or `/proc`) while the identical foreground invocation refuses.
+        """
+        self._without_runtime_mounts(monkeypatch)
+        mock_root.return_value = Path("/project")
+        options = ContainerOptions(
+            mounts=(ContainerMount(Path("/host/data"), Path("/home/dev/.claude")),)
+        )
+
+        with pytest.raises(MountCollisionError):
+            compose_up_detached(mock_app_config, options)
+
+        mock_run.assert_not_called()
+
+    @patch("djinn_in_a_box.core.docker.get_project_root")
+    @patch("djinn_in_a_box.core.docker.subprocess.run")
     def test_carries_the_env_half_of_the_runtime_mount_pairs(
         self,
         mock_run: MagicMock,

--- a/tests/test_docker.py
+++ b/tests/test_docker.py
@@ -1,5 +1,6 @@
 """Tests for djinn_in_a_box.core.docker module."""
 
+import json
 import os
 import re
 import socket
@@ -28,6 +29,7 @@ from djinn_in_a_box.core.docker import (
     clear_sync_path,
     compose_build,
     compose_run,
+    compose_up_detached,
     delete_volumes,
     ensure_network,
     extract_sync_path_name,
@@ -39,6 +41,7 @@ from djinn_in_a_box.core.docker import (
     get_existing_volumes_by_category,
     get_running_containers,
     get_shell_mount_args,
+    is_background_process_group,
     is_container_running,
     is_sync_archive,
     parse_mount_spec,
@@ -1792,3 +1795,215 @@ class TestRestoreVolume:
         result = restore_volume("nonexistent", tmp_path)
         assert not result.success
         assert "Archive not found" in result.stderr
+
+
+class TestBackgroundProcessGroupGuard:
+    """``djinn start ... &`` must fail fast instead of storming the container.
+
+    A backgrounded TTY-attached compose client turns every terminal-attribute
+    call into SIGTTOU, which Compose forwards into the container until PID 1 —
+    which installs no handler for it — stops. The guard refuses that shape.
+    """
+
+    @staticmethod
+    def _without_runtime_mounts(monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(docker_mod, "get_shell_mount_args", _empty_mount_args)
+        monkeypatch.setattr(docker_mod, "get_audio_mount_args", _empty_mount_args)
+        monkeypatch.setattr(docker_mod, "get_dbus_mount_args", _empty_mount_args)
+
+    @staticmethod
+    def _stdin_state(
+        monkeypatch: pytest.MonkeyPatch,
+        *,
+        isatty: bool,
+        foreground: bool = True,
+        no_controlling_terminal: bool = False,
+    ) -> None:
+        class _Stdin:
+            def fileno(self) -> int:
+                return 0
+
+        def _tcgetpgrp(_fd: int) -> int:
+            if no_controlling_terminal:
+                raise OSError("no controlling terminal")
+            return 4242 if foreground else 9999
+
+        def _isatty(_fd: int) -> bool:
+            return isatty
+
+        def _getpgrp() -> int:
+            return 4242
+
+        monkeypatch.setattr(docker_mod.sys, "stdin", _Stdin())
+        monkeypatch.setattr(docker_mod.os, "isatty", _isatty)
+        monkeypatch.setattr(docker_mod.os, "getpgrp", _getpgrp)
+        monkeypatch.setattr(docker_mod.os, "tcgetpgrp", _tcgetpgrp)
+
+    def test_detects_background_process_group(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        self._stdin_state(monkeypatch, isatty=True, foreground=False)
+        assert is_background_process_group()
+
+    def test_accepts_foreground_process_group(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        self._stdin_state(monkeypatch, isatty=True, foreground=True)
+        assert not is_background_process_group()
+
+    def test_ignores_non_tty_stdin(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """`< /dev/null` detaches stdin from the terminal, so no SIGTTOU is possible."""
+        self._stdin_state(monkeypatch, isatty=False, foreground=False)
+        assert not is_background_process_group()
+
+    def test_ignores_missing_controlling_terminal(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """`setsid` leaves no controlling terminal, so the kernel raises no SIGTTOU."""
+        self._stdin_state(monkeypatch, isatty=True, no_controlling_terminal=True)
+        assert not is_background_process_group()
+
+    @patch("djinn_in_a_box.core.docker.subprocess.run")
+    def test_interactive_run_refuses_from_background(
+        self,
+        mock_run: MagicMock,
+        mock_app_config: AppConfig,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        self._stdin_state(monkeypatch, isatty=True, foreground=False)
+
+        result = compose_run(mock_app_config, ContainerOptions(), interactive=True)
+
+        assert result.returncode == 1
+        assert "SIGTTOU" in result.stderr
+        assert "--detach" in result.stderr
+        mock_run.assert_not_called()
+
+    @patch("djinn_in_a_box.core.docker.get_project_root")
+    @patch("djinn_in_a_box.core.docker.subprocess.run")
+    def test_headless_run_is_unaffected(
+        self,
+        mock_run: MagicMock,
+        mock_root: MagicMock,
+        mock_app_config: AppConfig,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Headless runs pass ``-T``, allocate no TTY, and need no guard."""
+        self._without_runtime_mounts(monkeypatch)
+        self._stdin_state(monkeypatch, isatty=True, foreground=False)
+        mock_root.return_value = Path("/project")
+        mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+
+        compose_run(mock_app_config, ContainerOptions(), command="echo", interactive=False)
+
+        mock_run.assert_called_once()
+
+
+class TestVolumeSpecsFromMountArgs:
+    """``up`` takes no ``-v`` flags, so specs are lifted out of the run-style args."""
+
+    def test_extracts_specs_after_volume_flags(self) -> None:
+        assert docker_mod._volume_specs_from_mount_args(
+            ["-v", "/a:/b", "-v", "/c:/d:ro"]
+        ) == ["/a:/b", "/c:/d:ro"]
+
+    def test_ignores_unrelated_arguments(self) -> None:
+        assert docker_mod._volume_specs_from_mount_args(["--rm", "-e", "X=1"]) == []
+
+    def test_ignores_volume_flag_without_specification(self) -> None:
+        assert docker_mod._volume_specs_from_mount_args(["-v"]) == []
+
+
+class TestComposeUpDetached:
+    """Detached start uses ``up -d``, leaving no TTY client to be backgrounded."""
+
+    @staticmethod
+    def _without_runtime_mounts(monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(docker_mod, "get_shell_mount_args", _empty_mount_args)
+        monkeypatch.setattr(docker_mod, "get_audio_mount_args", _empty_mount_args)
+        monkeypatch.setattr(docker_mod, "get_dbus_mount_args", _empty_mount_args)
+
+    @patch("djinn_in_a_box.core.docker.get_project_root")
+    @patch("djinn_in_a_box.core.docker.subprocess.run")
+    def test_issues_up_detached_for_the_service(
+        self,
+        mock_run: MagicMock,
+        mock_root: MagicMock,
+        mock_app_config: AppConfig,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        self._without_runtime_mounts(monkeypatch)
+        mock_root.return_value = Path("/project")
+        mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+
+        compose_up_detached(mock_app_config, ContainerOptions())
+
+        cmd = mock_run.call_args.args[0]
+        assert cmd[:2] == ["docker", "compose"]
+        assert cmd[-3:] == ["up", "-d", "dev"]
+
+    @patch("djinn_in_a_box.core.docker.get_project_root")
+    @patch("djinn_in_a_box.core.docker.subprocess.run")
+    def test_hands_dynamic_mounts_over_as_an_override_file(
+        self,
+        mock_run: MagicMock,
+        mock_root: MagicMock,
+        mock_app_config: AppConfig,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+    ) -> None:
+        self._without_runtime_mounts(monkeypatch)
+        mock_root.return_value = Path("/project")
+        payload: dict[str, object] = {}
+        seen_paths: list[Path] = []
+
+        def _read_override(cmd: list[str], **_kwargs: object) -> MagicMock:
+            override = Path(next(arg for arg in cmd if "djinn-detach-" in arg))
+            seen_paths.append(override)
+            payload.update(json.loads(override.read_text()))
+            return MagicMock(returncode=0, stdout="", stderr="")
+
+        mock_run.side_effect = _read_override
+        options = ContainerOptions(
+            mounts=(ContainerMount(tmp_path, Path("/work"), read_only=True),)
+        )
+
+        compose_up_detached(mock_app_config, options)
+
+        service = payload["services"]["dev"]  # type: ignore[index]
+        assert service["volumes"] == [f"{tmp_path}:/work:ro"]
+        assert service["working_dir"] == "/work"
+        # The override is Compose's only view of these mounts; it must not outlive the call.
+        assert not seen_paths[0].exists()
+
+    @patch("djinn_in_a_box.core.docker.get_project_root")
+    @patch("djinn_in_a_box.core.docker.subprocess.run")
+    def test_omits_the_override_when_nothing_is_dynamic(
+        self,
+        mock_run: MagicMock,
+        mock_root: MagicMock,
+        mock_app_config: AppConfig,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        self._without_runtime_mounts(monkeypatch)
+        mock_root.return_value = Path("/project")
+        mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+
+        compose_up_detached(mock_app_config, ContainerOptions())
+
+        cmd = mock_run.call_args.args[0]
+        assert not any("djinn-detach-" in arg for arg in cmd)
+
+    @patch("djinn_in_a_box.core.docker.get_project_root")
+    @patch("djinn_in_a_box.core.docker.subprocess.run")
+    def test_carries_the_firewall_flag_through_compose_interpolation(
+        self,
+        mock_run: MagicMock,
+        mock_root: MagicMock,
+        mock_app_config: AppConfig,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """``up`` has no ``-e``, so ENABLE_FIREWALL must ride the host environment."""
+        self._without_runtime_mounts(monkeypatch)
+        mock_root.return_value = Path("/project")
+        mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+
+        compose_up_detached(mock_app_config, ContainerOptions(firewall_enabled=True))
+
+        assert mock_run.call_args.kwargs["env"]["ENABLE_FIREWALL"] == "true"

--- a/tests/test_docker.py
+++ b/tests/test_docker.py
@@ -1801,9 +1801,10 @@ class TestBackgroundProcessGroupGuard:
     """``djinn start ... &`` must fail fast instead of storming the container.
 
     A backgrounded TTY-attached compose client turns every terminal-attribute
-    call into SIGTTOU, which Compose forwards into the container until PID 1 —
-    which floods Docker's event ring buffer and stops the host-side compose client,
-    after which `--rm` reaps the container. The guard refuses that shape.
+    call into SIGTTOU. Container PID 1 survives those — namespace init discards a
+    signal it has no handler for — but the storm floods Docker's event ring buffer
+    and stops the host-side compose client, after which `--rm` reaps the
+    container. The guard refuses that shape.
     """
 
     @staticmethod
@@ -1819,23 +1820,40 @@ class TestBackgroundProcessGroupGuard:
         isatty: bool,
         foreground: bool = True,
         no_controlling_terminal: bool = False,
+        tty_fds: frozenset[int] | None = None,
     ) -> None:
-        class _Stdin:
+        """Drive all three standard streams.
+
+        ``tty_fds`` overrides ``isatty`` per descriptor (0=stdin, 1=stdout,
+        2=stderr) so the streams can disagree — which is the whole point, because
+        Compose picks its TTY from stdout while the storm needs any terminal.
+        """
+
+        class _Stream:
+            def __init__(self, fd: int) -> None:
+                self._fd = fd
+
             def fileno(self) -> int:
-                return 0
+                return self._fd
+
+            def isatty(self) -> bool:
+                # `_host_terminal_width()` asks the stream directly, not os.isatty.
+                return _isatty(self._fd)
 
         def _tcgetpgrp(_fd: int) -> int:
             if no_controlling_terminal:
                 raise OSError("no controlling terminal")
             return 4242 if foreground else 9999
 
-        def _isatty(_fd: int) -> bool:
-            return isatty
+        def _isatty(fd: int) -> bool:
+            return isatty if tty_fds is None else fd in tty_fds
 
         def _getpgrp() -> int:
             return 4242
 
-        monkeypatch.setattr(docker_mod.sys, "stdin", _Stdin())
+        monkeypatch.setattr(docker_mod.sys, "stdin", _Stream(0))
+        monkeypatch.setattr(docker_mod.sys, "stdout", _Stream(1))
+        monkeypatch.setattr(docker_mod.sys, "stderr", _Stream(2))
         monkeypatch.setattr(docker_mod.os, "isatty", _isatty)
         monkeypatch.setattr(docker_mod.os, "getpgrp", _getpgrp)
         monkeypatch.setattr(docker_mod.os, "tcgetpgrp", _tcgetpgrp)
@@ -1848,8 +1866,20 @@ class TestBackgroundProcessGroupGuard:
         self._stdin_state(monkeypatch, isatty=True, foreground=True)
         assert not is_background_process_group()
 
-    def test_ignores_non_tty_stdin(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """`< /dev/null` detaches stdin from the terminal, so no SIGTTOU is possible."""
+    def test_detects_background_when_only_stdout_is_a_terminal(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """`djinn start < /dev/null &` — the shape a stdin-only guard waves through.
+
+        Compose selects TTY allocation from the *client's stdout*, so redirecting
+        only stdin still yields a terminal, a background process group, and the
+        storm. The entrypoint's no-TTY fallback does not help here: a TTY exists.
+        """
+        self._stdin_state(monkeypatch, isatty=True, foreground=False, tty_fds=frozenset({1, 2}))
+        assert is_background_process_group()
+
+    def test_ignores_non_tty_streams(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """`< /dev/null > log 2>&1` leaves no terminal at all, so nothing can storm."""
         self._stdin_state(monkeypatch, isatty=False, foreground=False)
         assert not is_background_process_group()
 

--- a/tests/test_entrypoint_shutdown.py
+++ b/tests/test_entrypoint_shutdown.py
@@ -73,6 +73,16 @@ def _sync_lines(tmp_path: Path) -> list[str]:
     return [line for line in log.read_text(encoding="utf-8").splitlines() if line]
 
 
+def _probe_until_answered(fd: int, deadline: float) -> bool:
+    """Write a probe until the shell answers it, or the deadline passes."""
+    end = time.monotonic() + deadline
+    while time.monotonic() < end:
+        os.write(fd, b"echo PROBE_$((6*7))\n")
+        if _read_until(fd, b"PROBE_42", timeout=1.0):
+            return True
+    return False
+
+
 def _read_until(fd: int, needle: bytes, timeout: float) -> bool:
     deadline = time.monotonic() + timeout
     buffer = b""
@@ -115,8 +125,11 @@ def test_interactive_shell_survives_with_no_arguments(tmp_path: Path) -> None:
         assert os.waitpid(pid, os.WNOHANG) == (0, 0), (
             "the shell exited instead of staying up — stdin was not handed over"
         )
-        os.write(fd, b"echo PROBE_$((6*7))\n")
-        assert _read_until(fd, b"PROBE_42", timeout=5.0), (
+        # Retry the probe rather than writing once: on a loaded or low-core runner
+        # zsh's line editor may not have finished initialising after the warm-up,
+        # and its startup tcsetattr flushes anything already typed. Retrying keeps
+        # the assertion identical while removing a load-dependent false red.
+        assert _probe_until_answered(fd, deadline=15.0), (
             "the shell did not evaluate input — it is alive but not interactive"
         )
     finally:
@@ -147,14 +160,21 @@ def test_without_a_tty_the_container_stays_up_instead_of_exiting(tmp_path: Path)
             stderr=sink,
             start_new_session=True,
         )
+        group = os.getpgid(process.pid)
         try:
             time.sleep(1.0)
             assert process.poll() is None, "entrypoint exited instead of staying up"
-            os.killpg(os.getpgid(process.pid), signal.SIGTERM)
+            # PID 1 only — `docker stop` does not signal the process group. Sending
+            # to the group would also hit the keeper directly, so a foreground
+            # keeper (the regression `& `+`wait` exists to prevent) would still
+            # look fine.
+            os.kill(process.pid, signal.SIGTERM)
             assert process.wait(timeout=15) == 128 + signal.SIGTERM
         finally:
+            # The keeper is orphaned once PID 1 exits; reap the whole group.
+            with suppress(ProcessLookupError, PermissionError):
+                os.killpg(group, signal.SIGKILL)
             if process.poll() is None:  # pragma: no cover - only on regression
-                os.killpg(os.getpgid(process.pid), signal.SIGKILL)
                 process.wait(timeout=5)
         sink.seek(0)
         assert "No TTY available" in sink.read()
@@ -247,7 +267,15 @@ def test_sigterm_persists_state_before_exiting(tmp_path: Path) -> None:
 
 @requires_zsh
 def test_sigterm_persists_state_only_once(tmp_path: Path) -> None:
-    """Repeated signals must not re-run the sync — the guard flag is load-bearing."""
+    """Repeated SIGTERMs must not double-write the sync.
+
+    What this does NOT pin, deliberately: zsh blocks a signal while its own
+    handler runs, so same-signal re-entry cannot happen whether or not
+    `_DJINN_STATE_PERSISTED` exists — deleting the flag leaves this green. The
+    flag actually guards the *cross-signal* case (TERM then INT), a known
+    accepted residual of this change, and asserting today's behaviour there
+    would freeze a defect rather than prevent one.
+    """
     process = subprocess.Popen(
         [str(_harness(tmp_path)), "-c", "sleep 60"],
         stdout=subprocess.PIPE,

--- a/tests/test_entrypoint_shutdown.py
+++ b/tests/test_entrypoint_shutdown.py
@@ -54,7 +54,10 @@ def _harness(tmp_path: Path) -> Path:
         'OPENCODE_PERSISTENT_SETTINGS="/dev/null"\n'
         'reverse_sync_file() { echo "file:$1" >> "$SYNC_LOG"; }\n'
         'reverse_sync_claude_settings() { echo "claude:$1" >> "$SYNC_LOG"; }\n'
-        "ui_warn() { :; }\n"
+        # Echoed rather than silenced: the no-TTY path reports through these, and
+        # a stub that swallows them would hide whether it reported at all.
+        'ui_warn() { echo "[warn] $*" >&2; }\n'
+        'ui_item() { echo "[item] $*" >&2; }\n'
         "\n" + _shutdown_section(),
         encoding="utf-8",
     )
@@ -121,6 +124,41 @@ def test_interactive_shell_survives_with_no_arguments(tmp_path: Path) -> None:
         with suppress(ChildProcessError):
             os.waitpid(pid, 0)
         os.close(fd)
+
+
+@requires_zsh
+def test_without_a_tty_the_container_stays_up_instead_of_exiting(tmp_path: Path) -> None:
+    """No terminal must not mean instant death — that is the whole failure class.
+
+    `docker compose run` selects `-T` from the *client's* stdout, so merely
+    redirecting output produces a container without a TTY, whatever stdin does.
+    An interactive shell cannot run there, but `djinn enter` (docker exec, which
+    brings its own TTY) can — so PID 1 stays up and says why, and a later
+    `docker stop` still reaches the reverse-sync.
+    """
+    harness = _harness(tmp_path)
+    sink_path = tmp_path / "output.log"
+    with sink_path.open("w+") as sink:
+        process = subprocess.Popen(
+            [str(harness)],
+            stdin=subprocess.DEVNULL,
+            stdout=sink,
+            stderr=sink,
+            start_new_session=True,
+        )
+        try:
+            time.sleep(1.0)
+            assert process.poll() is None, "entrypoint exited instead of staying up"
+            os.killpg(os.getpgid(process.pid), signal.SIGTERM)
+            assert process.wait(timeout=15) == 128 + signal.SIGTERM
+        finally:
+            if process.poll() is None:  # pragma: no cover - only on regression
+                os.killpg(os.getpgid(process.pid), signal.SIGKILL)
+                process.wait(timeout=5)
+        sink.seek(0)
+        assert "No TTY available" in sink.read()
+
+    assert len(_sync_lines(tmp_path)) == 3
 
 
 @requires_zsh

--- a/tests/test_entrypoint_shutdown.py
+++ b/tests/test_entrypoint_shutdown.py
@@ -162,6 +162,51 @@ def test_without_a_tty_the_container_stays_up_instead_of_exiting(tmp_path: Path)
 
 
 @requires_zsh
+def test_sigterm_persists_with_an_interactive_shell_running(tmp_path: Path) -> None:
+    """The shape `docker stop` actually meets: PID 1 with a live interactive zsh.
+
+    The SIGTERM tests below drive `-c sleep 60`, whose shell is non-interactive and
+    therefore *does* die on SIGTERM — exactly the property the entrypoint's comment
+    says an interactive shell lacks. A trap rewritten to signal the shell and wait
+    for it would pass those tests and hang here until the grace period expired,
+    losing every setting.
+    """
+    harness = _harness(tmp_path)
+    pid, fd = pty.fork()
+    if pid == 0:  # pragma: no cover - the child never returns
+        try:
+            os.execv("/bin/zsh", ["/bin/zsh", str(harness)])
+        finally:
+            os._exit(127)
+
+    try:
+        time.sleep(1.0)
+        assert os.waitpid(pid, os.WNOHANG) == (0, 0), "the interactive shell never came up"
+
+        os.kill(pid, signal.SIGTERM)  # docker stop signals PID 1 only
+        status: int | None = None
+        deadline = time.monotonic() + 15
+        while time.monotonic() < deadline:
+            reaped, raw_status = os.waitpid(pid, os.WNOHANG)
+            if reaped:
+                status = raw_status
+                break
+            time.sleep(0.1)
+
+        assert status is not None, "PID 1 did not exit within the grace period"
+        assert os.WIFEXITED(status), "PID 1 was killed rather than exiting through the trap"
+        assert os.WEXITSTATUS(status) == 128 + signal.SIGTERM
+    finally:
+        with suppress(ProcessLookupError):
+            os.kill(pid, signal.SIGKILL)
+        with suppress(ChildProcessError):
+            os.waitpid(pid, 0)
+        os.close(fd)  # hangs up the orphaned shell still holding the pty
+
+    assert len(_sync_lines(tmp_path)) == 3
+
+
+@requires_zsh
 def test_normal_shell_exit_persists_state_and_keeps_the_exit_code(tmp_path: Path) -> None:
     result = subprocess.run(
         [str(_harness(tmp_path)), "-c", "exit 7"],

--- a/tests/test_entrypoint_shutdown.py
+++ b/tests/test_entrypoint_shutdown.py
@@ -11,10 +11,13 @@ helpers stubbed, so the control flow under test is the shipped one.
 from __future__ import annotations
 
 import os
+import pty
+import select
 import shutil
 import signal
 import subprocess
 import time
+from contextlib import suppress
 from pathlib import Path
 
 import pytest
@@ -64,6 +67,60 @@ def _sync_lines(tmp_path: Path) -> list[str]:
     if not log.exists():
         return []
     return [line for line in log.read_text(encoding="utf-8").splitlines() if line]
+
+
+def _read_until(fd: int, needle: bytes, timeout: float) -> bool:
+    deadline = time.monotonic() + timeout
+    buffer = b""
+    while time.monotonic() < deadline:
+        if not select.select([fd], [], [], 0.2)[0]:
+            continue
+        try:
+            chunk = os.read(fd, 4096)
+        except OSError:  # pragma: no cover - pty closed by the child dying
+            break
+        if not chunk:
+            break
+        buffer += chunk
+        if needle in buffer:
+            return True
+    return False
+
+
+@requires_zsh
+def test_interactive_shell_survives_with_no_arguments(tmp_path: Path) -> None:
+    """The container passes NO arguments — the shape the other tests never reach.
+
+    `ENTRYPOINT ["/home/dev/entrypoint.sh"]` sets no CMD and no compose file sets
+    `command:`, so `"$@"` is empty and the shell must be interactive on its own.
+    Backgrounding it reassigns stdin to /dev/null unless the descriptor is handed
+    over explicitly; zsh is then non-interactive, reads EOF and exits within
+    milliseconds, taking the container with it. Passing `-c <cmd>` (as the tests
+    below do) hides this entirely, because such a shell never needs a terminal.
+    """
+    harness = _harness(tmp_path)
+    pid, fd = pty.fork()
+    if pid == 0:  # pragma: no cover - the child never returns
+        try:
+            os.execv("/bin/zsh", ["/bin/zsh", str(harness)])
+        finally:
+            os._exit(127)
+
+    try:
+        time.sleep(1.0)
+        assert os.waitpid(pid, os.WNOHANG) == (0, 0), (
+            "the shell exited instead of staying up — stdin was not handed over"
+        )
+        os.write(fd, b"echo PROBE_$((6*7))\n")
+        assert _read_until(fd, b"PROBE_42", timeout=5.0), (
+            "the shell did not evaluate input — it is alive but not interactive"
+        )
+    finally:
+        with suppress(ProcessLookupError):
+            os.kill(pid, signal.SIGKILL)
+        with suppress(ChildProcessError):
+            os.waitpid(pid, 0)
+        os.close(fd)
 
 
 @requires_zsh

--- a/tests/test_entrypoint_shutdown.py
+++ b/tests/test_entrypoint_shutdown.py
@@ -1,0 +1,138 @@
+"""Tests for the entrypoint's shutdown path — settings persistence on both exits.
+
+The interactive shell exiting normally and `docker stop` (SIGTERM to PID 1) must
+both reach the reverse-sync. The detached container has no other shutdown path,
+so a regression here loses settings silently.
+
+These run the real section lifted out of ``scripts/entrypoint.sh`` with the sync
+helpers stubbed, so the control flow under test is the shipped one.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import signal
+import subprocess
+import time
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+ENTRYPOINT = ROOT / "scripts" / "entrypoint.sh"
+SECTION_MARKER = "# Interactive Shell (reverse-sync settings on exit)"
+
+requires_zsh = pytest.mark.skipif(
+    shutil.which("zsh") is None, reason="zsh is not installed on this host"
+)
+
+
+def _shutdown_section() -> str:
+    """The shipped shutdown section, from its banner to the end of the file."""
+    text = ENTRYPOINT.read_text(encoding="utf-8")
+    marker = text.index(SECTION_MARKER)
+    return text[text.rindex("# ====", 0, marker) :]
+
+
+def _harness(tmp_path: Path) -> Path:
+    """Wrap the real section in stubs so it can run outside a container."""
+    log = tmp_path / "sync.log"
+    helper = tmp_path / "settings_copy.py"
+    helper.write_text("import sys\nsys.exit(0)\n", encoding="utf-8")
+
+    script = tmp_path / "harness.sh"
+    script.write_text(
+        "#!/bin/zsh\n"
+        "set -euo pipefail\n"
+        f'SYNC_LOG="{log}"\n'
+        f'SETTINGS_COPY_HELPER="{helper}"\n'
+        'OPENCODE_RUNTIME_SETTINGS="/dev/null"\n'
+        'OPENCODE_PERSISTENT_SETTINGS="/dev/null"\n'
+        'reverse_sync_file() { echo "file:$1" >> "$SYNC_LOG"; }\n'
+        'reverse_sync_claude_settings() { echo "claude:$1" >> "$SYNC_LOG"; }\n'
+        "ui_warn() { :; }\n"
+        "\n" + _shutdown_section(),
+        encoding="utf-8",
+    )
+    script.chmod(0o755)
+    return script
+
+
+def _sync_lines(tmp_path: Path) -> list[str]:
+    log = tmp_path / "sync.log"
+    if not log.exists():
+        return []
+    return [line for line in log.read_text(encoding="utf-8").splitlines() if line]
+
+
+@requires_zsh
+def test_normal_shell_exit_persists_state_and_keeps_the_exit_code(tmp_path: Path) -> None:
+    result = subprocess.run(
+        [str(_harness(tmp_path)), "-c", "exit 7"],
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+
+    assert result.returncode == 7, result.stderr
+    assert len(_sync_lines(tmp_path)) == 3
+
+
+@requires_zsh
+def test_sigterm_persists_state_before_exiting(tmp_path: Path) -> None:
+    """`docker stop` is the only shutdown a detached container ever gets."""
+    process = subprocess.Popen(
+        [str(_harness(tmp_path)), "-c", "sleep 60"],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        start_new_session=True,
+    )
+    try:
+        _wait_until_shell_started(process)
+        process.send_signal(signal.SIGTERM)
+        process.wait(timeout=15)
+    finally:
+        if process.poll() is None:  # pragma: no cover - only on regression
+            os.killpg(os.getpgid(process.pid), signal.SIGKILL)
+            process.wait(timeout=5)
+
+    assert process.returncode == 128 + signal.SIGTERM
+    # Exactly three: the signal path must not double-run the normal path.
+    assert len(_sync_lines(tmp_path)) == 3
+
+
+@requires_zsh
+def test_sigterm_persists_state_only_once(tmp_path: Path) -> None:
+    """Repeated signals must not re-run the sync — the guard flag is load-bearing."""
+    process = subprocess.Popen(
+        [str(_harness(tmp_path)), "-c", "sleep 60"],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        start_new_session=True,
+    )
+    try:
+        _wait_until_shell_started(process)
+        for _ in range(3):
+            if process.poll() is None:
+                process.send_signal(signal.SIGTERM)
+        process.wait(timeout=15)
+    finally:
+        if process.poll() is None:  # pragma: no cover - only on regression
+            os.killpg(os.getpgid(process.pid), signal.SIGKILL)
+            process.wait(timeout=5)
+
+    assert len(_sync_lines(tmp_path)) == 3
+
+
+def _wait_until_shell_started(process: subprocess.Popen[str]) -> None:
+    """Let the harness reach `wait` before signalling it.
+
+    Signalling earlier would race the trap installation and test nothing.
+    """
+    time.sleep(0.5)
+    if process.poll() is not None:  # pragma: no cover - only on regression
+        raise AssertionError("harness exited before it could be signalled")

--- a/tests/test_entrypoint_shutdown.py
+++ b/tests/test_entrypoint_shutdown.py
@@ -54,10 +54,11 @@ def _harness(tmp_path: Path) -> Path:
         'OPENCODE_PERSISTENT_SETTINGS="/dev/null"\n'
         'reverse_sync_file() { echo "file:$1" >> "$SYNC_LOG"; }\n'
         'reverse_sync_claude_settings() { echo "claude:$1" >> "$SYNC_LOG"; }\n'
-        # Echoed rather than silenced: the no-TTY path reports through these, and
-        # a stub that swallows them would hide whether it reported at all.
-        'ui_warn() { echo "[warn] $*" >&2; }\n'
-        'ui_item() { echo "[item] $*" >&2; }\n'
+        # The real UI library, not stubs. Variadic `$*` stubs accept any arity and
+        # would hide an arity or `set -u` violation in the section under test —
+        # which is exactly how a one-argument `ui_item` call reached production and
+        # survived a full review round.
+        f'source "{ROOT / "scripts" / "output-lib.sh"}"\n'
         "\n" + _shutdown_section(),
         encoding="utf-8",
     )

--- a/tests/test_ws3_doctor_session.py
+++ b/tests/test_ws3_doctor_session.py
@@ -306,7 +306,11 @@ def test_session_interactive_failure_prints_stderr(tmp_path: Path) -> None:
             session_mod.session(project="testproj")
 
         assert exc_info.value.exit_code == 127
-        mock_err_print.assert_any_call("Agent binary not found: claude\n", end="")
+        # Asserts the text reaches stderr, not how print_captured spells its kwargs.
+        assert any(
+            call.args and "Agent binary not found: claude" in str(call.args[0])
+            for call in mock_err_print.call_args_list
+        )
         mock_instance.run_interactive.assert_called_once()
 
 


### PR DESCRIPTION
## The bug

The container died after 3–5 minutes with no exit code and no log, reproducibly,
across host reboots.

`djinn start --docker-direct &` leaves a TTY-attached Compose client in a
background process group. Every `tcsetattr()` from there raises SIGTTOU
unconditionally (the `tostop` flag gates background *writes*, not
terminal-attribute changes), Compose forwards those into the container by the
tens per second, and the storm both floods Docker's event ring buffer — which is
why no crash logs survived — and stops the host-side client, after which `--rm`
reaps the container.

Container PID 1 is **not** what dies: namespace init discards signals it has no
handler for, and a container was observed surviving 45+ minutes under continuous
SIGTTOU. OOM was ruled out early (`oom_kill 0`, memory PSI 0.00, 42 GiB free).

## What this changes

- **Background-start guard.** `djinn start` refuses an interactive start from a
  background process group before allocating a TTY. Keyed on stdout, because
  that is what Compose derives TTY allocation from — so `djinn start &` and
  `djinn start < /dev/null &` are refused, while `djinn start > log &` (no TTY,
  nothing can storm) stays allowed.
- **`djinn start --detach`.** Starts via `docker compose up -d`, leaving no
  client to background at all; attach with `djinn enter`. Dynamic mounts reach
  Compose through a generated JSON override (valid YAML, no new dependency),
  including the `-e` half of the audio/D-Bus pairs — without it the sockets are
  mounted but `PULSE_SERVER`/`DBUS_SESSION_BUS_ADDRESS` are unset.
- **Settings survive `docker stop`.** The reverse-sync used to run only after an
  interactive shell returned, which a detached container never does. It now sits
  in an idempotent `persist_session_state()` reached from both paths.
- **The container no longer dies without a TTY.** An interactive zsh without a
  terminal reads EOF and exits immediately. Any start shape that ends up without
  a TTY now keeps the container alive and says why, so `djinn enter` (which
  brings its own TTY) still works.
- **Captured Docker output is no longer mangled.** One `print_captured()` across
  all twelve call sites; Rich was deleting `[internal]` / `[dev 3/25]` BuildKit
  stage tags — the tokens that locate a failing build step.
- Startup banner leads with a blank line so the djinn's turban is not clipped.

## Verification

885 tests, ruff clean, `pyright src/` 0 errors, bandit clean, `zsh -n` clean.

Beyond the suite, the load-bearing claims were checked against reality rather
than asserted: the shell behaviour on real ptys (before/after, and against every
rejected fix variant), the Compose override against a real `docker compose
config`, and the finished image end-to-end — the container running this branch is
detached, has a live interactive shell, working PulseAudio, and zero SIGTTOU
events.

Every fix is falsified individually: reverting it fails exactly its own test and
no other.

## Review

Five review rounds (three Claude, two Codex as an independent control pass).
Four criticals were found and fixed — three of them in the *previous round's
fix*, which is why the rounds continued. Full finding and disposition record,
including the deliberately accepted residuals, is in the local workspace under
`.claude/work/djinn-crash/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
