### PR TITLE
docs: stop claiming the SIGTTOU storm killed the container

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,8 +25,10 @@ Versioning before and after the first stable release.
 - Guard against starting an interactive container from a background process
   group. `djinn start ... &` left a TTY-attached Compose client in the
   background, where every `tcsetattr()` raises SIGTTOU; Compose forwarded the
-  signal into the container, producing tens of events per second and flooding
-  Docker's event ring buffer. `djinn start` now fails with an explanation and
+  signal into the container, producing tens of events per second. Two effects
+  were measured: host load, and a continuously overflowing Docker event ring
+  buffer — which is why the early container deaths left no diagnostic record at
+  all. Whether the storm also ended the container was never established. `djinn start` now fails with an explanation and
   points at `--detach` or a foreground start. The check keys on stdout, which is
   what Compose derives TTY allocation from, so `djinn start > log &` stays allowed
   (no TTY is allocated, so nothing can storm) while `djinn start < /dev/null &` is

--- a/IMPLEMENTATION.md
+++ b/IMPLEMENTATION.md
@@ -713,9 +713,12 @@ backed by named volumes.
   forwards the signals into the container. `djinn start ... &` is exactly that
   shape and produces tens of events per second. Container PID 1 is not what dies —
   namespace init discards a signal it has no handler for, and a container was
-  observed surviving 45+ minutes under continuous SIGTTOU. What the storm does is
-  flood Docker's event ring buffer (hence the missing logs) and stop the host-side
-  compose client, after which `--rm` reaps the container.
+  observed surviving 45+ minutes under continuous SIGTTOU. What the storm reliably
+  does is load the host and overflow Docker's event ring buffer — which is why the
+  early crashes left no records at all, and why the first usable post-mortem only
+  arrived once the storm was gone. Whether it also ends the container is unproven;
+  the plausible path is the host-side compose client being stopped, after which
+  `--rm` reaps it.
   `is_background_process_group()` compares `os.tcgetpgrp(stdout)` against
   `os.getpgrp()` — **stdout, and only stdout**, because that is what Compose keys
   on: it derives `noTty` from `!dockerCli.Out().IsTerminal()` and allocates a TTY

--- a/README.md
+++ b/README.md
@@ -27,8 +27,9 @@ Djinn gives you one repeatable container image and several ways to use it:
   the background with `djinn start --detach` and attach to it later with
   `djinn enter`. Do not background the interactive form with `&`: that leaves a
   TTY-attached Compose client in a background process group, which storms the
-  container with SIGTTOU until its host-side client is stopped and `--rm` reaps
-  it. `djinn start` refuses that shape.
+  container with SIGTTOU — loading the host and overflowing Docker's event ring
+  buffer, so nothing that goes wrong in that container stays diagnosable.
+  `djinn start` refuses that shape.
 - Run a one-shot agent prompt with `djinn run`.
 - Attach another shell to a running container with `djinn enter`.
 - Keep reusable session workspaces under `~/.djinn/sessions/` with

--- a/src/djinn_in_a_box/commands/container.py
+++ b/src/djinn_in_a_box/commands/container.py
@@ -162,9 +162,9 @@ def start(
     Use --detach to leave the container running in the background. Do NOT
     background the foreground form with `&`: that keeps a TTY-attached Compose
     client in a background process group, which storms the container with
-    SIGTTOU until its host-side client is stopped and `--rm` reaps it. `djinn start`
-    refuses that shape rather than let it
-    happen. A detached container still persists its settings: the entrypoint
+    SIGTTOU. That floods Docker's event ring buffer, so anything else that goes wrong
+    in the container stops being diagnosable. `djinn start` refuses that shape rather
+    than let it happen. A detached container still persists its settings: the entrypoint
     traps the SIGTERM from `docker stop` and reverse-syncs before exiting.
 
     Examples:

--- a/src/djinn_in_a_box/core/docker.py
+++ b/src/djinn_in_a_box/core/docker.py
@@ -691,9 +691,9 @@ BACKGROUND_START_ERROR = (
     "\n"
     "`docker compose run` allocates a TTY, and every terminal-attribute call from the\n"
     "background raises SIGTTOU. Compose forwards those signals into the container by the\n"
-    "tens per second, which floods Docker's event ring buffer and stops the host-side\n"
-    "compose client — and once that client is gone, `--rm` reaps the container. No exit\n"
-    "code, no log.\n"
+    "tens per second. Two effects are measured: the host carries the load, and Docker's\n"
+    "event ring buffer overflows continuously — which erases the very records you would\n"
+    "need to diagnose anything else going wrong in that container.\n"
     "\n"
     "`djinn start ... &` is exactly this shape. Use one of:\n"
     "  djinn start --detach ...        (no TTY client at all; then `djinn enter`)\n"
@@ -709,9 +709,12 @@ def is_background_process_group() -> bool:
     process group that raises SIGTTOU unconditionally — the ``tostop`` terminal
     flag gates background *writes*, not terminal-attribute changes — and Compose
     forwards the signals into the container by the tens per second. Container PID 1
-    survives them — namespace init discards a signal it has no handler for — but the
-    storm floods Docker's event ring buffer and stops the *host-side* compose client,
-    and once that client is gone ``--rm`` reaps the container: no exit code, no log.
+    survives them — namespace init discards a signal it has no handler for. What the
+    storm reliably costs is host load and Docker's event ring buffer, which overflows
+    continuously and takes the diagnostic record with it. Whether it also ends the
+    container is unproven: the plausible path is SIGTTOU stopping the *host-side*
+    compose client, after which ``--rm`` reaps it, but that was never observed
+    directly.
 
     ``djinn start ... &`` is precisely that shape: ``&`` puts the process group in
     the background while a standard stream stays attached to the terminal.

--- a/tests/test_docker.py
+++ b/tests/test_docker.py
@@ -1803,9 +1803,9 @@ class TestBackgroundProcessGroupGuard:
 
     A backgrounded TTY-attached compose client turns every terminal-attribute
     call into SIGTTOU. Container PID 1 survives those — namespace init discards a
-    signal it has no handler for — but the storm floods Docker's event ring buffer
-    and stops the host-side compose client, after which `--rm` reaps the
-    container. The guard refuses that shape.
+    signal it has no handler for — but the storm costs host load and overflows
+    Docker's event ring buffer, erasing the diagnostic record. Whether it also ends
+    the container was never established. The guard refuses that shape.
     """
 
     @staticmethod


### PR DESCRIPTION
## Why

Six places stated — in the error message, two docstrings, a test docstring, the
README and IMPLEMENTATION.md — that the SIGTTOU storm stopped the host-side
compose client and `--rm` then reaped the container. That chain was always
labelled *plausible*, never proven, and the wording drifted into stating it as
fact. `djinn start --help` and the README carried it to users.

Today's post-mortem shows the overclaim. The container that actually died was
killed by `docker compose down`, issued by a test inside an agent's mutation-test
sandbox: SIGTERM, exit 143, no storm involved. And `down --remove-orphans` reaches
a `compose run` container just as well, so the earlier deaths may have had the
same cause from the start.

## What changed

Only the causal claims. The guard, its remedies, and every test are untouched.

The storm's *measured* costs stay in the text, because they justify the guard on
their own:

- host load
- a continuously overflowing Docker event ring buffer

The second one matters more than it sounds: it is why the early crashes left no
records at all, and why the first usable post-mortem only arrived once the storm
was gone. Without that fix, today's actual cause would still be invisible.

Where the client-stopped-then-`--rm` path is still mentioned, it is now explicitly
marked as unproven.

## Verification

891 tests, ruff clean, `pyright src/` 0 errors. Documentation only — no behaviour
change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
