### PR TITLE
fix(clean): refuse to tear down the container we are running inside

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,14 @@ Versioning before and after the first stable release.
 
 ### Fixed
 
+- `compose down` now refuses to reap the container it is running inside. The
+  docker socket is mounted into the dev container, and `docker-compose.yml` pins
+  the project name, so a teardown started from *any* copy of the repo — including
+  a throwaway one — selects the live session's container. That is not theoretical:
+  a mutation test that disabled an unrelated guard let `clean_all` run through to
+  a real teardown and killed the container it was executing in. Teardown from the
+  host is unaffected; from inside, the command explains itself and points at
+  `djinn clean`.
 - A detached container no longer dies when its unused PID-1 shell receives EOF.
   `up -d` gives the container a TTY (the compose file sets `tty: true`) that
   nobody is attached to, and an interactive shell there made the whole session

--- a/IMPLEMENTATION.md
+++ b/IMPLEMENTATION.md
@@ -735,7 +735,13 @@ backed by named volumes.
 - `status()`: reports config, containers, known volumes, config-root paths,
   networks, Docker proxy, and MCP Gateway status.
 - `clean_default()`: `djinn clean` stops and removes containers with
-  `compose_down(config=None)`, using best-effort placeholders. `compose_down`
+  `compose_down(config=None)`, using best-effort placeholders. `compose_down()`
+  refuses outright when the container it would reap is the one the process runs
+  in (`is_own_container()`: `/.dockerenv` plus a hostname match against
+  `container_name`). Compose selects by the pinned project name, so a teardown
+  from any copy of the repo — a test sandbox, an agent's scratch checkout — would
+  otherwise destroy the live session, and the socket is mounted so anything in the
+  container can trigger it. Teardown from the host is unaffected. `compose_down`
   passes `--remove-orphans`, without which Compose skips the one-off containers
   that `start` and `run` create and also leaves a proxy from `--docker` behind.
 - `clean_volumes()`: lists or deletes named volume categories and clears

--- a/src/djinn_in_a_box/core/docker.py
+++ b/src/djinn_in_a_box/core/docker.py
@@ -6,6 +6,7 @@ import json
 import os
 import re
 import shutil
+import socket
 import subprocess
 import sys
 import tempfile
@@ -1027,6 +1028,36 @@ def compose_up_detached(
             override_path.unlink(missing_ok=True)
 
 
+SELF_TEARDOWN_ERROR = (
+    "Refusing to tear down the container this process is running inside.\n"
+    "\n"
+    "`docker compose down` selects by project name, which docker-compose.yml pins to\n"
+    "`djinn-in-a-box` — so it reaps the running dev container no matter which copy of\n"
+    "the repo it runs from, including a throwaway one. With the docker socket mounted,\n"
+    "anything in here can do that to itself: a test, an agent, a stray command.\n"
+    "\n"
+    "Run teardown from the host instead:\n"
+    "  djinn clean\n"
+)
+
+
+def is_own_container(name: str) -> bool:
+    """True when ``name`` is the container this process is running inside.
+
+    Cheap and deliberately conservative: ``/.dockerenv`` plus a hostname match,
+    because the compose file sets ``container_name`` and ``hostname`` to the same
+    value. A renamed container falls through and is not protected — best-effort is
+    the right trade here, since the alternative costs a Docker round-trip on every
+    teardown.
+    """
+    try:
+        if not Path("/.dockerenv").exists():
+            return False
+        return socket.gethostname() == name
+    except OSError:
+        return False
+
+
 def compose_down(config: AppConfig | None = None) -> RunResult:
     """Stop and remove the project's containers.
 
@@ -1042,7 +1073,13 @@ def compose_down(config: AppConfig | None = None) -> RunResult:
     declare — a proxy left by ``--docker``, or a service dropped in an upgrade.
     Those two are transient; the one-off case is permanent. Do not drop the flag
     on the reasoning that ``cleanup_docker_proxy`` already covers the proxy.
+
+    Refuses outright when the container it would reap is the one this process runs
+    in — that is always self-destruction, never intent.
     """
+    if is_own_container(_SERVICE_CONTAINER_NAMES.get("dev", "djinn")):
+        return RunResult(returncode=1, stderr=SELF_TEARDOWN_ERROR)
+
     project_root = get_project_root()
     compose_files = get_compose_files()
     return _run_compose(

--- a/tests/test_docker.py
+++ b/tests/test_docker.py
@@ -28,6 +28,7 @@ from djinn_in_a_box.core.docker import (
     cleanup_docker_proxy,
     clear_sync_path,
     compose_build,
+    compose_down,
     compose_run,
     compose_up_detached,
     delete_volumes,
@@ -1937,6 +1938,48 @@ class TestBackgroundProcessGroupGuard:
         compose_run(mock_app_config, ContainerOptions(), command="echo", interactive=False)
 
         mock_run.assert_called_once()
+
+
+class TestSelfTeardownGuard:
+    """`compose down` must never reap the container it is running inside.
+
+    The docker socket is mounted, so any process in the container can do this to
+    itself. It is not hypothetical: a mutation test that disabled an unrelated
+    guard let `clean_all` through to a real teardown, and `compose down` selects
+    by the project name pinned in docker-compose.yml — so it killed the live
+    session from a throwaway copy of the repo.
+    """
+
+    @staticmethod
+    def _inside(monkeypatch: pytest.MonkeyPatch, *, dockerenv: bool, hostname: str) -> None:
+        monkeypatch.setattr(docker_mod.Path, "exists", lambda self: dockerenv)
+        monkeypatch.setattr(docker_mod.socket, "gethostname", lambda: hostname)
+
+    def test_detects_its_own_container(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        self._inside(monkeypatch, dockerenv=True, hostname="djinn")
+        assert docker_mod.is_own_container("djinn")
+
+    def test_ignores_a_different_container(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        self._inside(monkeypatch, dockerenv=True, hostname="some-other-box")
+        assert not docker_mod.is_own_container("djinn")
+
+    def test_ignores_the_host(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """No /.dockerenv means we are on the host, where teardown is the point."""
+        self._inside(monkeypatch, dockerenv=False, hostname="djinn")
+        assert not docker_mod.is_own_container("djinn")
+
+    @patch("djinn_in_a_box.core.docker.subprocess.run")
+    def test_compose_down_refuses_from_inside(
+        self, mock_run: MagicMock, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(docker_mod, "is_own_container", lambda _name: True)
+
+        result = compose_down()
+
+        assert result.returncode == 1
+        assert "Refusing to tear down" in result.stderr
+        assert "djinn clean" in result.stderr
+        mock_run.assert_not_called()
 
 
 class TestVolumeSpecsFromMountArgs:

--- a/tests/test_ws0.py
+++ b/tests/test_ws0.py
@@ -99,19 +99,25 @@ class TestComposeEnvBridge:
         compose_build(mock_app_config)
         self._assert_guarded(self._env_of(mock_run), mock_app_config)
 
+    # Teardown from the host: the self-teardown guard is not what this pins, and
+    # the suite may well be running inside the container it would refuse to reap.
+    @patch("djinn_in_a_box.core.docker.is_own_container", return_value=False)
     @patch("djinn_in_a_box.core.docker.get_project_root", return_value=Path("/project"))
     @patch("djinn_in_a_box.core.docker.subprocess.run")
     def test_compose_down(
-        self, mock_run: MagicMock, _root: MagicMock, mock_app_config: AppConfig
+        self, mock_run: MagicMock, _root: MagicMock, _own: MagicMock, mock_app_config: AppConfig
     ) -> None:
         mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
         compose_down(mock_app_config)
         self._assert_guarded(self._env_of(mock_run), mock_app_config)
 
+    # Teardown from the host: the self-teardown guard is not what this pins, and
+    # the suite may well be running inside the container it would refuse to reap.
+    @patch("djinn_in_a_box.core.docker.is_own_container", return_value=False)
     @patch("djinn_in_a_box.core.docker.get_project_root", return_value=Path("/project"))
     @patch("djinn_in_a_box.core.docker.subprocess.run")
     def test_compose_down_removes_orphans(
-        self, mock_run: MagicMock, _root: MagicMock, mock_app_config: AppConfig
+        self, mock_run: MagicMock, _root: MagicMock, _own: MagicMock, mock_app_config: AppConfig
     ) -> None:
         """Teardown must reap one-off containers and undeclared project containers.
 


### PR DESCRIPTION
## What happened

A container died mid-session again. This time the sidecar monitor caught the
cause with the process tree intact:

```
claude agents → daemon → bg-pty-host → bg-spare
  → zsh -c ⟨mutation-test sandbox⟩ → uv run pytest → python pytest
    → docker compose -f ⟨sandbox⟩/docker-compose.yml down --remove-orphans
```

400 ms later: `die exit=143`.

Nothing in that chain was careless. The sandbox test asserts that a command's
guard aborts *before* doing work. One of the mutations under test disables
exactly that guard — so the call sailed past it into `clean_all(force=True)`,
which reached `compose_down()` for real. Compose selects by project name, which
`docker-compose.yml` pins to `djinn-in-a-box`, so the teardown found the **live**
container rather than the sandbox's own. The mutation test destroyed its own
runtime.

## The guard

`compose_down()` now refuses when the container it would reap is the one the
process is running in, detected via `/.dockerenv` plus a hostname match against
`container_name`. Teardown from the host — where it belongs — is untouched.

This closes the class rather than the instance: the docker socket is mounted, so
*anything* in the container could do this to itself. A test, an agent, a mistyped
command. It needs no cooperation from the code that triggers it.

## Verification

891 tests, ruff clean, `pyright src/` 0 errors.

- Live in this container: `is_own_container("djinn")` → True, `compose_down()` →
  exit 1 with the explanation instead of self-destruction.
- Falsified: removing the guard fails exactly the new test and nothing else.
- The two existing teardown tests now state explicitly that they exercise the
  host path, instead of depending on where the suite happens to run — the same
  hermeticity lesson as the `DJINN_DETACHED` fix.

## Scope note

`is_own_container()` is deliberately best-effort: a renamed container falls
through unprotected. The alternative costs a Docker round-trip on every teardown,
which is not worth it for a guard against an accident.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
