### PR TITLE
test(entrypoint): stop inheriting DJINN_DETACHED from the environment

### DIFF
--- a/tests/test_entrypoint_shutdown.py
+++ b/tests/test_entrypoint_shutdown.py
@@ -48,6 +48,10 @@ def _harness(tmp_path: Path) -> Path:
     script.write_text(
         "#!/bin/zsh\n"
         "set -euo pipefail\n"
+        # Never inherit DJINN_DETACHED: djinn's own detached container exports it,
+        # so running this suite inside one would flip the very branch under test.
+        # Each test declares what it wants through DJINN_TEST_DETACHED instead.
+        'DJINN_DETACHED="${DJINN_TEST_DETACHED:-}"\n'
         f'SYNC_LOG="{log}"\n'
         f'SETTINGS_COPY_HELPER="{helper}"\n'
         'OPENCODE_RUNTIME_SETTINGS="/dev/null"\n'
@@ -197,7 +201,7 @@ def test_detached_uses_the_keeper_even_though_a_tty_exists(tmp_path: Path) -> No
     pid, fd = pty.fork()
     if pid == 0:  # pragma: no cover - the child never returns
         try:
-            os.environ["DJINN_DETACHED"] = "true"
+            os.environ["DJINN_TEST_DETACHED"] = "true"
             os.execv("/bin/zsh", ["/bin/zsh", str(harness)])
         finally:
             os._exit(127)


### PR DESCRIPTION
## The problem

The entrypoint shutdown tests read `DJINN_DETACHED` — the very flag that selects
the branch they exercise. `djinn start --detach` exports it into the container,
so running the suite from inside a detached djinn container (the normal case)
flipped two tests into the wrong branch:

```
FAILED test_interactive_shell_survives_with_no_arguments
  the shell did not evaluate input — it is alive but not interactive
FAILED test_without_a_tty_the_container_stays_up_instead_of_exiting
  assert 'No TTY available' in '[info] Detached container — PID 1 holds it open…'
```

Both got a keeper where they expected an interactive shell, because the harness
inherited `DJINN_DETACHED=true` from its own environment.

CI never sees this — the variable does not exist on the runner. Only developers
running the suite where djinn actually runs do.

## The fix

The harness derives `DJINN_DETACHED` from `DJINN_TEST_DETACHED`, which only the
tests set. An inherited value can no longer reach the section under test, and each
test states its intent explicitly.

## Verification

- Green with `DJINN_DETACHED=true`, with `=false`, and with the variable unset —
  7/7 in each case.
- Falsified: removing the line fails exactly those two tests inside a detached
  container, and nothing else.
- Full suite 887 passed, ruff clean, `pyright src/` 0 errors.

Tests only — no runtime behaviour changes, so no rebuild is needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
