### PR TITLE
fix(entrypoint): run the keeper instead of a shell when detached

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,16 @@ Versioning before and after the first stable release.
 
 ### Fixed
 
+- A detached container no longer dies when its unused PID-1 shell receives EOF.
+  `up -d` gives the container a TTY (the compose file sets `tty: true`) that
+  nobody is attached to, and an interactive shell there made the whole session
+  hostage to that terminal: one EOF — a stray attach, a closed pty master, a
+  Ctrl-D — ended the shell with 0, PID 1 followed, and the container was gone
+  with no signal and no error to point at. `djinn start --detach` now marks the
+  container with `DJINN_DETACHED=true`, and the entrypoint runs its keeper
+  instead of a shell. Consumers were never using that shell anyway — `djinn
+  enter` brings its own TTY through `docker exec` — and `docker stop` still
+  reaches the settings reverse-sync unchanged.
 - Captured Docker output is no longer mangled by Rich. Every command that echoes
   a subprocess's stdout/stderr as its own output — `build`, `start`, `clean`,
   `run`, `session`, `mcp` — now routes through `print_captured()`, which disables

--- a/IMPLEMENTATION.md
+++ b/IMPLEMENTATION.md
@@ -529,9 +529,10 @@ SIGTERM to PID 1 and that is its only shutdown. `entrypoint.sh` therefore:
   a real pty: a shell launched with `-c <cmd>` never needs a terminal and would
   hide the regression entirely.
 
-- refuses to start an interactive shell when there is no terminal at all, and
-  keeps the container alive instead. This closes a whole class rather than one
-  instance: an interactive zsh without a TTY reads EOF and returns immediately,
+- refuses to start an interactive shell in two cases — no terminal at all, or
+  `DJINN_DETACHED=true` — and keeps the container alive with a `sleep infinity`
+  keeper instead. This closes a whole class rather than one instance: an
+  interactive zsh without a TTY reads EOF and returns immediately,
   so PID 1 exits 0 and the container disappears with an empty log — the very
   signature this work started from. The class has several entrances, and the
   background-start guard deliberately does not cover them all: it refuses only
@@ -540,6 +541,16 @@ SIGTERM to PID 1 and that is its only shutdown. `entrypoint.sh` therefore:
   use PID 1's shell without a terminal anyway, while `djinn enter` brings its own
   TTY through `docker exec`, staying up is strictly better than dying silently.
   The reverse-sync on `docker stop` works unchanged in that state.
+
+  The detached case needs the flag because it is invisible from inside: the
+  compose file sets `tty: true`, so a terminal *does* exist under `up -d` — there
+  is simply nobody on it. An unused interactive shell as PID 1 makes the session
+  hostage to that terminal, since any EOF on it (a stray attach, a closed pty
+  master, a Ctrl-D) ends the shell with 0 and takes the container down with no
+  signal and no error to point at. `compose_up_detached()` therefore exports
+  `DJINN_DETACHED=true` through the same compose interpolation `ENABLE_FIREWALL`
+  uses (`${DJINN_DETACHED:-false}` in `docker-compose.yml`), leaving the generated
+  override purely about mounts. Every other path sees `false`.
 
 Shell-side startup output is sectioned through `scripts/output-lib.sh`:
 `Seed & Config`, `MCP`, `Tools`, and `Security`. `mcp-register.sh` captures

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -97,6 +97,7 @@ services:
       <<: *common-environment
       MCP_GATEWAY_URL: http://mcp-gateway:8811/
       ENABLE_FIREWALL: ${ENABLE_FIREWALL:-false}
+      DJINN_DETACHED: ${DJINN_DETACHED:-false}
     extra_hosts:
       # Expose the host (for MCP servers running as host services, e.g. a local MCP server)
       - "host.docker.internal:host-gateway"

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -266,19 +266,28 @@ trap '_djinn_on_termination_signal 2' INT
 # Fence set -e around the interactive shell: a non-zero shell exit must NOT abort
 # the script before EXIT_CODE capture + reverse-sync (else settings persistence is silently skipped).
 set +e
-if [[ $# -eq 0 && ! -t 0 ]]; then
-    # An interactive shell was requested but there is no terminal to drive it, so
-    # zsh would read EOF and exit within milliseconds — PID 1 would follow and the
-    # container would vanish with exit code 0 and nothing in its log. That is the
-    # whole failure class this guard closes, and it has more entrances than it
-    # looks: `docker compose run` picks `-T` from the *client's stdout*, so merely
-    # redirecting output is enough to land here, no matter what stdin does.
+if [[ $# -eq 0 ]] && { [[ "${DJINN_DETACHED:-}" == "true" ]] || [[ ! -t 0 ]]; }; then
+    # Two shapes end up here, and neither wants an interactive shell as PID 1.
     #
-    # Staying alive is strictly better than dying silently: nobody can use PID 1's
-    # shell without a terminal anyway, while `djinn enter` (docker exec, which
-    # brings its own TTY) works perfectly against a live container.
-    ui_warn "No TTY available — not starting an interactive shell."
-    ui_info "The container stays up; attach with: djinn enter"
+    # 1. No terminal at all: zsh would read EOF and exit within milliseconds, PID 1
+    #    would follow, and the container would vanish with exit code 0 and nothing
+    #    in its log. `docker compose run` picks `-T` from the *client's stdout*, so
+    #    merely redirecting output is enough to land here.
+    # 2. Detached (`djinn start --detach`): a TTY exists, but nobody is on it.
+    #    Consumers attach with `djinn enter`, which brings its own TTY via
+    #    docker exec. Leaving an unused interactive shell as PID 1 makes the whole
+    #    session hostage to that terminal — one EOF on it, from a stray attach, a
+    #    closed pty master, or a Ctrl-D, and the container is gone with exit 0.
+    #
+    # Either way a keeper is strictly better: it cannot be ended by anything
+    # happening on a terminal, and `docker stop` still reaches the reverse-sync
+    # through the trap below.
+    if [[ "${DJINN_DETACHED:-}" == "true" ]]; then
+        ui_info "Detached container — PID 1 holds it open; attach with: djinn enter"
+    else
+        ui_warn "No TTY available — not starting an interactive shell."
+        ui_info "The container stays up; attach with: djinn enter"
+    fi
     sleep infinity &
     DJINN_SHELL_PID=$!
 else

--- a/src/djinn_in_a_box/core/docker.py
+++ b/src/djinn_in_a_box/core/docker.py
@@ -1015,7 +1015,12 @@ def compose_up_detached(
             args,
             config=config,
             cwd=project_root,
-            extra_env={"ENABLE_FIREWALL": str(options.firewall_enabled).lower()},
+            extra_env={
+                "ENABLE_FIREWALL": str(options.firewall_enabled).lower(),
+                # Tells the entrypoint nobody will ever use PID 1's shell here:
+                # consumers attach with `djinn enter`, which brings its own TTY.
+                "DJINN_DETACHED": "true",
+            },
         )
     finally:
         if override_path is not None:

--- a/tests/test_docker.py
+++ b/tests/test_docker.py
@@ -2160,3 +2160,25 @@ class TestComposeUpDetached:
         compose_up_detached(mock_app_config, ContainerOptions(firewall_enabled=True))
 
         assert mock_run.call_args.kwargs["env"]["ENABLE_FIREWALL"] == "true"
+
+    @patch("djinn_in_a_box.core.docker.get_project_root")
+    @patch("djinn_in_a_box.core.docker.subprocess.run")
+    def test_marks_the_container_as_detached(
+        self,
+        mock_run: MagicMock,
+        mock_root: MagicMock,
+        mock_app_config: AppConfig,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """The entrypoint needs to know nobody will use PID 1's shell.
+
+        Rides the same compose interpolation as ENABLE_FIREWALL rather than the
+        mount override, so the override stays purely about mounts.
+        """
+        self._without_runtime_mounts(monkeypatch)
+        mock_root.return_value = Path("/project")
+        mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+
+        compose_up_detached(mock_app_config, ContainerOptions())
+
+        assert mock_run.call_args.kwargs["env"]["DJINN_DETACHED"] == "true"

--- a/tests/test_entrypoint_shutdown.py
+++ b/tests/test_entrypoint_shutdown.py
@@ -183,6 +183,55 @@ def test_without_a_tty_the_container_stays_up_instead_of_exiting(tmp_path: Path)
 
 
 @requires_zsh
+def test_detached_uses_the_keeper_even_though_a_tty_exists(tmp_path: Path) -> None:
+    """`--detach` must not leave an interactive shell as PID 1.
+
+    The compose file sets `tty: true`, so a terminal exists and the no-TTY branch
+    does not catch this mode. But nobody is on that terminal — consumers attach
+    with `djinn enter`, which brings its own TTY through docker exec. An unused
+    interactive shell as PID 1 makes the whole session hostage to it: a single EOF
+    (a stray attach, a closed pty master, a Ctrl-D) ends the shell with 0, PID 1
+    follows, and the container is gone without a signal or an error to point at.
+    """
+    harness = _harness(tmp_path)
+    pid, fd = pty.fork()
+    if pid == 0:  # pragma: no cover - the child never returns
+        try:
+            os.environ["DJINN_DETACHED"] = "true"
+            os.execv("/bin/zsh", ["/bin/zsh", str(harness)])
+        finally:
+            os._exit(127)
+
+    try:
+        time.sleep(1.0)
+        assert os.waitpid(pid, os.WNOHANG) == (0, 0), "the keeper exited instead of holding"
+        os.write(fd, b"echo PROBE_$((6*7))\n")
+        assert not _read_until(fd, b"PROBE_42", timeout=2.0), (
+            "input was evaluated — an interactive shell is running, not the keeper"
+        )
+
+        os.kill(pid, signal.SIGTERM)  # docker stop signals PID 1 only
+        status: int | None = None
+        deadline = time.monotonic() + 15
+        while time.monotonic() < deadline:
+            reaped, raw = os.waitpid(pid, os.WNOHANG)
+            if reaped:
+                status = raw
+                break
+            time.sleep(0.1)
+        assert status is not None, "PID 1 did not exit within the grace period"
+        assert os.WIFEXITED(status) and os.WEXITSTATUS(status) == 128 + signal.SIGTERM
+    finally:
+        with suppress(ProcessLookupError):
+            os.kill(pid, signal.SIGKILL)
+        with suppress(ChildProcessError):
+            os.waitpid(pid, 0)
+        os.close(fd)
+
+    assert len(_sync_lines(tmp_path)) == 3
+
+
+@requires_zsh
 def test_sigterm_persists_with_an_interactive_shell_running(tmp_path: Path) -> None:
     """The shape `docker stop` actually meets: PID 1 with a live interactive zsh.
 


### PR DESCRIPTION
## The symptom

A detached container died again — this time **while nobody was working in it**,
and with a signature unlike the original bug:

| | |
|---|---|
| Exit code | **0** (clean) |
| OOMKilled | false |
| Signal | none |
| SIGTTOU storm | none (0 events) |
| Uptime | 16 minutes |
| Last log line | zsh drawing its prompt and enabling bracketed paste — ZLE waiting for input — in the same millisecond as the exit |

Ruled out by measurement: memory (1.7 of 16 GiB, `oom_kill 0`), pids (178 of
69454), ptys, file descriptors. The entrypoint behaved *correctly*: its shell
returned 0, so it ran the reverse-sync and exited 0 too.

## The exposure

`up -d` gives the container a TTY — the compose file sets `tty: true` — that
nobody is attached to, and the entrypoint put an **interactive shell** on it.
That makes the whole session hostage to a terminal no one uses: a single EOF on
it (a stray attach, a closed pty master, a Ctrl-D) ends the shell with 0, PID 1
follows through its normal shutdown, and the container is gone with no signal,
no error, and a clean exit code that explains nothing.

Consumers were never using that shell anyway — `djinn enter` is `docker exec -it`
and brings its own TTY.

## The change

`compose_up_detached()` exports `DJINN_DETACHED=true` through the same compose
interpolation `ENABLE_FIREWALL` already uses, and the entrypoint takes the keeper
branch it already had for the TTY-less case. The flag deliberately does *not* go
through the generated mount override, so that override stays purely about mounts
— otherwise every detached start would emit one, including starts with no dynamic
mounts at all.

`docker stop` still reaches the settings reverse-sync in that state: verified at
rc 143 with all three syncs written.

## Verification

887 tests, ruff clean, `pyright src/` 0 errors, `zsh -n` clean.

Checked against reality rather than asserted:

- All three start shapes against the shipped entrypoint section on a real pty —
  TTY without the flag stays interactive; TTY **with** the flag runs the keeper
  and does not evaluate input; headless `-c cmd` is untouched. SIGTERM yields 143
  with three sync lines in every case.
- The compose interpolation against real `docker compose config`:
  `DJINN_DETACHED: "true"` on the detached path, `"false"` everywhere else.

Falsified in both halves: dropping the export fails the docker test, ignoring the
flag in the entrypoint fails the new pty test, and neither failure touches any
other test.

## Honest limit

What produced the EOF is **not** established — the docker event ring buffer had
already rolled over, and `docker exec` sessions cannot reach pts/0. This change
removes the exposure rather than waiting to identify the trigger. A sidecar
monitor is now recording events, periodic `docker top` snapshots, and an
automatic post-mortem capture (state + logs) on any die/kill/oom event, so a
recurrence leaves evidence instead of hypotheses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
