### PR TITLE
fix(build): make a failing build diagnosable and its network selectable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,7 +52,40 @@ Versioning before and after the first stable release.
 - Shell startup UI helpers for section rules, status markers, boxed external
   command output, and zsh/bash-compatible sourcing.
 
+### Added
+
+- `build.network` config key (`default` | `host`) selects the network for
+  image-build steps, reaching compose as `DJINN_BUILD_NETWORK`. `host` is for a
+  host whose container DNS server is reachable from one Docker network only — a
+  VPN or split-DNS setup, where a resolver listens on one bridge while builds run
+  on another and resolve nothing there. The build then resolves through the same
+  resolver the host uses, instead of bypassing it; in exchange every build step
+  shares the host's network namespace, so it is opt-in and documented as such.
+  Default is unchanged. Buildkit's `none` is not offered (no layer of this image
+  builds without a network) and a named network buildkit rejects itself.
+- The image build now refuses a network it cannot resolve names on, checking from
+  inside each network-dependent build step rather than in a layer of its own — a
+  separate guard layer can stay cached while the download it protects re-runs. The
+  error names `build.network` and states its trade-off. Previously the failure
+  surfaced one timeout at a time: 70 minutes before npm gave up, since it retries
+  every package six times with a backoff, and over two minutes for `apt-get
+  update` alone.
+- `DJINN_BUILD_PROGRESS` overrides the build's progress renderer for anyone who
+  prefers compose's compact redrawing view; an unusable value falls back to
+  `plain` with a warning.
+
 ### Changed
+
+- `djinn build` now shows the build log while the build runs. It previously
+  captured the whole output and returned it only when the process exited, so a
+  build that stopped making progress displayed nothing at all — and on failure
+  only `stderr` was printed while `stdout` was discarded, which cost the lines
+  that name the failing step's cause. The build now inherits stdout/stderr and
+  forces `--progress plain`, keeping every stage line on screen so the stage a
+  stalled build last entered stays visible. Deliberately without a timeout:
+  killing the compose client would leave `docker-buildx` and the BuildKit solve
+  in the daemon running, so the timeout would report a cancellation it cannot
+  actually perform.
 
 - Restructured `djinn start` output into Python-rendered banner,
   `Environment`, and `Container` sections followed by shell-rendered

--- a/Dockerfile
+++ b/Dockerfile
@@ -80,10 +80,10 @@ ENV PATH="/home/${USERNAME}/.local/bin:/home/${USERNAME}/.local/share/fnm:$PATH"
 RUN eval "$(fnm env)" && fnm install --lts && fnm default lts-latest
 
 # CLI Agent versions - update with: ./scripts/update-agents.sh
-ARG CLAUDE_CODE_VERSION=2.1.226
-ARG GEMINI_CLI_VERSION=0.54.4
-ARG CODEX_VERSION=0.147.0
-ARG OPENCODE_VERSION=1.18.16
+ARG CLAUDE_CODE_VERSION=2.1.238
+ARG GEMINI_CLI_VERSION=0.56.0
+ARG CODEX_VERSION=0.149.0
+ARG OPENCODE_VERSION=1.18.19
 
 # Claude Code via native installer (no npm/Node.js dependency)
 # Installs to ~/.local/bin/claude (already in PATH via .zshrc)

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,15 @@ FROM debian:bookworm-slim
 ENV DEBIAN_FRONTEND=noninteractive
 
 # System dependencies (base)
-RUN apt-get update && apt-get install -y --no-install-recommends \
+# The DNS guard runs *inside* the network-dependent layers rather than in one of its
+# own. A separate guard layer can stay cached while the download below re-runs — only
+# sharing a RUN instruction shares the cache decision. It guards the first download
+# here and the agent installs further down; the curl-based steps in between fail in
+# seconds with their own resolver error, so they are left alone.
+COPY scripts/check-build-dns.sh /usr/local/bin/check-build-dns.sh
+RUN chmod +x /usr/local/bin/check-build-dns.sh
+
+RUN check-build-dns.sh && apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates curl gnupg openssh-client git zsh jq python3 build-essential iptables sudo unzip locales \
     libpulse0 pulseaudio-utils alsa-utils libasound2-plugins sox \
     && rm -rf /var/lib/apt/lists/*
@@ -22,6 +30,7 @@ RUN printf 'pcm.!default { type pulse }\nctl.!default { type pulse }\n' > /etc/a
 # Copy packages.txt if it exists (wildcard allows missing file)
 COPY packages.tx[t] /tmp/
 RUN if [ -f /tmp/packages.txt ]; then \
+        check-build-dns.sh && \
         apt-get update && \
         sed 's/#.*//' /tmp/packages.txt | grep -v '^[[:space:]]*$' | \
         xargs -r apt-get install -y --no-install-recommends && \
@@ -95,7 +104,13 @@ RUN curl -fsSL https://claude.ai/install.sh | bash -s "${CLAUDE_CODE_VERSION}"
 # platform binary — that postinstall hard-exits 1 on a failed fetch, and this
 # layer re-runs on every `djinn update` (ARG bump). Hardens the unattended
 # build against transient registry/CDN hiccups without slowing runtime npm.
-RUN eval "$(fnm env --shell bash)" && \
+# The guard shares this RUN on purpose: this is the layer a `djinn update` bump
+# invalidates while everything above stays cached, and the layer whose failure mode is
+# pathological -- six retries per package with a backoff, measured at 70 minutes
+# before npm gave up. In the same instruction it cannot be cached away from the
+# install it protects.
+RUN check-build-dns.sh && \
+    eval "$(fnm env --shell bash)" && \
     NPM_CONFIG_FETCH_RETRIES=5 NPM_CONFIG_FETCH_RETRY_MAXTIMEOUT=120000 \
     npm install -g \
     typescript \

--- a/IMPLEMENTATION.md
+++ b/IMPLEMENTATION.md
@@ -153,6 +153,9 @@ producer:
   also gates command and CLI modules against literal Rich color usage: palette
   hex values must appear once in `theme.py`, and command/CLI Python files must
   not introduce literal hex colors or named Rich color style literals.
+- The build path is the one exception to captured output: it inherits the child's
+  streams (see "Image Build"), so `print_captured()` does not apply there — the
+  output never passes through Rich.
 - `core/console.py` defines `console` for stdout and `err_console` for stderr.
   Operational UI helpers (`success()`, `error()`, `warning()`, `info()`,
   `status_line()`, `blank()`, `header()`, and `rule()`) print through
@@ -200,6 +203,12 @@ Shell UI consumers include `scripts/entrypoint.sh`, `scripts/mcp-register.sh`,
 - `resources: ResourceLimits`
 - `shell: ShellConfig`
 - `config_sync: ConfigSyncConfig`
+- `build: BuildConfig`: `network: BuildNetwork` (`default` | `host`, default
+  `default`) — reaches compose as `DJINN_BUILD_NETWORK`, which
+  `docker-compose.yml` interpolates into `build.network`. `host` trades the
+  build's network isolation for the host's resolver path. Buildkit's third mode,
+  `none`, is not offered: no layer of this image builds without a network. A named
+  network buildkit rejects itself.
 
 `ResourceLimits` defaults are:
 
@@ -679,6 +688,40 @@ creates empty zone targets; `doctor` reports unmigrated paths, collisions, drift
 permission drift, and large direct files that cannot safely be overlaid.
 
 ## Image Build
+
+The Dockerfile refuses a build network it cannot resolve names on:
+`scripts/check-build-dns.sh`, invoked *inside* the network-dependent `RUN`
+instructions rather than in a layer of its own — the base `apt-get`, the optional
+`packages.txt` install, and the global `npm install`. A guard in its own layer
+would be cache-independent of the download it protects: it can stay cached while
+the download re-runs. Sharing the instruction is what makes them share the cache
+decision, which matters most for the npm layer, since a `djinn update` version bump
+invalidates exactly that layer while everything above it stays cached. The
+curl-based steps in between are deliberately unguarded: they fail in seconds with
+their own resolver error, so the guard would add noise without adding information.
+One script, so the check and its message have a single home; it uses `getent`,
+which ships with glibc and therefore works on the bare base image. Without the
+guard the failure surfaced one timeout at a time: measured at 70 minutes for the
+npm layer, because npm retries every package six times with a backoff, and over
+two minutes for `apt-get update` alone.
+
+The build streams. `compose_build()` runs compose through `_run_streamed()`
+instead of `_run_captured()`, so stdout and stderr are inherited and the log
+appears while the build runs rather than after it exits. It passes
+`--progress plain` — a *global* compose flag, therefore placed before the
+subcommand — so every stage line stays on screen instead of being redrawn in
+place, and the stage a stalled build last entered remains readable. Setting
+`DJINN_BUILD_PROGRESS` to another compose progress mode overrides that; an
+unusable value falls back to `plain` with a warning rather than letting compose
+reject the build over a typo.
+
+The streamed `RunResult` carries no output: the log already went to the terminal,
+and `commands/container.py build()` therefore points the reader upwards on
+failure instead of reprinting. The exception is a spawn failure, where the
+process never ran — there `stderr` holds the 126/127 diagnosis and is printed.
+Streaming has no timeout: killing the compose client would leave `docker-buildx`
+and the BuildKit solve in the daemon running, so a timeout here would report a
+cancellation it cannot perform.
 
 `Dockerfile` builds from `debian:bookworm-slim`. It installs base packages,
 audio client support, optional packages from `packages.txt`, Docker CLI,

--- a/README.md
+++ b/README.md
@@ -182,9 +182,29 @@ Supported `djinn config set` keys are:
 | `shell.skip_mounts` | Skip host shell config mounts | `false` |
 | `shell.omp_theme_path` | Optional Oh My Posh theme file mounted read-only | unset |
 | `config_sync.source` | Native global workflow source: `claude`, `codex`, or `opencode` | `claude` |
+| `build.network` | Network for image-build steps: `default` or `host` | `default` |
 
 Memory values must use Docker-style units such as `8G`, `4096M`, or `512K`.
 CPU values are positive integers. Reservations cannot exceed limits.
+
+`build.network` stays at `default` on an ordinary Docker host. Set it to `host`
+when your container DNS server is reachable from one Docker network only — a VPN
+or split-DNS setup, for instance, where a resolver listens on one bridge while
+builds run on another and resolve nothing there. The build then resolves through
+the resolver the host itself uses, which keeps DNS on its intended path instead of
+bypassing it.
+
+**Understand the trade-off before setting it.** `host` removes the build's network
+isolation: every `RUN` step in the Dockerfile shares the host's network namespace
+and can reach host-local services, including anything bound to loopback. It
+applies to the whole build, not one step, so enable it only for a Dockerfile you
+trust. It changes nothing about the resulting image or about how containers run
+afterwards — only how build steps reach the network.
+
+`djinn build` refuses early with this hint when it detects the situation, instead
+of letting each download time out in turn. Buildkit also accepts `none`, which
+`djinn` does not offer: no layer of this image can be built without a network. A
+named Docker network is rejected by buildkit itself.
 
 `DJINN_CONFIG_ROOT` is not something you normally have to export. The CLI loads
 `config.toml` and injects Compose interpolation variables, including

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -85,6 +85,12 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
+      # `default` on an ordinary host. `host` is the escape hatch for a host whose
+      # container DNS resolver is reachable from only one Docker network: builds run
+      # on another one and resolve nothing there. Set it via `djinn config set
+      # build.network host` — build steps then share the host's network namespace.
+      # Buildkit takes default/host/none, never a named network.
+      network: ${DJINN_BUILD_NETWORK:-default}
     image: djinn-in-a-box:latest
     container_name: djinn
     hostname: djinn

--- a/scripts/check-build-dns.sh
+++ b/scripts/check-build-dns.sh
@@ -1,0 +1,35 @@
+#!/bin/sh
+# Refuse a build network that cannot resolve names, before anything tries to download.
+#
+# Without this the failure surfaces one timeout at a time. Measured on this project:
+# a 70-minute build that ended in `EAI_AGAIN`, because npm retries every package six
+# times with a backoff before giving up; `apt-get update` on a nameless network takes
+# over two minutes on its own. Neither says what to do about it.
+#
+# `getent` ships with glibc, so this runs on the bare base image before any install.
+set -eu
+
+if getent hosts registry.npmjs.org > /dev/null 2>&1; then
+    exit 0
+fi
+
+cat >&2 << 'MSG'
+
+ERROR: this build's network cannot resolve registry.npmjs.org.
+
+Every download below would retry for minutes and then fail.
+
+If the container DNS server on this host is reachable from one Docker network
+only -- a VPN or split-DNS setup, say, where a resolver listens on one bridge
+while builds run on another -- then build on the host's network stack:
+
+    djinn config set build.network host
+
+That keeps DNS on the path the host itself uses instead of bypassing it. Note
+the trade-off: build steps then share the host's network namespace, so they can
+reach host-local services. Use it only with a Dockerfile you trust.
+
+Otherwise check the Docker daemon's DNS configuration.
+
+MSG
+exit 1

--- a/src/djinn_in_a_box/commands/config.py
+++ b/src/djinn_in_a_box/commands/config.py
@@ -18,6 +18,7 @@ from rich.text import Text
 from djinn_in_a_box.config.loader import load_config, save_config
 from djinn_in_a_box.config.models import (
     AppConfig,
+    BuildConfig,
     ConfigSyncConfig,
     ResourceLimits,
     ShellConfig,
@@ -55,6 +56,7 @@ ALLOWED_CONFIG_KEYS: tuple[str, ...] = (
     "shell.skip_mounts",
     "shell.omp_theme_path",
     "config_sync.source",
+    "build.network",
 )
 _LOCK_PROBLEM_IDENTIFIER = "canonical-lock-failed"
 
@@ -292,6 +294,7 @@ def _build_config(
     resources: ResourceLimits | None = None,
     shell: ShellConfig | None = None,
     config_sync: ConfigSyncConfig | None = None,
+    build: BuildConfig | None = None,
 ) -> AppConfig:
     return AppConfig(
         code_dir=config.code_dir if code_dir is None else code_dir,
@@ -302,6 +305,7 @@ def _build_config(
         resources=config.resources if resources is None else resources,
         shell=config.shell if shell is None else shell,
         config_sync=config.config_sync if config_sync is None else config_sync,
+        build=config.build if build is None else build,
     )
 
 
@@ -386,6 +390,9 @@ def _set_config_value(config: AppConfig, key: str, value: str) -> AppConfig:
     if key == "config_sync.source":
         config_sync = ConfigSyncConfig.model_validate({"source": value})
         return _build_config(config, config_sync=config_sync)
+    if key == "build.network":
+        build = BuildConfig.model_validate({"network": value.strip().lower()})
+        return _build_config(config, build=build)
 
     error(f"Unknown configuration key: {key}")
     error(f"Allowed keys: {_allowed_keys_message()}")
@@ -417,6 +424,8 @@ def _format_config_value(config: AppConfig, key: str) -> str:
         return str(config.shell.omp_theme_path)
     if key == "config_sync.source":
         return config.config_sync.source
+    if key == "build.network":
+        return config.build.network
 
     msg = f"Unknown configuration key: {key}"
     raise ValueError(msg)
@@ -567,6 +576,9 @@ def config_show(
             "Config Sync",
             [("source", config.config_sync.source)],
         )
+        console.print()
+
+        _print_config_table("Build", [("network", config.build.network)])
 
 
 def config_path() -> None:

--- a/src/djinn_in_a_box/commands/container.py
+++ b/src/djinn_in_a_box/commands/container.py
@@ -164,9 +164,15 @@ def build(
         blank()
         success("Done! Run 'djinn start' to begin.")
     else:
+        blank()
         error(f"Build failed with exit code {result.returncode}")
+        # The build streams, so its log is already above this line — reprinting is
+        # not possible and not wanted. `stderr` is only populated when the compose
+        # binary could not be started at all, and that diagnosis exists nowhere else.
         if result.stderr:
             print_captured(result.stderr)
+        else:
+            info("The failing step's output is above.")
         raise typer.Exit(result.returncode)
 
 

--- a/src/djinn_in_a_box/config/models.py
+++ b/src/djinn_in_a_box/config/models.py
@@ -153,6 +153,36 @@ class ConfigSyncConfig(BaseModel):
     """Native workflow tree used as the single source of truth."""
 
 
+BuildNetwork = Literal["default", "host"]
+"""Build-step networks djinn offers.
+
+Buildkit also accepts ``none``, under which every network-dependent layer of this
+image would fail — that is a way to break a build, not to configure one, so it is
+left out. A *named* network buildkit rejects itself.
+"""
+
+
+class BuildConfig(BaseModel):
+    """Image-build settings."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    network: BuildNetwork = "default"
+    """Network for build steps (compose ``build.network``).
+
+    ``default`` suits an ordinary Docker host. ``host`` exists for a host whose
+    container DNS server is reachable from one Docker network only — a VPN or
+    split-DNS setup, say, where a resolver listens on one bridge while builds run
+    on another and can resolve nothing there. Building on the host stack then uses
+    the resolver the host itself uses, which keeps DNS on its intended path rather
+    than bypassing it.
+
+    The trade-off is why it stays opt-in: build steps then share the host's network
+    namespace and can reach host-local services, so it belongs only to a Dockerfile
+    you trust. Set it with ``djinn config set build.network host``.
+    """
+
+
 class AppConfig(BaseModel):
     """Main application configuration for Djinn in a Box.
 
@@ -186,6 +216,9 @@ class AppConfig(BaseModel):
 
     config_sync: ConfigSyncConfig = Field(default_factory=ConfigSyncConfig)
     """Agent workflow synchronization configuration."""
+
+    build: BuildConfig = Field(default_factory=BuildConfig)
+    """Image-build settings."""
 
     @field_validator("timezone", mode="after")
     @classmethod

--- a/src/djinn_in_a_box/core/docker.py
+++ b/src/djinn_in_a_box/core/docker.py
@@ -15,7 +15,7 @@ import tempfile
 from dataclasses import dataclass
 from enum import Enum
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Final
 
 if TYPE_CHECKING:
     from djinn_in_a_box.config.models import AppConfig
@@ -328,6 +328,39 @@ def _run_captured(
         return RunResult(returncode=126, stdout="", stderr=f"Permission denied: {e}")
 
 
+def _run_streamed(
+    cmd: list[str], *, cwd: Path | None = None, env: dict[str, str] | None = None,
+) -> RunResult:
+    """Run a subprocess with stdout/stderr *inherited*, so its output is live.
+
+    The build path needs this: a captured build reveals nothing until the process
+    exits, which is precisely when a stalled build tells you nothing at all. The
+    child writes straight to this process's terminal instead.
+
+    Consequences the caller must know:
+
+    - ``RunResult.stdout``/``stderr`` are empty when the process actually ran —
+      the output already went to the terminal, there is nothing left to hand back.
+      The two spawn failures below are the exception: there `stderr` carries the
+      only diagnosis that exists.
+    - No ``timeout``. ``subprocess.run`` would kill only this direct child, not its
+      process group and not a BuildKit solve already running in the daemon, so a
+      timeout here would report a cancellation it cannot actually perform.
+    - ``stdin`` is closed: an inherited terminal descriptor lets a subprocess block
+      on a prompt, and on this path that prompt is indistinguishable from a hang.
+    - No ``text=True``: nothing is decoded here, because nothing is captured.
+    """
+    try:
+        result = subprocess.run(
+            cmd, stdin=subprocess.DEVNULL, cwd=cwd, env=env, check=False,
+        )
+        return RunResult(returncode=result.returncode)
+    except FileNotFoundError as e:
+        return RunResult(returncode=127, stdout="", stderr=f"Command not found: {e}")
+    except PermissionError as e:
+        return RunResult(returncode=126, stdout="", stderr=f"Permission denied: {e}")
+
+
 def _decode_timeout_output(
     exc: subprocess.TimeoutExpired,
     timeout: int,
@@ -448,21 +481,30 @@ def _run_compose(
     config: AppConfig | None,
     cwd: Path,
     extra_env: dict[str, str] | None = None,
+    stream: bool = False,
 ) -> RunResult:
-    """Single choke-point for *captured* ``docker compose`` calls.
+    """Single choke-point for non-interactive ``docker compose`` calls.
 
-    Every captured compose invocation routes through here so the host
-    interpolation env is always injected. (The interactive/headless path in
-    ``compose_run`` is the only other sanctioned compose site.)
+    Every such compose invocation routes through here so the host interpolation
+    env is always injected. (The interactive/headless path in ``compose_run`` is
+    the only other sanctioned compose site.)
 
     ``extra_env`` carries values a subcommand cannot pass as a flag — ``up`` has
     no per-invocation ``-e`` — and is layered on top of the host bridge, never
     replacing it.
+
+    ``stream=True`` inherits stdout/stderr instead of capturing them, for a
+    long-running subcommand whose progress must be visible while it runs. It
+    returns empty ``stdout``/``stderr`` — see ``_run_streamed``. Callers that
+    parse output must leave it at the default.
     """
     env = _compose_host_env(config)
     if extra_env:
         env.update(extra_env)
-    return _run_captured(["docker", "compose", *args], cwd=cwd, env=env)
+    cmd = ["docker", "compose", *args]
+    if stream:
+        return _run_streamed(cmd, cwd=cwd, env=env)
+    return _run_captured(cmd, cwd=cwd, env=env)
 
 
 def get_shell_mount_args(config: AppConfig) -> list[str]:
@@ -733,12 +775,50 @@ def validate_container_mounts(
         )
 
 
+_COMPOSE_PROGRESS_MODES: Final[frozenset[str]] = frozenset(
+    {"auto", "tty", "plain", "quiet", "json"}
+)
+BUILD_PROGRESS_ENV: Final[str] = "DJINN_BUILD_PROGRESS"
+
+
+def _build_progress() -> str:
+    """Progress renderer for the build, ``plain`` unless overridden.
+
+    ``plain`` is the default because it keeps every stage line on screen, which is
+    what makes a stalled build readable. Someone who wants the compact redrawing
+    view back can set the env var; an unusable value falls back rather than
+    letting compose reject the whole build over a typo.
+    """
+    requested = os.environ.get(BUILD_PROGRESS_ENV)
+    if requested is None:
+        return "plain"
+    if requested not in _COMPOSE_PROGRESS_MODES:
+        warning(
+            f"Ignoring {BUILD_PROGRESS_ENV}={requested!r}: "
+            f"expected one of {', '.join(sorted(_COMPOSE_PROGRESS_MODES))}."
+        )
+        return "plain"
+    return requested
+
+
 def compose_build(config: AppConfig | None = None, *, no_cache: bool = False) -> RunResult:
+    """Build the image, streaming progress to the terminal as it happens.
+
+    ``--progress plain`` is the deliberate default, overridable via
+    ``DJINN_BUILD_PROGRESS``: it keeps every stage line
+    on screen instead of redrawing one in place, so the stage a stalled build last
+    entered stays readable. It is a *global* compose flag and must precede the
+    subcommand — passing it after ``build`` still works but earns a deprecation
+    warning from compose.
+
+    Streaming means the returned ``RunResult`` carries no output. The build log was
+    already on the terminal; there is nothing to print afterwards.
+    """
     project_root = get_project_root()
-    args = ["build"]
+    args = ["--progress", _build_progress(), "build"]
     if no_cache:
         args.append("--no-cache")
-    return _run_compose(args, config=config, cwd=project_root)
+    return _run_compose(args, config=config, cwd=project_root, stream=True)
 
 
 BACKGROUND_START_ERROR = (

--- a/src/djinn_in_a_box/core/docker.py
+++ b/src/djinn_in_a_box/core/docker.py
@@ -1031,6 +1031,7 @@ def compose_up_detached(
     dbus_args = _canonicalize_runtime_mount_args(
         get_dbus_mount_args() if dbus_mount_args is None else dbus_mount_args
     )
+    zone_overlay_args, zone_overlay_targets = _zone_overlay_mount_args_and_targets(config)
     validate_container_mounts(
         mounts,
         config,
@@ -1038,6 +1039,7 @@ def compose_up_detached(
         shell_args=shell_args,
         audio_args=audio_args,
         dbus_args=dbus_args,
+        zone_overlay_targets=zone_overlay_targets,
     )
 
     volume_specs: list[str] = []
@@ -1047,6 +1049,12 @@ def compose_up_detached(
         if mount.read_only:
             spec += ":ro"
         volume_specs.append(spec)
+    # The overlays are reserved targets above, so they must also be mounted here:
+    # `up` has no per-invocation `-v`, and a container started without them shows
+    # every migrated zone path as missing. Docker then creates each absent target
+    # as root — inside the config-root bind that carries their parent, so they
+    # land on the host — and the migrated data stays invisible behind them.
+    volume_specs.extend(_volume_specs_from_mount_args(zone_overlay_args))
     runtime_args = [*shell_args, *audio_args, *dbus_args]
     volume_specs.extend(_volume_specs_from_mount_args(runtime_args))
     # The `-e` half of those same pairs has to ride along, or the sockets are

--- a/src/djinn_in_a_box/core/docker.py
+++ b/src/djinn_in_a_box/core/docker.py
@@ -464,6 +464,7 @@ def build_compose_env(config: AppConfig | None) -> dict[str, str]:
             "MEMORY_LIMIT": config.resources.memory_limit,
             "CPU_RESERVATION": str(config.resources.cpu_reservation),
             "MEMORY_RESERVATION": config.resources.memory_reservation,
+            "DJINN_BUILD_NETWORK": config.build.network,
         }
     if terminal_width is not None:
         env["DJINN_TERM_WIDTH"] = terminal_width

--- a/tests/test_commands/test_config.py
+++ b/tests/test_commands/test_config.py
@@ -1,0 +1,49 @@
+"""Tests for `djinn config set/get` handling of build settings."""
+
+from pathlib import Path
+
+import pytest
+
+from djinn_in_a_box.commands.config import (
+    ALLOWED_CONFIG_KEYS,
+    _format_config_value,
+    _set_config_value,
+)
+from djinn_in_a_box.config.models import AppConfig, BuildConfig
+
+
+@pytest.fixture
+def config(tmp_path: Path) -> AppConfig:
+    return AppConfig(code_dir=tmp_path)
+
+
+class TestBuildNetworkKey:
+    """`build.network` is the opt-in for hosts whose build network has no DNS."""
+
+    def test_key_is_settable(self) -> None:
+        assert "build.network" in ALLOWED_CONFIG_KEYS
+
+    def test_set_then_read_back(self, config: AppConfig) -> None:
+        updated = _set_config_value(config, "build.network", "host")
+        assert updated.build.network == "host"
+        assert _format_config_value(updated, "build.network") == "host"
+
+    def test_value_is_normalized(self, config: AppConfig) -> None:
+        assert _set_config_value(config, "build.network", "  HOST  ").build.network == "host"
+
+    def test_named_network_is_refused(self, config: AppConfig) -> None:
+        # Compose would interpolate it happily; buildkit refuses it mid-build.
+        with pytest.raises(Exception, match="network"):
+            _set_config_value(config, "build.network", "djinn-network")
+
+    def test_unrelated_set_preserves_it(self, tmp_path: Path) -> None:
+        """Setting any other key must not silently reset this one.
+
+        `_build_config` rebuilds the whole `AppConfig`, so a field it forgets to
+        carry over reverts to its default without a word — and the next build
+        would fail exactly the way this setting exists to prevent.
+        """
+        config = AppConfig(code_dir=tmp_path, build=BuildConfig(network="host"))
+        after = _set_config_value(config, "general.timezone", "Europe/Berlin")
+        assert after.timezone == "Europe/Berlin"
+        assert after.build.network == "host"

--- a/tests/test_commands/test_container.py
+++ b/tests/test_commands/test_container.py
@@ -82,6 +82,29 @@ class TestBuildCommand:
         assert "[dev 3/25]" in captured
         assert "[internal]" in captured
 
+    def test_build_failure_without_captured_output_points_at_the_streamed_log(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """A streamed build has already printed its log; there is nothing to reprint.
+
+        The empty `stderr` is the normal case now, so the failure message must send
+        the reader upwards instead of trailing off after the exit code.
+        """
+        with (
+            patch("djinn_in_a_box.commands.container.load_config"),
+            patch("djinn_in_a_box.commands.container.preflight"),
+            patch("djinn_in_a_box.commands.container._sync_build_files"),
+            patch("djinn_in_a_box.commands.container.compose_build") as mock_build,
+        ):
+            mock_build.return_value = RunResult(returncode=1)
+
+            with pytest.raises(typer.Exit):
+                container.build()
+
+        captured = capsys.readouterr().err
+        assert "exit code 1" in captured
+        assert "above" in captured
+
     def test_sync_build_files_uses_config_root_from_config_file(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:

--- a/tests/test_config_models.py
+++ b/tests/test_config_models.py
@@ -7,6 +7,8 @@ from pydantic import ValidationError
 
 from djinn_in_a_box.config.models import (
     AppConfig,
+    BuildConfig,
+    BuildNetwork,
     ConfigSyncConfig,
     ResourceLimits,
     ShellConfig,
@@ -144,3 +146,24 @@ class TestAppConfig:
         config = AppConfig.model_validate(data)
         assert config.resources.cpu_limit == 4
         assert config.shell.skip_mounts is True
+
+
+class TestBuildNetwork:
+    """BuildKit accepts default/host/none only — a named network is rejected."""
+
+    def test_default_is_conservative(self, tmp_path: Path) -> None:
+        assert AppConfig(code_dir=tmp_path).build.network == "default"
+
+    @pytest.mark.parametrize("mode", ["default", "host"])
+    def test_accepts_the_offered_modes(self, tmp_path: Path, mode: BuildNetwork) -> None:
+        assert AppConfig(code_dir=tmp_path, build=BuildConfig(network=mode)).build.network == mode
+
+    @pytest.mark.parametrize("mode", ["djinn-network", "none", "", "HOST"])
+    def test_rejects_everything_else(self, mode: str) -> None:
+        """Values arrive from untyped TOML, so validation is the only gate.
+
+        `none` is refused deliberately: buildkit accepts it, but no layer of this
+        image can be built without a network. A named network buildkit itself refuses.
+        """
+        with pytest.raises(ValidationError):
+            BuildConfig.model_validate({"network": mode})

--- a/tests/test_docker.py
+++ b/tests/test_docker.py
@@ -2257,6 +2257,45 @@ class TestComposeUpDetached:
 
     @patch("djinn_in_a_box.core.docker.get_project_root")
     @patch("djinn_in_a_box.core.docker.subprocess.run")
+    def test_carries_the_zone_overlays_like_the_foreground_path(
+        self,
+        mock_run: MagicMock,
+        mock_root: MagicMock,
+        mock_app_config: AppConfig,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Reserving a zone target without mounting it hides the migrated data.
+
+        The foreground path appends these overlays; this path builds its own
+        volume list, so a divergence starts the container with every migrated
+        zone path unmounted — the entrypoint then recreates them empty and the
+        agent state looks lost.
+        """
+        self._without_runtime_mounts(monkeypatch)
+        zones_file = mock_app_config.config_root.parent / "zones.toml"
+        monkeypatch.setattr(zones_mod, "ZONES_FILE", zones_file)
+        mock_root.return_value = Path("/project")
+        shared_source = Path(f"{mock_app_config.config_root}.shared") / "claude" / "projects"
+        shared_source.mkdir(parents=True)
+        local_source = Path(f"{mock_app_config.config_root}.local") / "claude" / "jobs"
+        local_source.mkdir(parents=True)
+        payload: dict[str, object] = {}
+
+        def _read_override(cmd: list[str], **_kwargs: object) -> MagicMock:
+            override = Path(next(arg for arg in cmd if "djinn-detach-" in arg))
+            payload.update(json.loads(override.read_text()))
+            return MagicMock(returncode=0, stdout="", stderr="")
+
+        mock_run.side_effect = _read_override
+
+        compose_up_detached(mock_app_config, ContainerOptions())
+
+        service = payload["services"]["dev"]  # type: ignore[index]
+        assert f"{shared_source}:/home/dev/.claude/projects" in service["volumes"]
+        assert f"{local_source}:/home/dev/.claude/jobs" in service["volumes"]
+
+    @patch("djinn_in_a_box.core.docker.get_project_root")
+    @patch("djinn_in_a_box.core.docker.subprocess.run")
     def test_carries_the_env_half_of_the_runtime_mount_pairs(
         self,
         mock_run: MagicMock,

--- a/tests/test_docker.py
+++ b/tests/test_docker.py
@@ -1216,6 +1216,137 @@ class TestComposeBuild:
         assert "--no-cache" in cmd
 
 
+class TestStreamedBuildPath:
+    """`djinn build` streams: the log must appear while the build runs.
+
+    A captured build says nothing until the process exits — which is precisely the
+    moment a stalled build has nothing left to tell you. These pin the streaming
+    contract and the result contract that comes with it.
+    """
+
+    @patch("djinn_in_a_box.core.docker.get_project_root", return_value=Path("/project"))
+    @patch("djinn_in_a_box.core.docker.subprocess.run")
+    def test_build_inherits_stdio_and_returns_no_output(
+        self, mock_run: MagicMock, _root: MagicMock
+    ) -> None:
+        mock_run.return_value = MagicMock(returncode=0)
+        result = compose_build()
+        kwargs = mock_run.call_args.kwargs
+        # Nothing may be piped: any redirection puts the log back into a buffer.
+        assert "capture_output" not in kwargs
+        assert "stdout" not in kwargs
+        assert "stderr" not in kwargs
+        # An inherited terminal stdin lets a prompt masquerade as a hang.
+        assert kwargs["stdin"] == subprocess.DEVNULL
+        # The log already went to the terminal, so the result carries none of it.
+        assert result.stdout == ""
+        assert result.stderr == ""
+
+    @patch("djinn_in_a_box.core.docker.get_project_root", return_value=Path("/project"))
+    @patch("djinn_in_a_box.core.docker.subprocess.run")
+    def test_missing_docker_binary_keeps_exit_code_127(
+        self, mock_run: MagicMock, _root: MagicMock
+    ) -> None:
+        """Streaming must not cost the spawn-failure contract of the captured path.
+
+        Here `stderr` is load-bearing rather than empty: no process ever ran, so the
+        terminal holds nothing and this is the only place the diagnosis exists.
+        """
+        mock_run.side_effect = FileNotFoundError("docker")
+        result = compose_build()
+        assert result.returncode == 127
+        assert "Command not found" in result.stderr
+
+    @patch("djinn_in_a_box.core.docker.get_project_root", return_value=Path("/project"))
+    @patch("djinn_in_a_box.core.docker.subprocess.run")
+    def test_unexecutable_docker_binary_keeps_exit_code_126(
+        self, mock_run: MagicMock, _root: MagicMock
+    ) -> None:
+        mock_run.side_effect = PermissionError("docker")
+        result = compose_build()
+        assert result.returncode == 126
+        assert "Permission denied" in result.stderr
+
+    @patch("djinn_in_a_box.core.docker.get_project_root", return_value=Path("/project"))
+    @patch("djinn_in_a_box.core.docker.subprocess.run")
+    def test_progress_flag_precedes_the_subcommand(
+        self, mock_run: MagicMock, _root: MagicMock
+    ) -> None:
+        """`--progress` is a *global* compose flag, so its position is load-bearing.
+
+        Passed after `build` it still works, but compose answers with a deprecation
+        warning — noise this path exists to avoid.
+        """
+        mock_run.return_value = MagicMock(returncode=0)
+        compose_build()
+        argv = mock_run.call_args.args[0]
+        assert argv[:5] == ["docker", "compose", "--progress", "plain", "build"]
+
+    @patch("djinn_in_a_box.core.docker.get_project_root", return_value=Path("/project"))
+    @patch("djinn_in_a_box.core.docker.subprocess.run")
+    def test_streamed_build_still_bridges_the_host_env(
+        self,
+        mock_run: MagicMock,
+        _root: MagicMock,
+        mock_app_config: AppConfig,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """The env bridge must survive the change of execution helper."""
+        monkeypatch.setenv("CODE_DIR", "/stale/from/shell")
+        mock_run.return_value = MagicMock(returncode=0)
+        compose_build(mock_app_config)
+        env = mock_run.call_args.kwargs["env"]
+        assert env["CODE_DIR"] == str(mock_app_config.code_dir)
+
+    @patch("djinn_in_a_box.core.docker.is_own_container", return_value=False)
+    @patch("djinn_in_a_box.core.docker.get_project_root", return_value=Path("/project"))
+    @patch("djinn_in_a_box.core.docker.subprocess.run")
+    def test_only_the_build_streams(
+        self,
+        mock_run: MagicMock,
+        _root: MagicMock,
+        _own: MagicMock,
+        mock_app_config: AppConfig,
+    ) -> None:
+        """Streaming is opt-in per call site, and only `build` opts in.
+
+        Every other compose subcommand has callers that read its output, so the
+        default must stay captured — this pins the branch, not just the helper.
+        """
+        mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+        compose_down(mock_app_config)
+        assert mock_run.call_args.kwargs["capture_output"] is True
+
+
+class TestBuildProgressOverride:
+    """`plain` is the default, but it must not be a cage."""
+
+    @patch("djinn_in_a_box.core.docker.get_project_root", return_value=Path("/project"))
+    @patch("djinn_in_a_box.core.docker.subprocess.run")
+    def test_override_is_honored(
+        self, mock_run: MagicMock, _root: MagicMock, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("DJINN_BUILD_PROGRESS", "tty")
+        mock_run.return_value = MagicMock(returncode=0)
+        compose_build()
+        assert mock_run.call_args.args[0][:4] == ["docker", "compose", "--progress", "tty"]
+
+    @patch("djinn_in_a_box.core.docker.get_project_root", return_value=Path("/project"))
+    @patch("djinn_in_a_box.core.docker.subprocess.run")
+    def test_unusable_value_falls_back_instead_of_failing_the_build(
+        self, mock_run: MagicMock, _root: MagicMock, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A typo must not cost the whole build: compose would reject the flag."""
+        monkeypatch.setenv("DJINN_BUILD_PROGRESS", "plian")
+        mock_run.return_value = MagicMock(returncode=0)
+        with patch("djinn_in_a_box.core.docker.warning") as mock_warning:
+            compose_build()
+        assert mock_run.call_args.args[0][:4] == ["docker", "compose", "--progress", "plain"]
+        # A silent fallback would leave the user believing the override took effect.
+        mock_warning.assert_called_once()
+        assert "plian" in mock_warning.call_args.args[0]
+
+
 class TestComposeRun:
     """Tests for compose_run function."""
 

--- a/tests/test_docker.py
+++ b/tests/test_docker.py
@@ -1347,6 +1347,67 @@ class TestBuildProgressOverride:
         assert "plian" in mock_warning.call_args.args[0]
 
 
+class TestDockerfileDnsGuard:
+    """The build must refuse a network it cannot resolve names on.
+
+    Without this the agent installs discover the failure one timeout at a time —
+    measured once at 70 minutes before npm gave up.
+    """
+
+    @staticmethod
+    def _dockerfile() -> str:
+        return (Path(__file__).parents[1] / "Dockerfile").read_text()
+
+    @staticmethod
+    def _run_instructions() -> list[str]:
+        """The Dockerfile's RUN instructions, each with its continuations joined.
+
+        Layer boundaries are what matter here, so line continuations must be folded
+        back into one string — a guard on the next physical line is in the same
+        instruction, a guard in the next RUN is not.
+        """
+        text = (Path(__file__).parents[1] / "Dockerfile").read_text()
+        joined = text.replace("\\\n", " ")
+        # Indented or lower-case RUN is still a RUN; matching the literal prefix only
+        # would let a renamed-but-real layer slip past this whole check.
+        return [line for line in joined.splitlines() if re.match(r"^\s*RUN\s+", line, re.I)]
+
+    def test_guard_shares_the_run_of_every_layer_it_protects(self) -> None:
+        """The guard must sit *inside* the download's instruction, not before it.
+
+        A guard in its own layer can stay cached while the download below re-runs —
+        only sharing a RUN shares the cache decision. `npm install -g` is the layer
+        that matters most: a `djinn update` bump invalidates it while everything
+        above stays cached, and its failure mode cost 70 minutes.
+        """
+        instructions = self._run_instructions()
+        assert instructions, "no RUN instructions parsed — has the Dockerfile moved?"
+        for needle in ("apt-get update", "npm install -g"):
+            owners = [i for i in instructions if needle in i]
+            assert owners, f"{needle} vanished from the Dockerfile"
+            for owner in owners:
+                assert "check-build-dns.sh" in owner, (
+                    f"the RUN containing {needle!r} does not call the DNS guard, "
+                    "so it can be cached away from it"
+                )
+
+    def test_guard_runs_before_the_download_it_shares_a_layer_with(self) -> None:
+        # `guard && download` fails first; `download && guard` would be decoration.
+        for instruction in self._run_instructions():
+            if "check-build-dns.sh" not in instruction:
+                continue
+            for needle in ("apt-get update", "npm install -g"):
+                if needle in instruction:
+                    assert instruction.index("check-build-dns.sh") < instruction.index(needle)
+
+    def test_guard_names_the_escape_hatch_and_its_cost(self) -> None:
+        # A message that does not say what to do costs another debugging session —
+        # and one that hides the trade-off invites an uninformed `host`.
+        script = (Path(__file__).parents[1] / "scripts" / "check-build-dns.sh").read_text()
+        assert "djinn config set build.network host" in script
+        assert "host's network namespace" in script
+
+
 class TestComposeRun:
     """Tests for compose_run function."""
 

--- a/tests/test_ws0.py
+++ b/tests/test_ws0.py
@@ -20,7 +20,7 @@ import djinn_in_a_box.core.docker as docker_mod
 from djinn_in_a_box.commands import doctor as doctor_mod
 from djinn_in_a_box.config.defaults import SYNC_PATHS
 from djinn_in_a_box.config.loader import load_config, save_config
-from djinn_in_a_box.config.models import AppConfig
+from djinn_in_a_box.config.models import AppConfig, BuildConfig
 from djinn_in_a_box.core.docker import (
     ContainerOptions,
     DockerMode,
@@ -55,6 +55,26 @@ class TestBuildComposeEnv:
         # The two ${...:?}-guarded vars must always be present so compose never aborts.
         for key in _GUARDED:
             assert key in env and env[key]
+
+    def test_build_network_reaches_compose(self, mock_app_config: AppConfig) -> None:
+        """`build.network` is interpolated from this var, so the bridge must carry it."""
+        assert build_compose_env(mock_app_config)["DJINN_BUILD_NETWORK"] == "default"
+
+    def test_configured_build_network_wins(self, tmp_path: Path) -> None:
+        config = AppConfig(code_dir=tmp_path, build=BuildConfig(network="host"))
+        assert build_compose_env(config)["DJINN_BUILD_NETWORK"] == "host"
+
+    def test_compose_consumes_the_variable_this_bridge_produces(self) -> None:
+        """Both halves of the contract, pinned together.
+
+        Rendering the variable is worthless if the compose file spells it differently
+        or reads it in the wrong place — and neither half fails on its own. This
+        checks the name, the default, and that it lands on `build.network`.
+        """
+        compose = (Path(__file__).parents[1] / "docker-compose.yml").read_text()
+        assert "network: ${DJINN_BUILD_NETWORK:-default}" in compose
+        build_section = compose[compose.find("build:") : compose.find("image: djinn-in-a-box")]
+        assert "DJINN_BUILD_NETWORK" in build_section, "variable is not under build:"
 
 
 class TestComposeEnvBridge:

--- a/tools/installers/azure-cli.sh
+++ b/tools/installers/azure-cli.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+# djinn-verify: az version
+# Microsoft Azure CLI (installed via uv for persistence)
+set -e
+
+INSTALL_BIN="${TOOLS_BIN:-$HOME/.cache/djinn-tools/bin}"
+INSTALL_TOOLS="${TOOLS_DIR:-$HOME/.cache/djinn-tools}/uv-tools"
+
+mkdir -p "$INSTALL_BIN" "$INSTALL_TOOLS"
+
+# Install Azure CLI via uv tool
+# - Requires Python 3.12 (3.14 not yet supported due to deprecated APIs)
+# - Requires --prerelease=allow for beta dependencies (azure-batch etc.)
+# - Use --force to overwrite existing installation
+# - UV_PYTHON_INSTALL_DIR kept on tools-cache volume to avoid cross-volume symlink breakage
+#   on container recreation (ephemeral ~/.local/share/uv/python would otherwise break the venv)
+UV_TOOL_DIR="$INSTALL_TOOLS" UV_TOOL_BIN_DIR="$INSTALL_BIN" \
+UV_PYTHON_INSTALL_DIR="$TOOLS_DIR/python" \
+    uv tool install azure-cli --python 3.12 --prerelease=allow --force 2>&1 | tail -5
+
+"$INSTALL_BIN/az" version --output tsv | head -1

--- a/tools/installers/pulumi.sh
+++ b/tools/installers/pulumi.sh
@@ -9,10 +9,16 @@ INSTALL_BIN="${TOOLS_BIN:-$INSTALL_ROOT/bin}"
 
 mkdir -p "$INSTALL_BIN"
 
+# Guard the fetch of the install script so a stalled connection fails fast
+# instead of holding container startup until the kernel's retransmit timeout.
+CURL_GUARDS=(--connect-timeout 10 --max-time 60 --retry 3 --retry-delay 2)
+
 if [[ "$PULUMI_VERSION" == "latest" ]]; then
-    curl -fsSL https://get.pulumi.com | sh -s -- --install-root "$INSTALL_ROOT"
+    curl -fsSL "${CURL_GUARDS[@]}" https://get.pulumi.com \
+        | sh -s -- --install-root "$INSTALL_ROOT"
 else
-    curl -fsSL https://get.pulumi.com | sh -s -- --install-root "$INSTALL_ROOT" --version "$PULUMI_VERSION"
+    curl -fsSL "${CURL_GUARDS[@]}" https://get.pulumi.com \
+        | sh -s -- --install-root "$INSTALL_ROOT" --version "$PULUMI_VERSION"
 fi
 
 "$INSTALL_BIN/pulumi" version

--- a/tools/installers/pulumi.sh
+++ b/tools/installers/pulumi.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+# djinn-verify: pulumi version
+# Pulumi Infrastructure as Code CLI
+set -e
+
+PULUMI_VERSION="${PULUMI_VERSION:-latest}"
+INSTALL_ROOT="${TOOLS_DIR:-$HOME/.cache/djinn-tools}"
+INSTALL_BIN="${TOOLS_BIN:-$INSTALL_ROOT/bin}"
+
+mkdir -p "$INSTALL_BIN"
+
+if [[ "$PULUMI_VERSION" == "latest" ]]; then
+    curl -fsSL https://get.pulumi.com | sh -s -- --install-root "$INSTALL_ROOT"
+else
+    curl -fsSL https://get.pulumi.com | sh -s -- --install-root "$INSTALL_ROOT" --version "$PULUMI_VERSION"
+fi
+
+"$INSTALL_BIN/pulumi" version

--- a/tools/installers/sops.sh
+++ b/tools/installers/sops.sh
@@ -6,9 +6,17 @@ INSTALL_DIR="${TOOLS_BIN:-$HOME/.cache/djinn-tools/bin}"
 
 mkdir -p "$INSTALL_DIR"
 
+# A stalled transfer would otherwise hold startup until the kernel's retransmit
+# timeout fires (~15 min, observed at exactly half of the 52 MB binary).
+# --speed-time aborts the stall so --retry can start over. No --max-time here:
+# the binary is large and a slow line must not be mistaken for a hang.
+CURL_GUARDS=(--connect-timeout 10 --retry 4 --retry-delay 3
+             --speed-limit 2048 --speed-time 30)
+
 # Resolve version: use SOPS_VERSION env var, or fetch latest from GitHub
 if [[ -z "${SOPS_VERSION:-}" ]]; then
-    SOPS_VERSION=$(curl -fsSL "https://api.github.com/repos/getsops/sops/releases/latest" \
+    SOPS_VERSION=$(curl -fsSL "${CURL_GUARDS[@]}" --max-time 30 \
+        "https://api.github.com/repos/getsops/sops/releases/latest" \
         | grep '"tag_name"' | sed -E 's/.*"v([^"]+)".*/\1/')
 fi
 
@@ -17,9 +25,16 @@ if ! [[ "$SOPS_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
     exit 1
 fi
 
-# Download SOPS binary directly to persistent volume
-curl -fsSL "https://github.com/getsops/sops/releases/download/v${SOPS_VERSION}/sops-v${SOPS_VERSION}.linux.amd64" \
-    -o "$INSTALL_DIR/sops"
-chmod +x "$INSTALL_DIR/sops"
+# Stage in a temporary file in the same directory, then move into place: a
+# partial transfer must never be left behind as $INSTALL_DIR/sops.
+staged=$(mktemp "$INSTALL_DIR/.sops.XXXXXX")
+trap 'rm -f "$staged"' EXIT
+
+curl -fsSL "${CURL_GUARDS[@]}" \
+    "https://github.com/getsops/sops/releases/download/v${SOPS_VERSION}/sops-v${SOPS_VERSION}.linux.amd64" \
+    -o "$staged"
+chmod +x "$staged"
+mv "$staged" "$INSTALL_DIR/sops"
+trap - EXIT
 
 "$INSTALL_DIR/sops" --version

--- a/tools/installers/sops.sh
+++ b/tools/installers/sops.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+# SOPS - Secrets OPerationS (encrypted secrets management)
+set -e
+
+INSTALL_DIR="${TOOLS_BIN:-$HOME/.cache/djinn-tools/bin}"
+
+mkdir -p "$INSTALL_DIR"
+
+# Resolve version: use SOPS_VERSION env var, or fetch latest from GitHub
+if [[ -z "${SOPS_VERSION:-}" ]]; then
+    SOPS_VERSION=$(curl -fsSL "https://api.github.com/repos/getsops/sops/releases/latest" \
+        | grep '"tag_name"' | sed -E 's/.*"v([^"]+)".*/\1/')
+fi
+
+if ! [[ "$SOPS_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+    echo "sops: Invalid version format '${SOPS_VERSION}', skipping" >&2
+    exit 1
+fi
+
+# Download SOPS binary directly to persistent volume
+curl -fsSL "https://github.com/getsops/sops/releases/download/v${SOPS_VERSION}/sops-v${SOPS_VERSION}.linux.amd64" \
+    -o "$INSTALL_DIR/sops"
+chmod +x "$INSTALL_DIR/sops"
+
+"$INSTALL_DIR/sops" --version

--- a/tools/tools.txt.example
+++ b/tools/tools.txt.example
@@ -1,0 +1,33 @@
+# =============================================================================
+# Optional CLI Tools
+# =============================================================================
+# Tools listed here are installed at container startup (with caching).
+# One tool per line. Comments (#) and empty lines are ignored.
+#
+# Usage:
+#   cp tools/tools.txt.example tools/tools.txt
+#   # uncomment the tools you want
+#   djinn start
+#
+# Every entry needs a matching installer at tools/installers/<name>.sh —
+# otherwise startup reports "Unknown tool: <name> (no installer found)".
+#
+# Note: tools are cached in a Docker volume, so they are reinstalled only when
+# the cache check fails (see the djinn-verify convention in tools/install.sh).
+# =============================================================================
+
+# --- Cloud CLIs ---
+# azure-cli          # Microsoft Azure CLI (az)
+# pulumi             # Pulumi Infrastructure as Code CLI
+
+# --- Secrets ---
+# sops               # SOPS — encrypted secrets management
+
+# --- Database Clients ---
+# psql               # PostgreSQL client (psql, pg_dump, …)
+
+# --- Dev ---
+# bun                # Bun JavaScript runtime & toolkit
+
+# --- Browser Automation ---
+# playwright         # Playwright browser automation


### PR DESCRIPTION
## Summary

A `djinn update` followed by `djinn build` ran for 45 minutes with no output at
all, then failed. Two separate defects, both fixed here, plus the tool-installer
and zone-overlay work that had been sitting on unmerged branches.

**Why nothing was visible.** `compose_build()` captured the whole build through
`_run_captured()`, which returns only when the process exits — precisely when a
build that stopped making progress has nothing left to say. On failure `build()`
printed just `stderr` and discarded `stdout`, so even the lines naming the failing
step's cause were dropped. The build now inherits stdout/stderr and forces
`--progress plain`.

Deliberately **without** a timeout: `subprocess.run(timeout=…)` kills only the
compose client, not `docker-buildx` and not the BuildKit solve in the daemon, so a
timeout would report a cancellation it cannot perform.

**What actually failed.** With the log visible: `EAI_AGAIN` on every package. The
build network could not resolve names. On the affected host a resolver listens on
one Docker bridge (a VPN/split-DNS arrangement, so container DNS travels through
the tunnel instead of leaking past it) while buildkit builds on another and can
resolve nothing there. Hence:

- `build.network` (`default` | `host`) — build on the host's stack so DNS stays on
  the path the host itself uses. Default unchanged; opt-in because build steps then
  share the host's network namespace. Buildkit's `none` is not offered (no layer of
  this image builds without a network) and a named network buildkit rejects itself.
- `scripts/check-build-dns.sh` — refuses an unresolvable build network in ~20s with
  a message naming the setting and its cost, instead of 70 minutes of retries. It
  runs *inside* the network-dependent `RUN` instructions: a guard in its own layer
  can stay cached while the download it protects re-runs.

## Commits

| Commit | Concern |
| --- | --- |
| `chore(agents)` | CLI agent version bump from `djinn update` |
| `fix(build)` | streamed build log + `DJINN_BUILD_PROGRESS` override |
| `feat(build)` | `build.network` + DNS guard |
| `docs(build)` | README / CHANGELOG / IMPLEMENTATION |

Also included, previously merged into a local integration branch but never
shipped: `feat(tools)` azure-cli/pulumi/sops installers, `docs(tools)`
`tools.txt.example`, `fix(tools)` sops/pulumi timeout+retry, `fix(zones)` zone
overlays in the detached start path.

## Checklist

- [x] `build.network` wired end to end: model → `config set`/`get`/`show` → TOML
      `[build]` → `build_compose_env` → `${DJINN_BUILD_NETWORK:-default}`
- [x] `_build_config()` carries the new field — a field it forgets silently reverts
      to default on *any* `config set`, which a test now pins
- [x] Guard shares the `RUN` of every layer it protects (base `apt`, optional
      `packages.txt`, `npm`), and runs first within it
- [x] 126/127 spawn-failure contract preserved on the streaming path
- [x] `"compose"` choke-point invariant intact (`_run_streamed` builds no command)

## Quality assurance

- `ruff check` clean; `pyright src/` (strict) shows only 4 pre-existing
  `contextmanager` deprecations in files this PR does not touch
- **1045 tests** pass (1025 before); each of the four commits was verified green in
  isolation
- Positive build: exit 0 in 168.6s, all four agent CLIs verified against the built
  image ID
- Negative build (`build.network=default`, no reachable resolver): fails in the
  `apt` layer after 20.4s with the full message
- Reviewed by an independent Codex reviewer over seven rounds (plan: FAIL →
  NOT-CONVERGED → CONVERGED; code: FAIL → FAIL → PASS-WITH-MINORS, last minor
  applied). It caught, among others, a guard sitting behind a network access, a
  guard coupled to one of four version ARGs, an ordering test that matched the
  `COPY` line instead of the call, and a recommendation stated without its security
  trade-off.

## Architecture impact

`_run_compose()` gains an opt-in `stream` flag; every other compose call site keeps
capturing, pinned by a routing test. Streamed results carry empty
`stdout`/`stderr` by contract — documented, since the log has already left for the
terminal.

Not addressed here: the host-side DNS configuration itself (the resolver's reach
across bridges) is a host concern, and `build.network` makes fixing it optional
rather than necessary.
